### PR TITLE
Bugfix/269 conflict from hardcoded wifi credentials

### DIFF
--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -342,6 +342,8 @@ void setupOTA()
 
 void setup()
 {
+  wifiManager.initialize();
+
   pinMode(LED_BUILTIN, OUTPUT); // set the LED pin mode
   digitalWrite(LED_BUILTIN, HIGH);
   // Serial setup

--- a/Firmware/GPAD_API/GPAD_API/WiFiManagerOTA.cpp
+++ b/Firmware/GPAD_API/GPAD_API/WiFiManagerOTA.cpp
@@ -10,15 +10,21 @@ int WiFiLed = 2; // Modify based on actual LED pin
 using namespace WifiOTA;
 
 Manager::Manager(WiFiClass &wifi, Print &print)
-    : wifi(wifi), print(print) {}
+    : wifi(wifi), print(print)
+{
+}
+
+void Manager::initialize()
+{
+  // According to WifiManager's documentation, best practice is still to set the WiFi mode manually
+  // https://github.com/tzapu/WiFiManager/blob/master/examples/Basic/Basic.ino#L5
+  this->wifi.mode(WIFI_STA);
+}
 
 Manager::~Manager() {}
 
 void Manager::connect(const char *const accessPointSsid)
 {
-  // According to WifiManager's documentation, best practice is still to set the WiFi mode manually
-  // https://github.com/tzapu/WiFiManager/blob/master/examples/Basic/Basic.ino#L5
-  this->wifi.mode(WIFI_STA);
 
   auto saveConfigCallback = [this]()
   {

--- a/Firmware/GPAD_API/GPAD_API/WiFiManagerOTA.h
+++ b/Firmware/GPAD_API/GPAD_API/WiFiManagerOTA.h
@@ -19,6 +19,7 @@ namespace WifiOTA
         Manager(WiFiClass &wifi, Print &print);
         ~Manager();
 
+        void initialize();
         void connect(const char *const accessPointSsid);
         void setConnectedCallback(std::function<void()> callBack);
 


### PR DESCRIPTION
The initial connection the WiFi network functions exactly as before. If there is no saved WiFi network then the Web Portal for the WifiManager is opened.

Once a network has been saved, it will now auto-reconnect if the network becomes accessible after a loss of connection