### PR TITLE
(#362): Version bump from `0.46` to `0.47`

### DIFF
--- a/Firmware/GPAD_API/pre_extra_script.py
+++ b/Firmware/GPAD_API/pre_extra_script.py
@@ -3,8 +3,7 @@ Import("env")
 cpp_defines = [
     ("COMPANY_NAME", "PubInv "),   # For the Broker ID for MQTT 
     ("PROG_NAME", "GPAD_API "),    # This program
-    # ("FIRMWARE_VERSION", "0.46 "), # Initial Menu implementation
-    ("FIRMWARE_VERSION", "A.46 "), # Changed for LIMIT_POWER_DRAW false.
+    ("FIRMWARE_VERSION", "0.47 "), # Initial Menu implementation
     ("MODEL_NAME", "KRAKE_"), 
     ("LICENSE", "GNU Affero General Public License, version 3 "),
     ("ORIGIN", "US"),


### PR DESCRIPTION
Cleaned up the `pre_extra_script.py` file to remove superfluous version line. 

Bumped the version from `0.46` -> `0.47`.