### PR TITLE
Added MAC address display to splash screen

### DIFF
--- a/Firmware/factoryTest/FactoryTest_wMenu/FactoryTest_wMenu.ino
+++ b/Firmware/factoryTest/FactoryTest_wMenu/FactoryTest_wMenu.ino
@@ -733,9 +733,6 @@ static bool initDFPlayer() {
     dfState = DF_FAIL;
     return false;
   }
-  else {
-    Serial.println(F("DFPlayer detected."));
-  }
 
   dfPlayer.setTimeOut(1000);
   //dfPlayer.enableACK();          // ← restore ACK for the rest of the session


### PR DESCRIPTION
# Links
- [x] Closes #414 

## What & Why
- `WiFi.macAddress()` was returning `00:00:00:00:00:00` in the splash because the WiFi driver wasn't initialized yet
- Added `WiFi.mode(WIFI_STA)` + `delay(100)` in `setup()` before the splash prints, then immediately set back to `WIFI_OFF`
- Added `[boot]` status lines for LittleFS and WiFi init so operator knows board is alive during startup
- Added MAC address to `splashserial()` for device traceability

## Validation / How to Verify
1. Flash v0.4.5.2 and open serial monitor at 115200 baud
2. Confirm `[boot] LittleFS... OK` and `[boot] WiFi init... OK` appear on startup
3. Confirm `MAC (STA):` in the splash shows a real MAC address (not `00:00:00:00:00:00`)

## Artifacts (attach if relevant)
- [x] Screenshots / PDFs / STLs
- [x] Logs

## Checklist
- [x] Only related changes  FactoryTest_wMenu.ino   
- [x] Folder structure respected, work directory  Firmware/factoryTest/FactoryTest_wMenu/FactoryTest_wMenu.ino   
- [x] Validation steps written