### PR TITLE
Fixed DFPlayer init issue

### DIFF
--- a/Firmware/factoryTest/FactoryTest_wMenu/FactoryTest_wMenu.ino
+++ b/Firmware/factoryTest/FactoryTest_wMenu/FactoryTest_wMenu.ino
@@ -1,13 +1,13 @@
 #define DEVICE_UNDER_TEST "SN: LB0008"  //A Serial Number
 #define PROG_NAME "FactoryTest_wMenu"
-#define FIRMWARE_VERSION "v0.4.5.0"
+#define FIRMWARE_VERSION "v0.4.5.1"
 /*
 ------------------------------------------------------------------------------
 File:            FactoryTest_wMenu.ino
 Project:         Krake / GPAD v2 – Factory Test Firmware
 Document Type:   Source Code (Factory Test)
 Document ID:     KRAKE-FT-ESP32-FT01
-Version:         v0.4.5.0
+Version:         v0.4.5.1
 Date:            2026-03-17
 Author(s):       Nagham Kheir, Public Invention
 Status:          Draft
@@ -57,6 +57,7 @@ Revision History:
 |         |           |               | active-LOW, external pull-up R603, hardware     |
 |         |           |               | RC debounce C602 on PCB. internalPullup=false.  |
 |         |           |               | Requires: OneButton lib from Library Manager.   |
+|v0.4.5.1 | 2026-3-23 | Yukti         | Fixed DFPlayer ACK handling                     |
 ----------------------------------------------------------------------------------------|
 Overview:
 - Repeatable factory test sequence for ESP32-WROOM-32D Krake/GPAD v2 boards.
@@ -731,6 +732,7 @@ static bool initDFPlayer() {
   }
 
   dfPlayer.setTimeOut(1000);
+  dfPlayer.enableACK();          // ← restore ACK for the rest of the session
   dfPlayer.outputDevice(DFPLAYER_DEVICE_SD);
   delay(1200);
 


### PR DESCRIPTION
## Links
- [ ] Closes #359 

## What & Why
- Fix DFPlayer false-negative on init: changed `isACK=true` to `isACK=false`
  in `dfPlayer.begin()` to prevent timing race where unsolicited SD card status
  packets cause `begin()` to miss the ACK and return false on working hardware.

## Validation / How to Verify
1. Flash v0.4.5.0 on a board with DFPlayer + SD card installed.
2. Run test `4` — should report `PASS` and not `DFPlayer not detected`.
3. Run tests `5` and `6` — SD file count should be > 0 and speaker should play.

## Artifacts (attach if relevant)
- [ ] Screenshots / PDFs / STLs
- [ ] Logs — attach Serial Monitor output showing `DFPlayer detected and responding`

## Checklist
- [ ] Only related changes  FactoryTest_wMenu.ino
- [ ] Folder structure respected, work directory  Firmware/factoryTest/FactoryTest_wMenu/FactoryTest_wMenu.ino