### PR TITLE
Hardware, PWA, Add a Jumper to BOM for J102  

### DIFF
--- a/PWA_REV2/AlarmAudio.kicad_sch
+++ b/PWA_REV2/AlarmAudio.kicad_sch
@@ -1,2774 +1,6745 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid afa1c7b7-2d71-4b83-b5de-2d55726f80a5)
-
-  (paper "A4")
-
-  (title_block
-    (title "KRAKE_PCB")
-    (date "2025-07-18")
-    (rev "2.0")
-    (company "PublicInvention")
-    (comment 1 "GNU Affero General Public License v3.0")
-    (comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
-    (comment 3 "https://github.com/PubInv/krake")
-    (comment 4 "Inherited from the GPAD")
-  )
-
-  (lib_symbols
-    (symbol "Connector:TestPoint" (pin_numbers hide) (pin_names (offset 0.762) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "TP" (at 0 6.858 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "TestPoint" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "test point tp" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "test point" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "Pin* Test*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "TestPoint_0_1"
-        (circle (center 0 3.302) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "TestPoint_1_1"
-        (pin passive line (at 0 0 90) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:C" (pin_numbers hide) (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C" (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Unpolarized capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "C_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_0_1"
-        (polyline
-          (pts
-            (xy -2.032 -0.762)
-            (xy 2.032 -0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.032 0.762)
-            (xy 2.032 0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "C_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:C_Polarized" (pin_numbers hide) (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C_Polarized" (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Polarized capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "CP_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_Polarized_0_1"
-        (rectangle (start -2.286 0.508) (end 2.286 1.016)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.778 2.286)
-            (xy -0.762 2.286)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 2.794)
-            (xy -1.27 1.778)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 2.286 -0.508) (end -2.286 -1.016)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "C_Polarized_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:R" (pin_numbers hide) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "R" (at 2.032 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "R" (at 0 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at -1.778 0 90)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "R res resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "R_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "R_0_1"
-        (rectangle (start -1.016 -2.54) (end 1.016 2.54)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "R_1_1"
-        (pin passive line (at 0 3.81 270) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:Speaker" (pin_names (offset 0) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "LS" (at 1.27 5.715 0)
-        (effects (font (size 1.27 1.27)) (justify right))
-      )
-      (property "Value" "Speaker" (at 1.27 3.81 0)
-        (effects (font (size 1.27 1.27)) (justify right))
-      )
-      (property "Footprint" "" (at 0 -5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at -0.254 -1.27 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "speaker sound" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Speaker" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Speaker_0_0"
-        (rectangle (start -2.54 1.27) (end 1.016 -3.81)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.016 1.27)
-            (xy 3.556 3.81)
-            (xy 3.556 -6.35)
-            (xy 1.016 -3.81)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "Speaker_1_1"
-        (pin input line (at -5.08 0 0) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -5.08 -2.54 0) (length 2.54)
-          (name "2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GND_1" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "GND_1" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"GND\" , ground" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "GND_1_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 -1.27)
-            (xy 1.27 -1.27)
-            (xy 0 -2.54)
-            (xy -1.27 -1.27)
-            (xy 0 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "GND_1_1_1"
-        (pin power_in line (at 0 0 270) (length 0) hide
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:22-23-2021" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
-      (property "Reference" "J" (at -2.54 1.27 0)
-        (effects (font (size 1.27 1.27)) (justify right))
-      )
-      (property "Value" "22-23-2021" (at 1.27 -3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "Connector_Molex:Molex_KK-254_AE-6410-02A_1x02_P2.54mm_Vertical" (at 5.08 5.08 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Datasheet" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf" (at 5.08 7.62 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Digi-Key_PN" "WM4200-ND" (at 5.08 10.16 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "MPN" "22-23-2021" (at 5.08 12.7 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Category" "Connectors, Interconnects" (at 5.08 15.24 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Family" "Rectangular Connectors - Headers, Male Pins" (at 5.08 17.78 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Datasheet_Link" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf" (at 5.08 20.32 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Detail_Page" "/product-detail/en/molex/22-23-2021/WM4200-ND/26667" (at 5.08 22.86 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Description" "CONN HEADER VERT 2POS 2.54MM" (at 5.08 25.4 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Manufacturer" "Molex" (at 5.08 27.94 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Status" "Active" (at 5.08 30.48 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Assembly Type" "HAND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "WM4200-ND KK 6373" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "CONN HEADER VERT 2POS 2.54MM" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "22-23-2021_1_1"
-        (rectangle (start -1.27 0) (end 3.81 -2.54)
-          (stroke (width 0) (type default))
-          (fill (type background))
-        )
-        (rectangle (start -0.254 -1.143) (end 0.254 -1.651)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start 2.286 -1.143) (end 2.794 -1.651)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (pin passive line (at 0 2.54 270) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 2.54 270) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:DFPlayermini_241116" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
-      (property "Reference" "J" (at 0 10.16 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "DFPlayermini" (at 0 -12.7 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:DFPlayer_mini_20241116" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://image.dfrobot.com/image/data/DFR0299/DFPlayer%20Mini%20Manul.pdf" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "MP3 player" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "MP3 Audio module, DFPlayer mini, 16P DIP " (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "Connector*:*_1x??_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "DFPlayermini_241116_0_1"
-        (arc (start 8.255 8.7088) (mid 10.16 6.9764) (end 12.065 8.7088)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "DFPlayermini_241116_1_0"
-        (pin input line (at 25.4 -10.16 180) (length 3.81)
-          (name "IO_1" (effects (font (size 1.27 1.27))))
-          (number "9" (effects (font (size 1.27 1.27))))
-        )
-      )
-      (symbol "DFPlayermini_241116_1_1"
-        (rectangle (start -1.27 -10.033) (end 0 -10.287)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -7.493) (end 0 -7.747)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -4.953) (end 0 -5.207)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -2.413) (end 0 -2.667)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 0.127) (end 0 -0.127)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 2.667) (end 0 2.413)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 5.207) (end 0 4.953)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 7.747) (end 0 7.493)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 8.89) (end 21.59 -11.43)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-        (rectangle (start 20.32 -10.287) (end 21.59 -10.033)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 20.32 -7.747) (end 21.59 -7.493)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 20.32 -5.207) (end 21.59 -4.953)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 20.32 -2.667) (end 21.59 -2.413)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 20.32 -0.127) (end 21.59 0.127)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 20.32 2.413) (end 21.59 2.667)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 20.32 4.953) (end 21.59 5.207)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 20.32 7.747) (end 21.59 7.493)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (pin power_in line (at -5.08 7.62 0) (length 3.81)
-          (name "VCC" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 25.4 -7.62 180) (length 3.81)
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "10" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 25.4 -5.08 180) (length 3.81)
-          (name "IO_2" (effects (font (size 1.27 1.27))))
-          (number "11" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 25.4 -2.54 180) (length 3.81)
-          (name "ADKEY_1" (effects (font (size 1.27 1.27))))
-          (number "12" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 25.4 0 180) (length 3.81)
-          (name "ADKEY_2" (effects (font (size 1.27 1.27))))
-          (number "13" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 25.4 2.54 180) (length 3.81)
-          (name "USB+" (effects (font (size 1.27 1.27))))
-          (number "14" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 25.4 5.08 180) (length 3.81)
-          (name "USB-" (effects (font (size 1.27 1.27))))
-          (number "15" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at 25.4 7.62 180) (length 3.81)
-          (name "BUSY" (effects (font (size 1.27 1.27))))
-          (number "16" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -5.08 5.08 0) (length 3.81)
-          (name "RX" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at -5.08 2.54 0) (length 3.81)
-          (name "TX" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at -5.08 0 0) (length 3.81)
-          (name "DAC_R" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at -5.08 -2.54 0) (length 3.81)
-          (name "DAC_I" (effects (font (size 1.27 1.27))))
-          (number "5" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at -5.08 -5.08 0) (length 3.81)
-          (name "SPK_1" (effects (font (size 1.27 1.27))))
-          (number "6" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at -5.08 -7.62 0) (length 3.81)
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "7" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at -5.08 -10.16 0) (length 3.81)
-          (name "SPK_2" (effects (font (size 1.27 1.27))))
-          (number "8" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:Micro_SD_Card_16GB_DFPLAYER" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
-      (property "Reference" "SD" (at -16.51 15.24 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "Micro_SD_Card_16GB_DFPLAYER" (at 16.51 15.24 0)
-        (effects (font (size 1.27 1.27)) (justify right))
-      )
-      (property "Footprint" "" (at 29.21 7.62 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 6.35 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" " SD microsd card dfplayer 16 gb" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Micro SD Card 16GB" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "microSD*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Micro_SD_Card_16GB_DFPLAYER_0_1"
-        (rectangle (start -7.62 -9.525) (end -5.08 -10.795)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start -7.62 -6.985) (end -5.08 -8.255)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start -7.62 -4.445) (end -5.08 -5.715)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start -7.62 -1.905) (end -5.08 -3.175)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start -7.62 0.635) (end -5.08 -0.635)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start -7.62 3.175) (end -5.08 1.905)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start -7.62 5.715) (end -5.08 4.445)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start -7.62 8.255) (end -5.08 6.985)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (polyline
-          (pts
-            (xy -8.89 -11.43)
-            (xy -8.89 8.89)
-            (xy -1.27 8.89)
-            (xy 2.54 12.7)
-            (xy 3.81 12.7)
-            (xy 3.81 11.43)
-            (xy 6.35 11.43)
-            (xy 7.62 12.7)
-            (xy 20.32 12.7)
-            (xy 20.32 -11.43)
-            (xy -8.89 -11.43)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
-      (property "Reference" "S601" (at 0 8.89 0)
-        (effects (font (size 1.524 1.524)))
-      )
-      (property "Value" "SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V" (at 0 5.08 0)
-        (effects (font (size 1.524 1.524)))
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:SW_PUSH-12mm_WithCap_Green" (at 5.08 5.08 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Datasheet" "" (at 5.08 7.62 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Distributor 1 PN" "C84931" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "JLCPCB" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 2" "Digikey" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 2 PN" "SW414-ND" (at 5.08 10.16 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Manufacturer" "Omron Electronics" (at 5.08 27.94 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "MPN" "B3F-4055" (at 5.08 12.7 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Category" "Switches" (at 5.08 15.24 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Family" "Tactile Switches" (at 5.08 17.78 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Cost" "0.1181" (at 5.08 20.32 0)
-        (effects (font (size 0 0)) (justify left) hide)
-      )
-      (property "DK_Detail_Page" "" (at 5.08 22.86 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Description" "SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V" (at 5.08 25.4 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Status" "Active" (at 5.08 30.48 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Assembly Type" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "AssemblyType" "HAND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "Omron Tact 12mmx123mm B3F-4055" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V_0_1"
-        (circle (center -1.524 0) (radius 0.254)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.54 2.54)
-            (xy -2.54 -2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.778 0)
-            (xy -2.54 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.778 1.27)
-            (xy 1.778 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 -2.54)
-            (xy 2.54 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 0)
-            (xy 1.778 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 1.524 0) (radius 0.254)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V_1_1"
-        (polyline
-          (pts
-            (xy -1.016 2.794)
-            (xy 0.889 2.794)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.794)
-            (xy 0 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (pin passive line (at -5.08 2.54 0) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -2.54 0) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 5.08 2.54 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 5.08 -2.54 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "power:+5V" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "+5V" (at 0 3.556 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"+5V\"" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "+5V_0_1"
-        (polyline
-          (pts
-            (xy -0.762 1.27)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.54)
-            (xy 0.762 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "+5V_1_1"
-        (pin power_in line (at 0 0 90) (length 0) hide
-          (name "+5V" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "power:PWR_FLAG" (power) (pin_numbers hide) (pin_names (offset 0) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "#FLG" (at 0 1.905 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "PWR_FLAG" (at 0 3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "flag power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Special symbol for telling ERC where power comes from" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "PWR_FLAG_0_0"
-        (pin power_out line (at 0 0 90) (length 0)
-          (name "pwr" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-      (symbol "PWR_FLAG_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 1.27)
-            (xy -1.016 1.905)
-            (xy 0 2.54)
-            (xy 1.016 1.905)
-            (xy 0 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-  )
-
-  (junction (at 99.06 86.36) (diameter 0) (color 0 0 0 0)
-    (uuid 09b13cb1-70ce-4948-a881-14b8da4bad50)
-  )
-  (junction (at 213.36 67.31) (diameter 0) (color 0 0 0 0)
-    (uuid 1446c332-b2aa-4dff-8b3e-14a8781c1d1b)
-  )
-  (junction (at 68.58 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 55e62e39-068b-4689-80ee-5147964e99d8)
-  )
-  (junction (at 182.88 128.27) (diameter 0) (color 0 0 0 0)
-    (uuid 5996c9a1-5c6b-4a71-bc7e-9826219bd0bb)
-  )
-  (junction (at 85.09 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 5dd23a45-d602-44a0-9132-eae8d7bf782d)
-  )
-  (junction (at 186.69 130.81) (diameter 0) (color 0 0 0 0)
-    (uuid 60fd8250-b75b-4f92-af5e-6d323272abd6)
-  )
-  (junction (at 212.09 71.12) (diameter 0) (color 0 0 0 0)
-    (uuid 650b5ec4-2381-4962-b220-58d80ffacfd5)
-  )
-  (junction (at 198.12 71.12) (diameter 0) (color 0 0 0 0)
-    (uuid 6f7035d3-faff-42b8-9cad-3cc6c989ba7d)
-  )
-  (junction (at 66.04 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid a587a6a0-2581-40e4-b9af-0024968264d3)
-  )
-  (junction (at 78.74 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid d4d3e8b9-d372-4c92-8abc-185a5fe20005)
-  )
-  (junction (at 218.44 67.31) (diameter 0) (color 0 0 0 0)
-    (uuid e97cc6de-2489-4800-9546-afe21dd0e3ce)
-  )
-
-  (no_connect (at 175.26 135.89) (uuid 26076311-5539-48e8-8d04-163dafe3c27f))
-  (no_connect (at 224.79 110.49) (uuid 2b50f162-7503-4ef3-bac8-0aae7bc5b66a))
-  (no_connect (at 175.26 138.43) (uuid 30be6ae6-8f47-47df-923f-a5f44b053834))
-  (no_connect (at 224.79 113.03) (uuid 47613a2e-fade-4bb6-bf94-5e50035dd301))
-  (no_connect (at 224.79 107.95) (uuid 57eec0f7-a414-4572-849f-62e352cf3354))
-  (no_connect (at 194.31 115.57) (uuid 979b5791-4cf8-4b1c-997a-619b7bf7a1aa))
-  (no_connect (at 224.79 123.19) (uuid b13cf22d-a95f-4c69-b493-e49f2c279220))
-  (no_connect (at 194.31 113.03) (uuid b723cdbc-7c48-4aea-952d-5e4b2c4019bb))
-  (no_connect (at 224.79 118.11) (uuid befa5ef5-b585-4f55-96cb-f8520bcd5791))
-  (no_connect (at 224.79 115.57) (uuid c04322c0-311c-4c2b-8796-da25faa6bda7))
-
-  (wire (pts (xy 185.42 120.65) (xy 194.31 120.65))
-    (stroke (width 0) (type default))
-    (uuid 0434a0f9-6ab4-441c-8dbc-1cd0cf11f602)
-  )
-  (wire (pts (xy 194.31 67.31) (xy 201.93 67.31))
-    (stroke (width 0) (type default))
-    (uuid 06d225e6-2c10-4881-b2ea-fac37610cb5a)
-  )
-  (wire (pts (xy 66.04 66.04) (xy 68.58 66.04))
-    (stroke (width 0) (type default))
-    (uuid 07a4f004-3098-40d4-887c-c78c0da09b64)
-  )
-  (wire (pts (xy 68.58 66.04) (xy 68.58 81.28))
-    (stroke (width 0) (type default))
-    (uuid 0ef9c4c5-42ba-4b9d-8a1c-58591875aa1f)
-  )
-  (wire (pts (xy 66.04 81.28) (xy 66.04 90.17))
-    (stroke (width 0) (type default))
-    (uuid 0fa83997-5698-45d0-93f6-f47bae6f815b)
-  )
-  (wire (pts (xy 78.74 102.87) (xy 81.28 102.87))
-    (stroke (width 0) (type default))
-    (uuid 123e348d-0c59-4d3d-8816-05118825f400)
-  )
-  (wire (pts (xy 187.96 123.19) (xy 187.96 130.81))
-    (stroke (width 0) (type default))
-    (uuid 16fd6a02-0bc4-478d-b687-59bdd273a279)
-  )
-  (wire (pts (xy 182.88 135.89) (xy 182.88 128.27))
-    (stroke (width 0) (type default))
-    (uuid 19ec55f1-0874-4148-abf2-1014859b7e2d)
-  )
-  (wire (pts (xy 187.96 135.89) (xy 182.88 135.89))
-    (stroke (width 0) (type default))
-    (uuid 1c213b70-dcb1-4b93-91dd-6d703fa34339)
-  )
-  (wire (pts (xy 180.34 130.81) (xy 186.69 130.81))
-    (stroke (width 0) (type default))
-    (uuid 20922ae3-07e6-4d7e-9f52-46dafc958019)
-  )
-  (wire (pts (xy 163.83 110.49) (xy 151.13 110.49))
-    (stroke (width 0) (type default))
-    (uuid 2bc6b8c2-855c-492a-8ecc-b0a417cfcf74)
-  )
-  (wire (pts (xy 99.06 86.36) (xy 99.06 91.44))
-    (stroke (width 0) (type default))
-    (uuid 2d43f4e6-cd05-498c-82fc-0fedcd33c701)
-  )
-  (wire (pts (xy 180.34 93.98) (xy 224.79 93.98))
-    (stroke (width 0) (type default))
-    (uuid 3445246a-752c-4f46-acff-2cc0b659cc81)
-  )
-  (wire (pts (xy 198.12 72.39) (xy 198.12 71.12))
-    (stroke (width 0) (type default))
-    (uuid 38f666f4-e595-497d-b1e5-2bda64e5f9bd)
-  )
-  (wire (pts (xy 78.74 81.28) (xy 85.09 81.28))
-    (stroke (width 0) (type default))
-    (uuid 3a20744a-9384-457f-8550-4ab3583ff437)
-  )
-  (wire (pts (xy 97.79 81.28) (xy 99.06 81.28))
-    (stroke (width 0) (type default))
-    (uuid 3c6fe1e5-0965-439e-a2c6-93bcd3aad78a)
-  )
-  (wire (pts (xy 198.12 71.12) (xy 212.09 71.12))
-    (stroke (width 0) (type default))
-    (uuid 3d0bbf13-a065-452f-af9d-61d046a5c567)
-  )
-  (wire (pts (xy 163.83 93.98) (xy 172.72 93.98))
-    (stroke (width 0) (type default))
-    (uuid 492b3df2-5851-4d0e-98ff-02c2e22b3b15)
-  )
-  (wire (pts (xy 81.28 100.33) (xy 78.74 100.33))
-    (stroke (width 0) (type default))
-    (uuid 4b3be1c1-7dfe-4f8a-bc27-51c4803125ca)
-  )
-  (wire (pts (xy 68.58 81.28) (xy 78.74 81.28))
-    (stroke (width 0) (type default))
-    (uuid 4d483424-1ada-4154-8efa-94c3b5c1c566)
-  )
-  (wire (pts (xy 151.13 105.41) (xy 167.64 105.41))
-    (stroke (width 0) (type default))
-    (uuid 5726776f-0811-42e3-9ebd-8f9fac81ae9b)
-  )
-  (wire (pts (xy 44.45 81.28) (xy 44.45 77.47))
-    (stroke (width 0) (type default))
-    (uuid 595f0f3e-987b-4642-a106-3b86c58bc8b9)
-  )
-  (wire (pts (xy 99.06 81.28) (xy 99.06 86.36))
-    (stroke (width 0) (type default))
-    (uuid 5e76ff34-4518-498d-8a06-2a91878b2442)
-  )
-  (wire (pts (xy 171.45 113.03) (xy 175.26 113.03))
-    (stroke (width 0) (type default))
-    (uuid 60b0e5df-64ac-4b17-a7cc-13ebc094664b)
-  )
-  (wire (pts (xy 175.26 113.03) (xy 175.26 110.49))
-    (stroke (width 0) (type default))
-    (uuid 63563c9b-7cd6-41c9-8a47-47192be29929)
-  )
-  (wire (pts (xy 78.74 102.87) (xy 78.74 105.41))
-    (stroke (width 0) (type default))
-    (uuid 6b2ee410-e383-42e7-b12f-6e70c145e0bd)
-  )
-  (wire (pts (xy 213.36 66.04) (xy 213.36 67.31))
-    (stroke (width 0) (type default))
-    (uuid 6daf8ff2-13d8-4c0f-8cf2-587e012a7964)
-  )
-  (wire (pts (xy 218.44 67.31) (xy 220.98 67.31))
-    (stroke (width 0) (type default))
-    (uuid 6f28b3b4-7f38-429e-93c0-74dd1acd8224)
-  )
-  (wire (pts (xy 66.04 97.79) (xy 66.04 100.33))
-    (stroke (width 0) (type default))
-    (uuid 76be1ed0-5596-497f-8c61-f3745e0ce551)
-  )
-  (wire (pts (xy 175.26 105.41) (xy 175.26 107.95))
-    (stroke (width 0) (type default))
-    (uuid 77f225d8-9806-4a7e-81c0-8347465090c6)
-  )
-  (wire (pts (xy 87.63 86.36) (xy 85.09 86.36))
-    (stroke (width 0) (type default))
-    (uuid 87942530-c6f1-458a-a64b-4639fc7bf038)
-  )
-  (wire (pts (xy 224.79 93.98) (xy 224.79 105.41))
-    (stroke (width 0) (type default))
-    (uuid 8d7d7742-20da-4fa9-8a84-805c4305a655)
-  )
-  (wire (pts (xy 189.23 71.12) (xy 198.12 71.12))
-    (stroke (width 0) (type default))
-    (uuid 8fbabbd8-0c91-42d8-89fb-45a3706dc6b7)
-  )
-  (wire (pts (xy 78.74 81.28) (xy 78.74 100.33))
-    (stroke (width 0) (type default))
-    (uuid 9029ceee-b696-4a09-aed9-eb7d917c601d)
-  )
-  (wire (pts (xy 182.88 118.11) (xy 194.31 118.11))
-    (stroke (width 0) (type default))
-    (uuid 9079bf0b-8993-4f1d-ae7c-2a07ce753183)
-  )
-  (wire (pts (xy 175.26 110.49) (xy 194.31 110.49))
-    (stroke (width 0) (type default))
-    (uuid 9233959e-f4de-4f48-86c2-5f2423e2be47)
-  )
-  (wire (pts (xy 212.09 71.12) (xy 220.98 71.12))
-    (stroke (width 0) (type default))
-    (uuid 9531274c-b436-4954-89b8-2bdb3dffa341)
-  )
-  (wire (pts (xy 97.79 86.36) (xy 99.06 86.36))
-    (stroke (width 0) (type default))
-    (uuid 9c3ae5fe-a743-4681-b091-2eb8ffe0730e)
-  )
-  (wire (pts (xy 163.83 113.03) (xy 163.83 110.49))
-    (stroke (width 0) (type default))
-    (uuid a55ca41d-9026-4222-8050-272b6817525b)
-  )
-  (wire (pts (xy 175.26 107.95) (xy 194.31 107.95))
-    (stroke (width 0) (type default))
-    (uuid a82c1d6a-0616-44c1-97d5-3c6e8b50c818)
-  )
-  (wire (pts (xy 212.09 81.28) (xy 212.09 80.01))
-    (stroke (width 0) (type default))
-    (uuid ac22b2bb-f9ef-4016-bccf-7a50110a074a)
-  )
-  (wire (pts (xy 220.98 71.12) (xy 220.98 67.31))
-    (stroke (width 0) (type default))
-    (uuid af791738-8f16-4112-943b-2889e3279f07)
-  )
-  (wire (pts (xy 182.88 128.27) (xy 182.88 118.11))
-    (stroke (width 0) (type default))
-    (uuid b572d934-fda8-4a46-8beb-77f0238956b1)
-  )
-  (wire (pts (xy 213.36 67.31) (xy 218.44 67.31))
-    (stroke (width 0) (type default))
-    (uuid be830cfe-e7bf-4041-b86e-758b61892b5a)
-  )
-  (wire (pts (xy 212.09 72.39) (xy 212.09 71.12))
-    (stroke (width 0) (type default))
-    (uuid c5971119-9583-4df3-ab7b-680911f52a9d)
-  )
-  (wire (pts (xy 186.69 133.35) (xy 186.69 130.81))
-    (stroke (width 0) (type default))
-    (uuid c9bfa6f0-b6cf-4189-a676-c2e3ee6e8a8f)
-  )
-  (wire (pts (xy 186.69 130.81) (xy 187.96 130.81))
-    (stroke (width 0) (type default))
-    (uuid ca8fd1c0-8673-44ee-a160-1679d19a7d5d)
-  )
-  (wire (pts (xy 187.96 133.35) (xy 186.69 133.35))
-    (stroke (width 0) (type default))
-    (uuid cb86c7e4-0e5d-4840-b10b-17813afa6c17)
-  )
-  (wire (pts (xy 198.12 82.55) (xy 198.12 80.01))
-    (stroke (width 0) (type default))
-    (uuid cbeed42b-2103-4437-af47-2cea321ff0ed)
-  )
-  (wire (pts (xy 218.44 58.42) (xy 218.44 67.31))
-    (stroke (width 0) (type default))
-    (uuid cd42cdff-fbcf-47ab-9757-cbb57c4c39f3)
-  )
-  (wire (pts (xy 66.04 81.28) (xy 62.23 81.28))
-    (stroke (width 0) (type default))
-    (uuid ce49fe49-c3a6-4a42-93d4-97f589c35ace)
-  )
-  (wire (pts (xy 66.04 81.28) (xy 68.58 81.28))
-    (stroke (width 0) (type default))
-    (uuid d104d274-5bbf-49f1-8709-8124bfb6fb24)
-  )
-  (wire (pts (xy 187.96 123.19) (xy 194.31 123.19))
-    (stroke (width 0) (type default))
-    (uuid dd469aa2-7c78-458a-a36a-33f5b3bdb3e4)
-  )
-  (wire (pts (xy 85.09 81.28) (xy 85.09 86.36))
-    (stroke (width 0) (type default))
-    (uuid e7e2d86b-fcb6-4601-af9c-0a143af44118)
-  )
-  (wire (pts (xy 189.23 105.41) (xy 194.31 105.41))
-    (stroke (width 0) (type default))
-    (uuid eed9c54a-dfe3-4fc3-a071-0572de54857c)
-  )
-  (wire (pts (xy 85.09 81.28) (xy 87.63 81.28))
-    (stroke (width 0) (type default))
-    (uuid f35b90ed-a0ce-45ac-af73-a3c4e6c025f0)
-  )
-  (wire (pts (xy 209.55 67.31) (xy 213.36 67.31))
-    (stroke (width 0) (type default))
-    (uuid f452a628-14fa-4bba-8de8-8c208c178073)
-  )
-  (wire (pts (xy 54.61 81.28) (xy 44.45 81.28))
-    (stroke (width 0) (type default))
-    (uuid f4666abd-27a1-4bcd-bddf-13bc332b777d)
-  )
-  (wire (pts (xy 180.34 128.27) (xy 182.88 128.27))
-    (stroke (width 0) (type default))
-    (uuid f4839b43-94de-4c89-89ad-b612c72839ad)
-  )
-  (wire (pts (xy 224.79 120.65) (xy 228.6 120.65))
-    (stroke (width 0) (type default))
-    (uuid f6e4e614-d467-49cf-833e-ed2ee565ed43)
-  )
-  (wire (pts (xy 189.23 105.41) (xy 189.23 71.12))
-    (stroke (width 0) (type default))
-    (uuid f8bca5f9-5bfa-4a38-bbe2-2e5618fc09c0)
-  )
-
-  (image (at 255.27 179.07) (scale 0.75)
-    (uuid e4f05a09-9bd4-4e9b-a131-93a86b5eb416)
-    (data
-      iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz
-      AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h
-      aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73
-      +/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA
-      xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y
-      Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h
-      xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO
-      GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful
-      fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv
-      4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ
-      EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R
-      Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM
-      vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H
-      cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0
-      6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT
-      O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA
-      4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86
-      sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+
-      oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/
-      55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0
-      qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+
-      KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn
-      Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4
-      mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii
-      P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr
-      voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6
-      bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO
-      h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da
-      4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y
-      YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC
-      0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP
-      SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb
-      WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw
-      v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay
-      PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX
-      Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh
-      oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD
-      7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da
-      43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l
-      zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl
-      pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS
-      H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV
-      ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY
-      MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2
-      NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx
-      fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl
-      tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew
-      iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj
-      jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI
-      cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo
-      XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R
-      9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv
-      8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV
-      RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY
-      l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf
-      YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN
-      EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU
-      sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z
-      7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs
-      OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs
-      qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7
-      G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6
-      wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7
-      zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln
-      Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX
-      apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk
-      lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw
-      TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb
-      54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID
-      qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd
-      P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l
-      UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD
-      zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH
-      Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1
-      QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/
-      ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX
-      08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC
-      KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ
-      SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu
-      h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp
-      VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf
-      G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK
-      dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO
-      uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2
-      DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn
-      byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc
-      dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N
-      iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP
-      NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4
-      wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8
-      K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s
-      xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS
-      Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC
-      Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5
-      m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm
-      aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj
-      gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn
-      p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL
-      ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx
-      u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+
-      FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa
-      ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h
-      1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj
-      DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy
-      +Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj
-      wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj
-      7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ
-      lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN
-      2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY
-      CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi
-      mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E
-      uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x
-      j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD
-      45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO
-      4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni
-      buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY
-      HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH
-      NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ
-      azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N
-      SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP
-      hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe
-      nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4
-      b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN
-      xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S
-      pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq
-      3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB
-      Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL
-      4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw
-      qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX
-      9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n
-      frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/
-      eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK
-      TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u
-      RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9
-      DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j
-      2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx
-      BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy
-      91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7
-      jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw
-      pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ
-      cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M
-      xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23
-      7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8
-      D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw
-      YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu
-      QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs
-      uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA
-      PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6
-      yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN
-      xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq
-      JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT
-      +HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg
-      hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K
-      hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt
-      g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z
-      5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf
-      u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO
-      Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG
-      gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK
-      hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x
-      moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56
-      KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp
-      ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz
-      eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO
-      0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA
-      BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ
-      2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB
-      4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF
-      6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI
-      gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv
-      OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt
-      8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI
-      bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM
-      500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4
-      CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V
-      aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5
-      yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF
-      zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss
-      tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q
-      r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj
-      xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h
-      6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y
-      9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE
-      XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh
-      oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk
-      Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4
-      ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW
-      zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr
-      wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV
-      BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7
-      LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr
-      owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX
-      hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j
-      1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF
-      5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw
-      a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6
-      Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN
-      +SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds
-      lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ
-      i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu
-      fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy
-      r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28
-      dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az
-      70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk
-      EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL
-      p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf
-      nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA
-      ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c
-      q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu
-      Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR
-      TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53
-      en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA
-      x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ
-      t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+
-      R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf
-      5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH
-      e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG
-      po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh
-      6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln
-      9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU
-      xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ
-      rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W
-      lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb
-      afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs
-      FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR
-      OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC
-      P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp
-      EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh
-      6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK
-      GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ
-      hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s
-      amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+
-      fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij
-      TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv
-      I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf
-      kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ
-      BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD
-      9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn
-      jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8
-      I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI
-      8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs
-      Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN
-      MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5
-      2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU
-      2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss
-      ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m
-      sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq
-      LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT
-      tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9
-      oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p
-      zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu
-      WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy
-      diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX
-      ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY
-      5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau
-      Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7
-      oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG
-      xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q
-      zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik
-      sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN
-      ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc
-      MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E
-      YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3
-      bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz
-      DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC
-      TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES
-      3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K
-      Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd
-      b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5
-      99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys
-      7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa
-      Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e
-      8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1
-      vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK
-      VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4
-      ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD
-      CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4
-      qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr
-      1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe
-      GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK
-      yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj
-      po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO
-      Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF
-      tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D
-      mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM
-      eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN
-      veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu
-      5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL
-      Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t
-      rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl
-      sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx
-      mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG
-      PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk
-      Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk
-      caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO
-      jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS
-      gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E
-      OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+
-      p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO
-      cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM
-      S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc
-      vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3
-      boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn
-      DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD
-      90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw
-      0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT
-      5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI
-      7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP
-      QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw
-      oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E
-      mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/
-      N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm
-      vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC
-      +OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp
-      gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz
-      gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni
-      R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3
-      j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo
-      BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl
-      IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4
-      jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA
-      Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS
-      AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz
-      6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H
-      qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp
-      cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa
-      M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv
-      4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M
-      IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD
-      Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r
-      un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr
-      2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/
-      kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF
-      7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8
-      YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk
-      zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp
-      8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF
-      o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt
-      Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA
-      hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx
-      LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk
-      iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2
-      HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5
-      K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo
-      XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/
-      D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j
-      MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c
-      O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB
-      fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X
-      /V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI
-      a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe
-      L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37
-      zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY
-      BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg==
-    )
-  )
-
-  (text "The speaker is not mounted directly onto the board"
-    (at 170.18 144.78 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 2ae5e599-ddb4-45d8-9978-2b07f6faacb2)
-  )
-  (text "Notes on DFPayer\n\nUSA1 has a low cost(TD5580A) which is not the DFROBOT\nMockingKrake has the DFROBOT"
-    (at 187.96 41.275 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 32c96388-aa00-4c99-9675-5717a6270c8f)
-  )
-  (text "NULL MODEM" (at 154.305 103.505 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 7a434bb3-17be-476e-b2d0-4478b55aa596)
-  )
-  (text "MUTE" (at 86.36 91.44 0)
-    (effects (font (size 2.54 2.54)) (justify left bottom))
-    (uuid 98ad732f-a113-4f23-81d6-204e4652a3fc)
-  )
-  (text "Place R503 near uControler TX pin." (at 128.905 108.585 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid a7261e35-bea3-49c3-96d8-85d78d705960)
-  )
-  (text "For external \"speaker\"." (at 156.845 125.095 0)
-    (effects (font (size 1.27 1.27)) (justify right bottom))
-    (uuid bb1e4833-f5dc-4d43-ae1e-23e63d9e7d60)
-  )
-  (text "Bypass capacitors" (at 215.9 82.55 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid cb2d075a-6a8d-447c-b188-dddd78b5257e)
-  )
-  (text "Decoupling Resistor " (at 189.23 60.96 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid cea54ac4-7ae1-45a7-9f2d-f48740084892)
-  )
-  (text "MP3 file are added on this card for DFplayer" (at 73.66 162.56 0)
-    (effects (font (size 2.54 2.54)) (justify left bottom))
-    (uuid f74a0315-aa1c-4717-8f13-52cad090d92b)
-  )
-
-  (label "5VDFP" (at 220.98 68.58 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 06c59ee3-7ab9-4146-ac4e-f8ef569ba3de)
-  )
-
-  (hierarchical_label "ControllerRX" (shape output) (at 151.13 110.49 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 1ebc6a1c-966d-4277-b580-6a09587e3851)
-  )
-  (hierarchical_label "Busy" (shape output) (at 163.83 93.98 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 4fcf61c5-94a2-4dad-9e02-59a84d41c3df)
-  )
-  (hierarchical_label "3v3" (shape input) (at 44.45 77.47 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 6773b42c-4cd1-4255-9176-9111c540574a)
-  )
-  (hierarchical_label "Switch_Mute" (shape input) (at 66.04 66.04 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 8619eb05-7cdf-4797-ab0c-7cdabed0664f)
-  )
-  (hierarchical_label "ControllerTX" (shape input) (at 151.13 105.41 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid d64f3302-3cea-4f44-8116-902a3b6b1ef2)
-  )
-
-  (symbol (lib_id "Device:R") (at 58.42 81.28 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062c8be9a)
-    (property "Reference" "R603" (at 57.15 76.2 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "10K" (at 58.42 78.74 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 58.42 79.502 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 58.42 81.28 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269701" (at 58.42 81.28 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 58.42 81.28 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 10K F N" (at 58.42 81.28 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS" (at 58.42 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 58.42 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 58.42 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 58.42 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 58.42 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4d21e80d-46e0-4d8d-b9d1-4c7e725ab4b3))
-    (pin "2" (uuid 648aec99-ccdd-467b-8fc4-be99e5168d0b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "R603") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 66.04 93.98 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062ff8897)
-    (property "Reference" "C602" (at 68.961 92.8116 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 68.961 95.123 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 67.0052 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 66.04 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 66.04 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 66.04 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 66.04 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 66.04 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 66.04 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 66.04 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 66.04 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 66.04 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 66.04 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 92304c69-972a-4578-878b-496a7dd583a4))
-    (pin "2" (uuid 4fb22f37-c864-4dee-b15d-40c499ef6497))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "C602") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:22-23-2021") (at 177.8 130.81 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0f252e94-d2a1-423b-82be-1f461151efaf)
-    (property "Reference" "J601" (at 182.88 132.08 90)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1X2P 1.25 mm Header" (at 181.61 124.46 90)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:Molex_PicoBlade_53047-0210_1x02_P1.25mm_Vertical" (at 182.88 125.73 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" " " (at 185.42 125.73 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" " " (at 187.96 125.73 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "530470210" (at 190.5 125.73 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" " " (at 193.04 125.73 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" " " (at 195.58 125.73 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" " " (at 198.12 125.73 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "" (at 200.66 125.73 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "1.25mm 1x2P 2 2P 3.2mm 4.25mm 4.2mm PA Phosphor Bronze PicoBlade(MX 1.25) " (at 203.2 125.73 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "MOLEX" (at 205.74 125.73 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "" (at 208.28 125.73 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Assembly Type" "" (at 66.04 325.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 177.8 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0183" (at 177.8 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 177.8 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C114130" (at 177.8 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 177.8 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 177.8 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 64890e0f-de38-496e-8f98-107411cfd603))
-    (pin "2" (uuid d690dbf5-f7ea-4d84-9689-0cad293e1038))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "J601") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "J?") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 198.12 82.55 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1177c079-1518-491c-8b62-ef372f9a0d68)
-    (property "Reference" "#PWR0108" (at 198.12 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 198.12 87.63 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 198.12 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 198.12 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 33827afe-1a7f-462f-8bec-a766a2a57aa7))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "#PWR0506") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:PWR_FLAG") (at 213.36 66.04 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 11e16220-9d3b-4407-af98-79fd53013081)
-    (property "Reference" "#FLG01" (at 213.36 64.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "PWR_FLAG" (at 212.09 62.23 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 213.36 66.04 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 213.36 66.04 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ab702218-0ee5-48ed-8cc3-b266fd2866a8))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#FLG01") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "#FLG02") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 171.45 105.41 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 46d3bb63-63cf-49cf-bb9e-3389fa5e046b)
-    (property "Reference" "R502" (at 170.18 100.33 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 171.45 102.87 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 171.45 103.632 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 171.45 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 171.45 105.41 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 171.45 105.41 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 171.45 105.41 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 171.45 105.41 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 171.45 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 171.45 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 171.45 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 171.45 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 171.45 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid db32693d-34d4-4a14-8d18-93cd6aa50061))
-    (pin "2" (uuid 6f15bd65-13fd-4e25-8082-c70802d24ee3))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R502") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "R510") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 205.74 67.31 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 4d39e90c-6c3c-484e-9d5e-f9dcc0531ae9)
-    (property "Reference" "R1" (at 203.2 62.23 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1R0" (at 205.74 64.77 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 205.74 65.532 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 205.74 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 205.74 67.31 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 205.74 67.31 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 205.74 67.31 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 205.74 67.31 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 205.74 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 205.74 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 205.74 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 205.74 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 205.74 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 176bcae2-0324-4d04-b849-ac2d51106dea))
-    (pin "2" (uuid 008b257b-42b7-48b2-8ee4-d100db5a055f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R1") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "R512") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+5V") (at 194.31 67.31 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4dd1d27b-8bdc-4720-8668-b21918610224)
-    (property "Reference" "#PWR011" (at 194.31 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+5V" (at 194.31 62.23 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 194.31 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 194.31 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1d7c88a0-48b8-46b6-b2d1-8d67e4b9f7fa))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR011") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "#PWR021") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:Speaker") (at 170.18 138.43 180) (unit 1)
-    (in_bom yes) (on_board no) (dnp no)
-    (uuid 578db7ac-82a4-429c-b431-931843d1ea0b)
-    (property "Reference" "LS?" (at 177.165 139.7 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "Speaker" (at 172.72 141.605 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:Speaker2w_Buzzer_12x9.5RM7.6" (at 170.18 133.35 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 170.434 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "1" (at 170.18 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "8 Ohm 2W Speaker 8ohm Round 28mm Loud Speakers Compatible with Small Loudspeaker Audio MP3 MP4 Player Speaker (with Terminal)" (at 170.18 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "Amazon" (at 170.18 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "https://www.amazon.com/dp/B0DCTL83H6" (at 170.18 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "ZGW-1" (at 170.18 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "	YFUSET" (at 170.18 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 170.18 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 170.18 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 170.18 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 93fd388b-0256-41a7-a0bf-c0c892d713bb))
-    (pin "2" (uuid 2ddd80e2-0576-4a0f-890c-01d90ba060ac))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "LS?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "BZ601") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 167.64 113.03 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 608a454a-fc7a-4a7c-b3e6-1d999fc380d4)
-    (property "Reference" "R503" (at 166.37 107.95 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 167.64 110.49 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 167.64 111.252 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 167.64 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 167.64 113.03 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 167.64 113.03 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 167.64 113.03 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 167.64 113.03 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 167.64 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 167.64 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 167.64 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 167.64 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 167.64 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 178deca7-c09d-4b73-ba65-80fd5e745071))
-    (pin "2" (uuid 9fb8f78f-f457-4486-b6fe-55d5d0f1f5ad))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "R509") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 212.09 81.28 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6a5b9ad4-7ab3-493d-94e5-0b4dbdd5d929)
-    (property "Reference" "#PWR0108" (at 212.09 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 212.09 86.36 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 212.09 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 212.09 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a2eab61c-db8c-4f85-9403-3f65ac4e198d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "#PWR0507") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 99.06 91.44 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7db1a171-7d24-437f-bec4-cdd4b92f89e6)
-    (property "Reference" "#PWR0108" (at 99.06 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 99.06 96.52 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 99.06 91.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 99.06 91.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5db82fd5-dcf8-4ed2-9946-a0820812ea9b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "#PWR0503") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 228.6 120.65 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 807a7977-af77-4497-9bfe-0ae20155bd84)
-    (property "Reference" "#PWR0108" (at 228.6 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 228.6 125.73 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 228.6 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 228.6 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e085b53c-3a2b-44a6-ac9c-f34dab357c25))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "#PWR0504") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 185.42 120.65 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8dc92aec-a108-41c0-8842-64a49d22d80c)
-    (property "Reference" "#PWR0108" (at 185.42 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 185.42 125.73 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 185.42 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 185.42 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e80b29fb-50a9-4cd0-8546-dc026fcace82))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "#PWR0505") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V") (at 92.71 83.82 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 9067c4e2-60cf-4adf-b453-c9067dba73e5)
-    (property "Reference" "S601" (at 92.71 74.93 0)
-      (effects (font (size 1.524 1.524)))
-    )
-    (property "Value" " SWITCH_TACTILE_Projected_12mmx12mm_7.3mm_SPST-NO_0.05A_24V" (at 92.71 78.74 0)
-      (effects (font (size 1.524 1.524)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:SW_PUSH-12mm_WithGPAD_KeyCap" (at 97.79 78.74 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://eu.mouser.com/datasheet/3/39/1/en-b3f.pdf" (at 97.79 76.2 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 92.71 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C84931" (at 92.71 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2" "Digikey" (at 92.71 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2 PN" "SW414-ND" (at 97.79 73.66 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Omron Electronics" (at 97.79 55.88 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "B3F-4055" (at 97.79 71.12 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Switches" (at 97.79 68.58 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Tactile Switches" (at 97.79 66.04 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Cost" "0.1181" (at 97.79 63.5 0)
-      (effects (font (size 0 0)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "" (at 97.79 60.96 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" " SWITCH_TACTILE_Projected_12mmx12mm_7.3mm_SPST-NO_0.05A_24V" (at 97.79 58.42 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 97.79 53.34 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Assembly Type" "" (at 92.71 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 92.71 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 92.71 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 92.71 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8b7f468e-b23b-47b2-93ec-a070ca85d857))
-    (pin "2" (uuid c22f7db2-68dc-4e70-818e-2b99fa3b0920))
-    (pin "3" (uuid ffce9277-6ec0-4786-961f-d0078bc791a0))
-    (pin "4" (uuid cdfb072e-2e6f-4323-a163-cbed8053e8a2))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "S601") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:22-23-2021") (at 190.5 133.35 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 94b7c89b-9bb2-47cd-addc-557d34dd892d)
-    (property "Reference" "J604" (at 194.31 130.81 90)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "2mm_2Pin" (at 186.69 139.7 90)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Footprint" "Connector_JST:JST_PH_B2B-PH-K_1x02_P2.00mm_Vertical" (at 185.42 138.43 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://jlcpcb.com/api/file/downloadByFileSystemAccessId/8588889744620572672" (at 182.88 138.43 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "B2B-PH-K-S" (at 180.34 138.43 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "B2B-PH-K-S(LF)(SN)" (at 177.8 138.43 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Connectors, Interconnects" (at 175.26 138.43 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "HEADER VERT 2POS 2MM" (at 165.1 138.43 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "JST" (at 162.56 138.43 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 160.02 138.43 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Cost" "0.0306" (at 190.5 133.35 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 190.5 133.35 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C131337" (at 190.5 133.35 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 190.5 133.35 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 190.5 133.35 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 190.5 133.35 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6ec1e884-925d-4d56-8017-cb1985fe724d))
-    (pin "2" (uuid 95b5a1f2-9631-422b-a99c-eda7811066e7))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "J604") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C_Polarized") (at 212.09 76.2 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 997fedce-c434-4b1f-b7a9-6a775ec9c2dc)
-    (property "Reference" "C4" (at 215.0872 75.0316 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "47uF 16V" (at 215.0872 77.343 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4" (at 213.0552 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 212.09 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 212.09 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2895272" (at 212.09 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "KNSCHA" (at 212.09 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RVT47UF16V67RV0019" (at 212.09 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 212.09 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.038" (at 212.09 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS" (at 212.09 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 212.09 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 212.09 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 681ac311-1ec2-4fd4-b9dc-e0915438e668))
-    (pin "2" (uuid 0ed236a1-8d15-4985-bcd4-1ce700ae5117))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C4") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "C505") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 198.12 76.2 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid a7b874c2-dbaa-4154-94e4-129d0d686d8f)
-    (property "Reference" "C2" (at 201.041 75.0316 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 201.041 77.343 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 199.0852 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 198.12 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 198.12 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 198.12 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 198.12 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 198.12 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 198.12 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 198.12 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 198.12 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 198.12 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 198.12 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid dfd4291c-8e1f-4151-ad1e-b1d2fd498eab))
-    (pin "2" (uuid 7fc5ff51-17be-4708-8192-cf5554283a7a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C2") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "C504") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:22-23-2021") (at 83.82 100.33 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid a7ffc9e4-29b6-4404-8b57-e4a320a6171b)
-    (property "Reference" "J602" (at 87.63 97.79 90)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "0.100_2Pin" (at 80.01 106.68 90)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical" (at 78.74 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf" (at 76.2 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "WM4200-ND" (at 73.66 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "68000-102HLF" (at 71.12 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Connectors, Interconnects" (at 68.58 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Rectangular Connectors - Headers, Male Pins" (at 66.04 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf" (at 63.5 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/molex/22-23-2021/WM4200-ND/26667" (at 60.96 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "HEADER VERT 2POS 2.54MM" (at 58.42 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Amphenol ICC" (at 55.88 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 53.34 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Assembly Type" "" (at 195.58 -93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 83.82 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.1458" (at 83.82 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 83.82 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C168673" (at 83.82 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 83.82 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 83.82 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d76655a0-e1bc-409b-aa42-fe87a5ab3348))
-    (pin "2" (uuid 296916b6-5830-433c-b793-70e426a6f6be))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "J602") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Micro_SD_Card_16GB_DFPLAYER") (at 83.82 177.8 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid a826fdd1-bd93-4895-b060-ee1258904523)
-    (property "Reference" "SD601" (at 105.41 175.895 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Micro_SD_Card_16GB_DFPLAYER" (at 105.41 178.435 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 113.03 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 90.17 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 83.82 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "7.11" (at 83.82 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "SanDisk Flash 16 GB SDHC Flash Memory Card SDSDB-016G " (at 83.82 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "Amazon" (at 83.82 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "https://www.amazon.com/SanDisk-Flash-Memory-SDSDB-016G-Change/dp/B001W1BSM0" (at 83.82 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "SDSDB-016G-E11" (at 83.82 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "	SanDisk" (at 83.82 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "SD601") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 176.53 93.98 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid aab0e578-7e02-4b63-8745-5ccb0f84d961)
-    (property "Reference" "R502" (at 175.26 88.9 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 176.53 91.44 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 176.53 92.202 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 176.53 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 176.53 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 176.53 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 176.53 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 176.53 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 176.53 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 176.53 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 176.53 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 176.53 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 176.53 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bf8543b5-7f8d-4eb4-81cd-ea8d340ac607))
-    (pin "2" (uuid 83a91490-b9fe-4883-8a59-e670980eb27a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R502") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "R511") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 66.04 100.33 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid afb2a3a7-8a42-42dc-9b96-7abf88fd3410)
-    (property "Reference" "#PWR0108" (at 66.04 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 66.04 105.41 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 66.04 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 66.04 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 80ada1bd-bbd7-4295-ab92-eaefbb9510d3))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "#PWR0501") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 218.44 58.42 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid d699e5b6-efa6-44ef-b8ab-d06ce4a63a73)
-    (property "Reference" "TP?" (at 208.28 50.8 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "5VDFP" (at 208.28 53.34 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 223.52 58.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 223.52 58.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 218.44 58.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings ROHS red" (at 218.44 58.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 218.44 58.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 218.44 58.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 218.44 58.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 218.44 58.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 218.44 58.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 218.44 58.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 218.44 58.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 48fe15b4-40d0-45e5-8b42-0c091ce9b28e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "TP501") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 78.74 105.41 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid eccb4e8a-0780-42a2-b507-e7ea87df53ca)
-    (property "Reference" "#PWR0108" (at 78.74 111.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 78.74 110.49 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 78.74 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 78.74 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f609fb85-cc55-41c0-8ecb-e7238e603ce5))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "#PWR0502") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:DFPlayermini_241116") (at 199.39 113.03 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f985fcee-ed71-4e98-a839-904faf6a2732)
-    (property "Reference" "J1" (at 209.55 99.695 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DFPlayermini" (at 209.55 102.235 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:DFPlayer_mini_20241116" (at 199.39 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://image.dfrobot.com/image/data/DFR0299/DFPlayer%20Mini%20Manul.pdf" (at 199.39 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 199.39 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "3.33" (at 199.39 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Mini MP3 Player" (at 199.39 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "Amazon" (at 199.39 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "Amazon" (at 199.39 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "https://www.amazon.com/dp/B089D5NLW1" (at 199.39 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 199.39 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "DFROBOT" (at 199.39 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 199.39 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "9" (uuid 9cf4e51e-e50b-436f-ae8d-efa8ca39ab65))
-    (pin "1" (uuid f2ad901a-9307-4b63-98e8-f2df1fc8c9be))
-    (pin "10" (uuid 0c6ce936-bc44-4632-9068-16acc8d8b2a9))
-    (pin "11" (uuid ec896a63-ddc7-4069-a4eb-1c9bdce8a843))
-    (pin "12" (uuid 00a0e3a7-b066-4d2f-8066-e3ef63601365))
-    (pin "13" (uuid 91393068-d6c3-45ca-adde-c4acb71ad0b7))
-    (pin "14" (uuid d11d80e8-6a47-4add-880c-76bb65bf646c))
-    (pin "15" (uuid 3604a44c-9d67-4ab9-95b6-e8072b1ff660))
-    (pin "16" (uuid f5a31259-2387-4d20-acfa-74c186e63d1e))
-    (pin "2" (uuid 0b028a6a-b091-44cf-a134-1ae050e7f7c4))
-    (pin "3" (uuid 68dd9a3b-7524-42cb-8712-121a4349f527))
-    (pin "4" (uuid 7611a25a-2ea2-4acf-8574-20c88a0390ac))
-    (pin "5" (uuid e596e75e-9c8f-4fad-a668-dff8a78e9ad5))
-    (pin "6" (uuid 04c17acd-f21c-4505-8502-646427aa5174))
-    (pin "7" (uuid 0b20e192-efee-4c05-92ff-1a36463b53d7))
-    (pin "8" (uuid 6244789d-8e44-4c13-8f1d-e758cff1f5e7))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "J1") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "J603") (unit 1)
-        )
-      )
-    )
-  )
+(kicad_sch
+	(version 20251012)
+	(generator "eeschema")
+	(generator_version "9.99")
+	(uuid "afa1c7b7-2d71-4b83-b5de-2d55726f80a5")
+	(paper "A4")
+	(title_block
+		(title "KRAKE_PCB")
+		(date "2025-07-18")
+		(rev "2.0")
+		(company "PublicInvention")
+		(comment 1 "GNU Affero General Public License v3.0")
+		(comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
+		(comment 3 "https://github.com/PubInv/krake")
+		(comment 4 "Inherited from the GPAD")
+	)
+	(lib_symbols
+		(symbol "Connector:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 5.08 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 5.08 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C_Polarized"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C_Polarized"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Polarized capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "CP_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_Polarized_0_1"
+				(rectangle
+					(start -2.286 0.508)
+					(end 2.286 1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 2.286) (xy -0.762 2.286)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 2.794) (xy -1.27 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 2.286 -0.508)
+					(end -2.286 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(symbol "C_Polarized_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:Speaker"
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "LS"
+				(at 1.27 5.715 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Value" "Speaker"
+				(at 1.27 3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 -5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at -0.254 -1.27 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Speaker"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "speaker sound"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Speaker_0_0"
+				(rectangle
+					(start -2.54 1.27)
+					(end 1.016 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.016 1.27) (xy 3.556 3.81) (xy 3.556 -6.35) (xy 1.016 -3.81)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "Speaker_1_1"
+				(pin input line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -5.08 -2.54 0)
+					(length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GND_1"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND_1"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_1_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:22-23-2021"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "J"
+				(at -2.54 1.27 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Value" "22-23-2021"
+				(at 1.27 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Connector_Molex:Molex_KK-254_AE-6410-02A_1x02_P2.54mm_Vertical"
+				(at 5.08 5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf"
+				(at 5.08 7.62 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Description" "CONN HEADER VERT 2POS 2.54MM"
+				(at 5.08 25.4 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Digi-Key_PN" "WM4200-ND"
+				(at 5.08 10.16 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "MPN" "22-23-2021"
+				(at 5.08 12.7 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Category" "Connectors, Interconnects"
+				(at 5.08 15.24 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Family" "Rectangular Connectors - Headers, Male Pins"
+				(at 5.08 17.78 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Datasheet_Link" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf"
+				(at 5.08 20.32 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Detail_Page" "/product-detail/en/molex/22-23-2021/WM4200-ND/26667"
+				(at 5.08 22.86 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Manufacturer" "Molex"
+				(at 5.08 27.94 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Status" "Active"
+				(at 5.08 30.48 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Assembly Type" "HAND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "WM4200-ND KK 6373"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "22-23-2021_1_1"
+				(rectangle
+					(start -1.27 0)
+					(end 3.81 -2.54)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(rectangle
+					(start -0.254 -1.143)
+					(end 0.254 -1.651)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start 2.286 -1.143)
+					(end 2.794 -1.651)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(pin passive line
+					(at 0 2.54 270)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 2.54 270)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:DFPlayermini_241116"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "J"
+				(at 0 10.16 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "DFPlayermini"
+				(at 0 -12.7 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:DFPlayer_mini_20241116"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://image.dfrobot.com/image/data/DFR0299/DFPlayer%20Mini%20Manul.pdf"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "MP3 Audio module, DFPlayer mini, 16P DIP"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "MP3 player"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "DFPlayermini_241116_0_1"
+				(arc
+					(start 12.065 8.7088)
+					(mid 10.16 6.9764)
+					(end 8.255 8.7088)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "DFPlayermini_241116_1_0"
+				(pin input line
+					(at 25.4 -10.16 180)
+					(length 3.81)
+					(name "IO_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "DFPlayermini_241116_1_1"
+				(rectangle
+					(start -1.27 8.89)
+					(end 21.59 -11.43)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(rectangle
+					(start -1.27 7.747)
+					(end 0 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 5.207)
+					(end 0 4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -7.493)
+					(end 0 -7.747)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -10.033)
+					(end 0 -10.287)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 20.32 7.747)
+					(end 21.59 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 20.32 4.953)
+					(end 21.59 5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 20.32 2.413)
+					(end 21.59 2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 20.32 -0.127)
+					(end 21.59 0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 20.32 -2.667)
+					(end 21.59 -2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 20.32 -5.207)
+					(end 21.59 -4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 20.32 -7.747)
+					(end 21.59 -7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 20.32 -10.287)
+					(end 21.59 -10.033)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin power_in line
+					(at -5.08 7.62 0)
+					(length 3.81)
+					(name "VCC"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 25.4 -7.62 180)
+					(length 3.81)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 25.4 -5.08 180)
+					(length 3.81)
+					(name "IO_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 25.4 -2.54 180)
+					(length 3.81)
+					(name "ADKEY_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 25.4 0 180)
+					(length 3.81)
+					(name "ADKEY_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 25.4 2.54 180)
+					(length 3.81)
+					(name "USB+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 25.4 5.08 180)
+					(length 3.81)
+					(name "USB-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 25.4 7.62 180)
+					(length 3.81)
+					(name "BUSY"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -5.08 5.08 0)
+					(length 3.81)
+					(name "RX"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at -5.08 2.54 0)
+					(length 3.81)
+					(name "TX"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "DAC_R"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "DAC_I"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at -5.08 -5.08 0)
+					(length 3.81)
+					(name "SPK_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at -5.08 -7.62 0)
+					(length 3.81)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at -5.08 -10.16 0)
+					(length 3.81)
+					(name "SPK_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:Micro_SD_Card_16GB_DFPLAYER"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "SD"
+				(at -16.51 15.24 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Micro_SD_Card_16GB_DFPLAYER"
+				(at 16.51 15.24 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Footprint" ""
+				(at 29.21 7.62 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 6.35 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Micro SD Card 16GB"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" " SD microsd card dfplayer 16 gb"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "microSD*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Micro_SD_Card_16GB_DFPLAYER_0_1"
+				(polyline
+					(pts
+						(xy -8.89 -11.43) (xy -8.89 8.89) (xy -1.27 8.89) (xy 2.54 12.7) (xy 3.81 12.7) (xy 3.81 11.43)
+						(xy 6.35 11.43) (xy 7.62 12.7) (xy 20.32 12.7) (xy 20.32 -11.43) (xy -8.89 -11.43)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(rectangle
+					(start -7.62 8.255)
+					(end -5.08 6.985)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start -7.62 5.715)
+					(end -5.08 4.445)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start -7.62 3.175)
+					(end -5.08 1.905)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start -7.62 0.635)
+					(end -5.08 -0.635)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start -7.62 -1.905)
+					(end -5.08 -3.175)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start -7.62 -4.445)
+					(end -5.08 -5.715)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start -7.62 -6.985)
+					(end -5.08 -8.255)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start -7.62 -9.525)
+					(end -5.08 -10.795)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "S601"
+				(at 0 8.89 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Value" "SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:SW_PUSH-12mm_WithCap_Green"
+				(at 5.08 5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" ""
+				(at 5.08 7.62 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Description" "SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V"
+				(at 5.08 25.4 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Distributor 1 PN" "C84931"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "JLCPCB"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 2" "Digikey"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 2 PN" "SW414-ND"
+				(at 5.08 10.16 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Manufacturer" "Omron Electronics"
+				(at 5.08 27.94 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "MPN" "B3F-4055"
+				(at 5.08 12.7 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Category" "Switches"
+				(at 5.08 15.24 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Family" "Tactile Switches"
+				(at 5.08 17.78 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Cost" "0.1181"
+				(at 5.08 20.32 0)
+				(hide yes)
+				(effects
+					(font
+						(size 0.001 0.001)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Detail_Page" ""
+				(at 5.08 22.86 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Status" "Active"
+				(at 5.08 30.48 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Assembly Type" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "AssemblyType" "HAND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "Omron Tact 12mmx123mm B3F-4055"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V_0_1"
+				(polyline
+					(pts
+						(xy -2.54 2.54) (xy -2.54 -2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 1.27) (xy 1.778 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 0) (xy -2.54 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -1.524 0)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 1.524 0)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 0) (xy 1.778 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 -2.54) (xy 2.54 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V_1_1"
+				(polyline
+					(pts
+						(xy -1.016 2.794) (xy 0.889 2.794)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.794) (xy 0 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 2.54 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 -2.54 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:+5V"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "+5V"
+				(at 0 3.556 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"+5V\""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "+5V_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "+5V_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(hide yes)
+					(name "+5V"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:PWR_FLAG"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#FLG"
+				(at 0 1.905 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "PWR_FLAG"
+				(at 0 3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Special symbol for telling ERC where power comes from"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "flag power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_0"
+				(pin power_out line
+					(at 0 0 90)
+					(length 0)
+					(name "pwr"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(text "The speaker is not mounted directly onto the board"
+		(exclude_from_sim no)
+		(at 170.18 144.78 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "2ae5e599-ddb4-45d8-9978-2b07f6faacb2")
+	)
+	(text "Notes on DFPayer\n\nUSA1 has a low cost(TD5580A) which is not the DFROBOT\nMockingKrake has the DFROBOT"
+		(exclude_from_sim no)
+		(at 187.96 41.275 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "32c96388-aa00-4c99-9675-5717a6270c8f")
+	)
+	(text "NULL MODEM"
+		(exclude_from_sim no)
+		(at 154.305 103.505 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "7a434bb3-17be-476e-b2d0-4478b55aa596")
+	)
+	(text "MUTE"
+		(exclude_from_sim no)
+		(at 86.36 91.44 0)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left bottom)
+		)
+		(uuid "98ad732f-a113-4f23-81d6-204e4652a3fc")
+	)
+	(text "Place R503 near uControler TX pin."
+		(exclude_from_sim no)
+		(at 128.905 108.585 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a7261e35-bea3-49c3-96d8-85d78d705960")
+	)
+	(text "For external \"speaker\"."
+		(exclude_from_sim no)
+		(at 156.845 125.095 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "bb1e4833-f5dc-4d43-ae1e-23e63d9e7d60")
+	)
+	(text "Bypass capacitors"
+		(exclude_from_sim no)
+		(at 215.9 82.55 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "cb2d075a-6a8d-447c-b188-dddd78b5257e")
+	)
+	(text "Decoupling Resistor "
+		(exclude_from_sim no)
+		(at 189.23 60.96 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "cea54ac4-7ae1-45a7-9f2d-f48740084892")
+	)
+	(text "MP3 file are added on this card for DFplayer"
+		(exclude_from_sim no)
+		(at 73.66 162.56 0)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left bottom)
+		)
+		(uuid "f74a0315-aa1c-4717-8f13-52cad090d92b")
+	)
+	(junction
+		(at 99.06 86.36)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "09b13cb1-70ce-4948-a881-14b8da4bad50")
+	)
+	(junction
+		(at 213.36 67.31)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1446c332-b2aa-4dff-8b3e-14a8781c1d1b")
+	)
+	(junction
+		(at 68.58 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "55e62e39-068b-4689-80ee-5147964e99d8")
+	)
+	(junction
+		(at 182.88 128.27)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5996c9a1-5c6b-4a71-bc7e-9826219bd0bb")
+	)
+	(junction
+		(at 85.09 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5dd23a45-d602-44a0-9132-eae8d7bf782d")
+	)
+	(junction
+		(at 186.69 130.81)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "60fd8250-b75b-4f92-af5e-6d323272abd6")
+	)
+	(junction
+		(at 212.09 71.12)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "650b5ec4-2381-4962-b220-58d80ffacfd5")
+	)
+	(junction
+		(at 198.12 71.12)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6f7035d3-faff-42b8-9cad-3cc6c989ba7d")
+	)
+	(junction
+		(at 66.04 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a587a6a0-2581-40e4-b9af-0024968264d3")
+	)
+	(junction
+		(at 78.74 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d4d3e8b9-d372-4c92-8abc-185a5fe20005")
+	)
+	(junction
+		(at 218.44 67.31)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e97cc6de-2489-4800-9546-afe21dd0e3ce")
+	)
+	(no_connect
+		(at 175.26 135.89)
+		(uuid "26076311-5539-48e8-8d04-163dafe3c27f")
+	)
+	(no_connect
+		(at 224.79 110.49)
+		(uuid "2b50f162-7503-4ef3-bac8-0aae7bc5b66a")
+	)
+	(no_connect
+		(at 175.26 138.43)
+		(uuid "30be6ae6-8f47-47df-923f-a5f44b053834")
+	)
+	(no_connect
+		(at 224.79 113.03)
+		(uuid "47613a2e-fade-4bb6-bf94-5e50035dd301")
+	)
+	(no_connect
+		(at 224.79 107.95)
+		(uuid "57eec0f7-a414-4572-849f-62e352cf3354")
+	)
+	(no_connect
+		(at 194.31 115.57)
+		(uuid "979b5791-4cf8-4b1c-997a-619b7bf7a1aa")
+	)
+	(no_connect
+		(at 224.79 123.19)
+		(uuid "b13cf22d-a95f-4c69-b493-e49f2c279220")
+	)
+	(no_connect
+		(at 194.31 113.03)
+		(uuid "b723cdbc-7c48-4aea-952d-5e4b2c4019bb")
+	)
+	(no_connect
+		(at 224.79 118.11)
+		(uuid "befa5ef5-b585-4f55-96cb-f8520bcd5791")
+	)
+	(no_connect
+		(at 224.79 115.57)
+		(uuid "c04322c0-311c-4c2b-8796-da25faa6bda7")
+	)
+	(wire
+		(pts
+			(xy 185.42 120.65) (xy 194.31 120.65)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0434a0f9-6ab4-441c-8dbc-1cd0cf11f602")
+	)
+	(wire
+		(pts
+			(xy 194.31 67.31) (xy 201.93 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "06d225e6-2c10-4881-b2ea-fac37610cb5a")
+	)
+	(wire
+		(pts
+			(xy 66.04 66.04) (xy 68.58 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "07a4f004-3098-40d4-887c-c78c0da09b64")
+	)
+	(wire
+		(pts
+			(xy 68.58 66.04) (xy 68.58 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0ef9c4c5-42ba-4b9d-8a1c-58591875aa1f")
+	)
+	(wire
+		(pts
+			(xy 66.04 81.28) (xy 66.04 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0fa83997-5698-45d0-93f6-f47bae6f815b")
+	)
+	(wire
+		(pts
+			(xy 78.74 102.87) (xy 81.28 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "123e348d-0c59-4d3d-8816-05118825f400")
+	)
+	(wire
+		(pts
+			(xy 187.96 123.19) (xy 187.96 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "16fd6a02-0bc4-478d-b687-59bdd273a279")
+	)
+	(wire
+		(pts
+			(xy 182.88 135.89) (xy 182.88 128.27)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "19ec55f1-0874-4148-abf2-1014859b7e2d")
+	)
+	(wire
+		(pts
+			(xy 187.96 135.89) (xy 182.88 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c213b70-dcb1-4b93-91dd-6d703fa34339")
+	)
+	(wire
+		(pts
+			(xy 180.34 130.81) (xy 186.69 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "20922ae3-07e6-4d7e-9f52-46dafc958019")
+	)
+	(wire
+		(pts
+			(xy 163.83 110.49) (xy 151.13 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2bc6b8c2-855c-492a-8ecc-b0a417cfcf74")
+	)
+	(wire
+		(pts
+			(xy 99.06 86.36) (xy 99.06 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d43f4e6-cd05-498c-82fc-0fedcd33c701")
+	)
+	(wire
+		(pts
+			(xy 180.34 93.98) (xy 224.79 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3445246a-752c-4f46-acff-2cc0b659cc81")
+	)
+	(wire
+		(pts
+			(xy 198.12 72.39) (xy 198.12 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "38f666f4-e595-497d-b1e5-2bda64e5f9bd")
+	)
+	(wire
+		(pts
+			(xy 78.74 81.28) (xy 85.09 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a20744a-9384-457f-8550-4ab3583ff437")
+	)
+	(wire
+		(pts
+			(xy 97.79 81.28) (xy 99.06 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3c6fe1e5-0965-439e-a2c6-93bcd3aad78a")
+	)
+	(wire
+		(pts
+			(xy 198.12 71.12) (xy 212.09 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3d0bbf13-a065-452f-af9d-61d046a5c567")
+	)
+	(wire
+		(pts
+			(xy 163.83 93.98) (xy 172.72 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "492b3df2-5851-4d0e-98ff-02c2e22b3b15")
+	)
+	(wire
+		(pts
+			(xy 81.28 100.33) (xy 78.74 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4b3be1c1-7dfe-4f8a-bc27-51c4803125ca")
+	)
+	(wire
+		(pts
+			(xy 68.58 81.28) (xy 78.74 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4d483424-1ada-4154-8efa-94c3b5c1c566")
+	)
+	(wire
+		(pts
+			(xy 151.13 105.41) (xy 167.64 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5726776f-0811-42e3-9ebd-8f9fac81ae9b")
+	)
+	(wire
+		(pts
+			(xy 44.45 81.28) (xy 44.45 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "595f0f3e-987b-4642-a106-3b86c58bc8b9")
+	)
+	(wire
+		(pts
+			(xy 99.06 81.28) (xy 99.06 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5e76ff34-4518-498d-8a06-2a91878b2442")
+	)
+	(wire
+		(pts
+			(xy 171.45 113.03) (xy 175.26 113.03)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60b0e5df-64ac-4b17-a7cc-13ebc094664b")
+	)
+	(wire
+		(pts
+			(xy 175.26 113.03) (xy 175.26 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "63563c9b-7cd6-41c9-8a47-47192be29929")
+	)
+	(wire
+		(pts
+			(xy 78.74 102.87) (xy 78.74 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6b2ee410-e383-42e7-b12f-6e70c145e0bd")
+	)
+	(wire
+		(pts
+			(xy 213.36 66.04) (xy 213.36 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6daf8ff2-13d8-4c0f-8cf2-587e012a7964")
+	)
+	(wire
+		(pts
+			(xy 218.44 67.31) (xy 220.98 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f28b3b4-7f38-429e-93c0-74dd1acd8224")
+	)
+	(wire
+		(pts
+			(xy 66.04 97.79) (xy 66.04 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "76be1ed0-5596-497f-8c61-f3745e0ce551")
+	)
+	(wire
+		(pts
+			(xy 175.26 105.41) (xy 175.26 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "77f225d8-9806-4a7e-81c0-8347465090c6")
+	)
+	(wire
+		(pts
+			(xy 87.63 86.36) (xy 85.09 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "87942530-c6f1-458a-a64b-4639fc7bf038")
+	)
+	(wire
+		(pts
+			(xy 224.79 93.98) (xy 224.79 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d7d7742-20da-4fa9-8a84-805c4305a655")
+	)
+	(wire
+		(pts
+			(xy 189.23 71.12) (xy 198.12 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8fbabbd8-0c91-42d8-89fb-45a3706dc6b7")
+	)
+	(wire
+		(pts
+			(xy 78.74 81.28) (xy 78.74 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9029ceee-b696-4a09-aed9-eb7d917c601d")
+	)
+	(wire
+		(pts
+			(xy 182.88 118.11) (xy 194.31 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9079bf0b-8993-4f1d-ae7c-2a07ce753183")
+	)
+	(wire
+		(pts
+			(xy 175.26 110.49) (xy 194.31 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9233959e-f4de-4f48-86c2-5f2423e2be47")
+	)
+	(wire
+		(pts
+			(xy 212.09 71.12) (xy 220.98 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9531274c-b436-4954-89b8-2bdb3dffa341")
+	)
+	(wire
+		(pts
+			(xy 97.79 86.36) (xy 99.06 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c3ae5fe-a743-4681-b091-2eb8ffe0730e")
+	)
+	(wire
+		(pts
+			(xy 163.83 113.03) (xy 163.83 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a55ca41d-9026-4222-8050-272b6817525b")
+	)
+	(wire
+		(pts
+			(xy 175.26 107.95) (xy 194.31 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a82c1d6a-0616-44c1-97d5-3c6e8b50c818")
+	)
+	(wire
+		(pts
+			(xy 212.09 81.28) (xy 212.09 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ac22b2bb-f9ef-4016-bccf-7a50110a074a")
+	)
+	(wire
+		(pts
+			(xy 220.98 71.12) (xy 220.98 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "af791738-8f16-4112-943b-2889e3279f07")
+	)
+	(wire
+		(pts
+			(xy 182.88 128.27) (xy 182.88 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b572d934-fda8-4a46-8beb-77f0238956b1")
+	)
+	(wire
+		(pts
+			(xy 213.36 67.31) (xy 218.44 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "be830cfe-e7bf-4041-b86e-758b61892b5a")
+	)
+	(wire
+		(pts
+			(xy 212.09 72.39) (xy 212.09 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c5971119-9583-4df3-ab7b-680911f52a9d")
+	)
+	(wire
+		(pts
+			(xy 186.69 133.35) (xy 186.69 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c9bfa6f0-b6cf-4189-a676-c2e3ee6e8a8f")
+	)
+	(wire
+		(pts
+			(xy 186.69 130.81) (xy 187.96 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca8fd1c0-8673-44ee-a160-1679d19a7d5d")
+	)
+	(wire
+		(pts
+			(xy 187.96 133.35) (xy 186.69 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb86c7e4-0e5d-4840-b10b-17813afa6c17")
+	)
+	(wire
+		(pts
+			(xy 198.12 82.55) (xy 198.12 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cbeed42b-2103-4437-af47-2cea321ff0ed")
+	)
+	(wire
+		(pts
+			(xy 218.44 58.42) (xy 218.44 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cd42cdff-fbcf-47ab-9757-cbb57c4c39f3")
+	)
+	(wire
+		(pts
+			(xy 66.04 81.28) (xy 62.23 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ce49fe49-c3a6-4a42-93d4-97f589c35ace")
+	)
+	(wire
+		(pts
+			(xy 66.04 81.28) (xy 68.58 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d104d274-5bbf-49f1-8709-8124bfb6fb24")
+	)
+	(wire
+		(pts
+			(xy 187.96 123.19) (xy 194.31 123.19)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dd469aa2-7c78-458a-a36a-33f5b3bdb3e4")
+	)
+	(wire
+		(pts
+			(xy 85.09 81.28) (xy 85.09 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e7e2d86b-fcb6-4601-af9c-0a143af44118")
+	)
+	(wire
+		(pts
+			(xy 189.23 105.41) (xy 194.31 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "eed9c54a-dfe3-4fc3-a071-0572de54857c")
+	)
+	(wire
+		(pts
+			(xy 85.09 81.28) (xy 87.63 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f35b90ed-a0ce-45ac-af73-a3c4e6c025f0")
+	)
+	(wire
+		(pts
+			(xy 209.55 67.31) (xy 213.36 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f452a628-14fa-4bba-8de8-8c208c178073")
+	)
+	(wire
+		(pts
+			(xy 54.61 81.28) (xy 44.45 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4666abd-27a1-4bcd-bddf-13bc332b777d")
+	)
+	(wire
+		(pts
+			(xy 180.34 128.27) (xy 182.88 128.27)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4839b43-94de-4c89-89ad-b612c72839ad")
+	)
+	(wire
+		(pts
+			(xy 224.79 120.65) (xy 228.6 120.65)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f6e4e614-d467-49cf-833e-ed2ee565ed43")
+	)
+	(wire
+		(pts
+			(xy 189.23 105.41) (xy 189.23 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f8bca5f9-5bfa-4a38-bbe2-2e5618fc09c0")
+	)
+	(image
+		(at 255.27 179.07)
+		(scale 0.2225)
+		(uuid "e4f05a09-9bd4-4e9b-a131-93a86b5eb416")
+		(data "iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz"
+			"AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h"
+			"aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73"
+			"+/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA"
+			"xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y"
+			"Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h"
+			"xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO"
+			"GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful"
+			"fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv"
+			"4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ"
+			"EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R"
+			"Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM"
+			"vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H"
+			"cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0"
+			"6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT"
+			"O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA"
+			"4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86"
+			"sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+"
+			"oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/"
+			"55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0"
+			"qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+"
+			"KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn"
+			"Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4"
+			"mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii"
+			"P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr"
+			"voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6"
+			"bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO"
+			"h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da"
+			"4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y"
+			"YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC"
+			"0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP"
+			"SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb"
+			"WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw"
+			"v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay"
+			"PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX"
+			"Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh"
+			"oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD"
+			"7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da"
+			"43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l"
+			"zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl"
+			"pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS"
+			"H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV"
+			"ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY"
+			"MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2"
+			"NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx"
+			"fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl"
+			"tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew"
+			"iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj"
+			"jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI"
+			"cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo"
+			"XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R"
+			"9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv"
+			"8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV"
+			"RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY"
+			"l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf"
+			"YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN"
+			"EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU"
+			"sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z"
+			"7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs"
+			"OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs"
+			"qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7"
+			"G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6"
+			"wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7"
+			"zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln"
+			"Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX"
+			"apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk"
+			"lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw"
+			"TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb"
+			"54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID"
+			"qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd"
+			"P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l"
+			"UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD"
+			"zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH"
+			"Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1"
+			"QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/"
+			"ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX"
+			"08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC"
+			"KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ"
+			"SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu"
+			"h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp"
+			"VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf"
+			"G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK"
+			"dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO"
+			"uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2"
+			"DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn"
+			"byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc"
+			"dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N"
+			"iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP"
+			"NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4"
+			"wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8"
+			"K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s"
+			"xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS"
+			"Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC"
+			"Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5"
+			"m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm"
+			"aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj"
+			"gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn"
+			"p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL"
+			"ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx"
+			"u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+"
+			"FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa"
+			"ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h"
+			"1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj"
+			"DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy"
+			"+Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj"
+			"wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj"
+			"7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ"
+			"lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN"
+			"2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY"
+			"CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi"
+			"mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E"
+			"uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x"
+			"j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD"
+			"45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO"
+			"4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni"
+			"buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY"
+			"HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH"
+			"NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ"
+			"azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N"
+			"SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP"
+			"hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe"
+			"nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4"
+			"b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN"
+			"xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S"
+			"pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq"
+			"3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB"
+			"Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL"
+			"4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw"
+			"qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX"
+			"9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n"
+			"frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/"
+			"eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK"
+			"TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u"
+			"RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9"
+			"DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j"
+			"2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx"
+			"BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy"
+			"91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7"
+			"jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw"
+			"pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ"
+			"cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M"
+			"xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23"
+			"7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8"
+			"D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw"
+			"YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu"
+			"QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs"
+			"uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA"
+			"PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6"
+			"yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN"
+			"xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq"
+			"JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT"
+			"+HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg"
+			"hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K"
+			"hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt"
+			"g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z"
+			"5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf"
+			"u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO"
+			"Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG"
+			"gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK"
+			"hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x"
+			"moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56"
+			"KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp"
+			"ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz"
+			"eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO"
+			"0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA"
+			"BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ"
+			"2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB"
+			"4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF"
+			"6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI"
+			"gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv"
+			"OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt"
+			"8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI"
+			"bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM"
+			"500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4"
+			"CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V"
+			"aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5"
+			"yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF"
+			"zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss"
+			"tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q"
+			"r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj"
+			"xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h"
+			"6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y"
+			"9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE"
+			"XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh"
+			"oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk"
+			"Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4"
+			"ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW"
+			"zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr"
+			"wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV"
+			"BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7"
+			"LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr"
+			"owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX"
+			"hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j"
+			"1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF"
+			"5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw"
+			"a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6"
+			"Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN"
+			"+SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds"
+			"lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ"
+			"i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu"
+			"fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy"
+			"r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28"
+			"dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az"
+			"70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk"
+			"EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL"
+			"p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf"
+			"nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA"
+			"ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c"
+			"q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu"
+			"Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR"
+			"TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53"
+			"en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA"
+			"x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ"
+			"t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+"
+			"R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf"
+			"5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH"
+			"e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG"
+			"po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh"
+			"6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln"
+			"9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU"
+			"xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ"
+			"rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W"
+			"lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb"
+			"afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs"
+			"FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR"
+			"OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC"
+			"P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp"
+			"EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh"
+			"6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK"
+			"GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ"
+			"hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s"
+			"amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+"
+			"fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij"
+			"TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv"
+			"I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf"
+			"kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ"
+			"BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD"
+			"9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn"
+			"jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8"
+			"I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI"
+			"8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs"
+			"Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN"
+			"MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5"
+			"2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU"
+			"2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss"
+			"ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m"
+			"sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq"
+			"LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT"
+			"tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9"
+			"oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p"
+			"zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu"
+			"WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy"
+			"diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX"
+			"ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY"
+			"5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau"
+			"Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7"
+			"oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG"
+			"xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q"
+			"zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik"
+			"sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN"
+			"ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc"
+			"MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E"
+			"YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3"
+			"bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz"
+			"DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC"
+			"TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES"
+			"3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K"
+			"Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd"
+			"b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5"
+			"99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys"
+			"7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa"
+			"Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e"
+			"8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1"
+			"vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK"
+			"VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4"
+			"ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD"
+			"CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4"
+			"qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr"
+			"1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe"
+			"GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK"
+			"yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj"
+			"po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO"
+			"Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF"
+			"tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D"
+			"mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM"
+			"eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN"
+			"veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu"
+			"5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL"
+			"Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t"
+			"rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl"
+			"sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx"
+			"mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG"
+			"PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk"
+			"Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk"
+			"caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO"
+			"jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS"
+			"gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E"
+			"OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+"
+			"p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO"
+			"cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM"
+			"S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc"
+			"vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3"
+			"boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn"
+			"DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD"
+			"90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw"
+			"0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT"
+			"5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI"
+			"7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP"
+			"QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw"
+			"oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E"
+			"mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/"
+			"N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm"
+			"vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC"
+			"+OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp"
+			"gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz"
+			"gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni"
+			"R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3"
+			"j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo"
+			"BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl"
+			"IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4"
+			"jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA"
+			"Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS"
+			"AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz"
+			"6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H"
+			"qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp"
+			"cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa"
+			"M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv"
+			"4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M"
+			"IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD"
+			"Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r"
+			"un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr"
+			"2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/"
+			"kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF"
+			"7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8"
+			"YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk"
+			"zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp"
+			"8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF"
+			"o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt"
+			"Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA"
+			"hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx"
+			"LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk"
+			"iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2"
+			"HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5"
+			"K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo"
+			"XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/"
+			"D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j"
+			"MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c"
+			"O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB"
+			"fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X"
+			"/V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI"
+			"a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe"
+			"L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37"
+			"zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY"
+			"BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg=="
+		)
+	)
+	(label "5VDFP"
+		(at 220.98 68.58 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "06c59ee3-7ab9-4146-ac4e-f8ef569ba3de")
+	)
+	(hierarchical_label "ControllerRX"
+		(shape output)
+		(at 151.13 110.49 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1ebc6a1c-966d-4277-b580-6a09587e3851")
+	)
+	(hierarchical_label "Busy"
+		(shape output)
+		(at 163.83 93.98 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4fcf61c5-94a2-4dad-9e02-59a84d41c3df")
+	)
+	(hierarchical_label "3v3"
+		(shape input)
+		(at 44.45 77.47 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6773b42c-4cd1-4255-9176-9111c540574a")
+	)
+	(hierarchical_label "Switch_Mute"
+		(shape input)
+		(at 66.04 66.04 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "8619eb05-7cdf-4797-ab0c-7cdabed0664f")
+	)
+	(hierarchical_label "ControllerTX"
+		(shape input)
+		(at 151.13 105.41 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d64f3302-3cea-4f44-8116-902a3b6b1ef2")
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 58.42 81.28 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062c8be9a")
+		(property "Reference" "R603"
+			(at 57.15 76.2 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10K"
+			(at 58.42 78.74 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 58.42 79.502 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 58.42 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS"
+			(at 58.42 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 58.42 81.28 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269701"
+			(at 58.42 81.28 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 58.42 81.28 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 10K F N"
+			(at 58.42 81.28 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 58.42 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 58.42 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 58.42 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 58.42 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "4d21e80d-46e0-4d8d-b9d1-4c7e725ab4b3")
+		)
+		(pin "2"
+			(uuid "648aec99-ccdd-467b-8fc4-be99e5168d0b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "R603")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 66.04 93.98 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062ff8897")
+		(property "Reference" "C602"
+			(at 68.961 92.8116 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 68.961 95.123 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 67.0052 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 66.04 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 66.04 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 66.04 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 66.04 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 66.04 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 66.04 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 66.04 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 66.04 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 66.04 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 66.04 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "92304c69-972a-4578-878b-496a7dd583a4")
+		)
+		(pin "2"
+			(uuid "4fb22f37-c864-4dee-b15d-40c499ef6497")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "C602")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:22-23-2021")
+		(at 177.8 130.81 270)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0f252e94-d2a1-423b-82be-1f461151efaf")
+		(property "Reference" "J601"
+			(at 182.88 132.08 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1X2P 1.25 mm Header"
+			(at 181.61 124.46 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:Molex_PicoBlade_53047-0210_1x02_P1.25mm_Vertical"
+			(at 182.88 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" ""
+			(at 185.42 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "1.25mm 1x2P 2 2P 3.2mm 4.25mm 4.2mm PA Phosphor Bronze PicoBlade(MX 1.25)"
+			(at 203.2 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" " "
+			(at 187.96 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "530470210"
+			(at 190.5 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" " "
+			(at 193.04 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" " "
+			(at 195.58 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" " "
+			(at 198.12 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" ""
+			(at 200.66 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "MOLEX"
+			(at 205.74 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" ""
+			(at 208.28 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Assembly Type" ""
+			(at 66.04 325.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 177.8 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0183"
+			(at 177.8 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 177.8 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C114130"
+			(at 177.8 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 177.8 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 177.8 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "64890e0f-de38-496e-8f98-107411cfd603")
+		)
+		(pin "2"
+			(uuid "d690dbf5-f7ea-4d84-9689-0cad293e1038")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "J601")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 198.12 82.55 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1177c079-1518-491c-8b62-ef372f9a0d68")
+		(property "Reference" "#PWR0506"
+			(at 198.12 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 198.12 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 198.12 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 198.12 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 198.12 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "33827afe-1a7f-462f-8bec-a766a2a57aa7")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "#PWR0506")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 213.36 66.04 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "11e16220-9d3b-4407-af98-79fd53013081")
+		(property "Reference" "#FLG02"
+			(at 213.36 64.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 212.09 62.23 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 213.36 66.04 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 213.36 66.04 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 213.36 66.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ab702218-0ee5-48ed-8cc3-b266fd2866a8")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "#FLG02")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 171.45 105.41 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "46d3bb63-63cf-49cf-bb9e-3389fa5e046b")
+		(property "Reference" "R510"
+			(at 170.18 100.33 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 171.45 102.87 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 171.45 103.632 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 171.45 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 171.45 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 171.45 105.41 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 171.45 105.41 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 171.45 105.41 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 171.45 105.41 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 171.45 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 171.45 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 171.45 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 171.45 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "db32693d-34d4-4a14-8d18-93cd6aa50061")
+		)
+		(pin "2"
+			(uuid "6f15bd65-13fd-4e25-8082-c70802d24ee3")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "R510")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 205.74 67.31 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "4d39e90c-6c3c-484e-9d5e-f9dcc0531ae9")
+		(property "Reference" "R512"
+			(at 203.2 62.23 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1R0"
+			(at 205.74 64.77 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 205.74 65.532 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 205.74 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 205.74 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 205.74 67.31 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 205.74 67.31 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 205.74 67.31 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 205.74 67.31 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 205.74 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 205.74 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 205.74 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 205.74 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "176bcae2-0324-4d04-b849-ac2d51106dea")
+		)
+		(pin "2"
+			(uuid "008b257b-42b7-48b2-8ee4-d100db5a055f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "R512")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 194.31 67.31 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4dd1d27b-8bdc-4720-8668-b21918610224")
+		(property "Reference" "#PWR021"
+			(at 194.31 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+5V"
+			(at 194.31 62.23 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 194.31 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 194.31 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 194.31 67.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "1d7c88a0-48b8-46b6-b2d1-8d67e4b9f7fa")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "#PWR021")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:Speaker")
+		(at 170.18 138.43 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(uuid "578db7ac-82a4-429c-b431-931843d1ea0b")
+		(property "Reference" "BZ601"
+			(at 177.165 139.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Speaker"
+			(at 172.72 141.605 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:Speaker2w_Buzzer_12x9.5RM7.6"
+			(at 170.18 133.35 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 170.434 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "8 Ohm 2W Speaker 8ohm Round 28mm Loud Speakers Compatible with Small Loudspeaker Audio MP3 MP4 Player Speaker (with Terminal)"
+			(at 170.18 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "1"
+			(at 170.18 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "Amazon"
+			(at 170.18 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "https://www.amazon.com/dp/B0DCTL83H6"
+			(at 170.18 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "ZGW-1"
+			(at 170.18 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "	YFUSET"
+			(at 170.18 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 170.18 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 170.18 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 170.18 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "93fd388b-0256-41a7-a0bf-c0c892d713bb")
+		)
+		(pin "2"
+			(uuid "2ddd80e2-0576-4a0f-890c-01d90ba060ac")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "BZ601")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 167.64 113.03 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "608a454a-fc7a-4a7c-b3e6-1d999fc380d4")
+		(property "Reference" "R509"
+			(at 166.37 107.95 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 167.64 110.49 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 167.64 111.252 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 167.64 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 167.64 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 167.64 113.03 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 167.64 113.03 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 167.64 113.03 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 167.64 113.03 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 167.64 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 167.64 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 167.64 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 167.64 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "178deca7-c09d-4b73-ba65-80fd5e745071")
+		)
+		(pin "2"
+			(uuid "9fb8f78f-f457-4486-b6fe-55d5d0f1f5ad")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "R509")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 212.09 81.28 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6a5b9ad4-7ab3-493d-94e5-0b4dbdd5d929")
+		(property "Reference" "#PWR0507"
+			(at 212.09 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 212.09 86.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 212.09 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 212.09 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 212.09 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a2eab61c-db8c-4f85-9403-3f65ac4e198d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "#PWR0507")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 99.06 91.44 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7db1a171-7d24-437f-bec4-cdd4b92f89e6")
+		(property "Reference" "#PWR0503"
+			(at 99.06 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 99.06 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 91.44 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 99.06 91.44 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "5db82fd5-dcf8-4ed2-9946-a0820812ea9b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "#PWR0503")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 228.6 120.65 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "807a7977-af77-4497-9bfe-0ae20155bd84")
+		(property "Reference" "#PWR0504"
+			(at 228.6 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 228.6 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 228.6 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 228.6 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 228.6 120.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e085b53c-3a2b-44a6-ac9c-f34dab357c25")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "#PWR0504")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 185.42 120.65 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8dc92aec-a108-41c0-8842-64a49d22d80c")
+		(property "Reference" "#PWR0505"
+			(at 185.42 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 185.42 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 185.42 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 185.42 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 185.42 120.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e80b29fb-50a9-4cd0-8546-dc026fcace82")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "#PWR0505")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:SWITCH_TACTILE_12mmx12mm_SPST-NO_0.05A_24V")
+		(at 92.71 83.82 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9067c4e2-60cf-4adf-b453-c9067dba73e5")
+		(property "Reference" "S601"
+			(at 92.71 74.93 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Value" "SWITCH_TACTILE_Projected_12mmx12mm_7.3mm_SPST-NO_0.05A_24V"
+			(at 92.71 78.74 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:SW_PUSH-12mm_WithGPAD_KeyCap"
+			(at 97.79 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://eu.mouser.com/datasheet/3/39/1/en-b3f.pdf"
+			(at 97.79 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "SWITCH_TACTILE_Projected_12mmx12mm_7.3mm_SPST-NO_0.05A_24V"
+			(at 97.79 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 92.71 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C84931"
+			(at 92.71 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2" "Digikey"
+			(at 92.71 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2 PN" "SW414-ND"
+			(at 97.79 73.66 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Omron Electronics"
+			(at 97.79 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "B3F-4055"
+			(at 97.79 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Switches"
+			(at 97.79 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Tactile Switches"
+			(at 97.79 66.04 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Cost" "0.1181"
+			(at 97.79 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 0.001 0.001)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" ""
+			(at 97.79 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 97.79 53.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Assembly Type" ""
+			(at 92.71 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 92.71 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 92.71 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 92.71 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "8b7f468e-b23b-47b2-93ec-a070ca85d857")
+		)
+		(pin "2"
+			(uuid "c22f7db2-68dc-4e70-818e-2b99fa3b0920")
+		)
+		(pin "3"
+			(uuid "ffce9277-6ec0-4786-961f-d0078bc791a0")
+		)
+		(pin "4"
+			(uuid "cdfb072e-2e6f-4323-a163-cbed8053e8a2")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "S601")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:22-23-2021")
+		(at 190.5 133.35 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "94b7c89b-9bb2-47cd-addc-557d34dd892d")
+		(property "Reference" "J604"
+			(at 194.31 130.81 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "2mm_2Pin"
+			(at 186.69 139.7 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "Connector_JST:JST_PH_B2B-PH-K_1x02_P2.00mm_Vertical"
+			(at 185.42 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://jlcpcb.com/api/file/downloadByFileSystemAccessId/8588889744620572672"
+			(at 182.88 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "HEADER VERT 2POS 2MM"
+			(at 165.1 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "B2B-PH-K-S"
+			(at 180.34 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "B2B-PH-K-S(LF)(SN)"
+			(at 177.8 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Connectors, Interconnects"
+			(at 175.26 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "JST"
+			(at 162.56 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 160.02 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Cost" "0.0306"
+			(at 190.5 133.35 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 190.5 133.35 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C131337"
+			(at 190.5 133.35 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 190.5 133.35 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 190.5 133.35 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 190.5 133.35 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6ec1e884-925d-4d56-8017-cb1985fe724d")
+		)
+		(pin "2"
+			(uuid "95b5a1f2-9631-422b-a99c-eda7811066e7")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "J604")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Polarized")
+		(at 212.09 76.2 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "997fedce-c434-4b1f-b7a9-6a775ec9c2dc")
+		(property "Reference" "C505"
+			(at 215.0872 75.0316 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "47uF 16V"
+			(at 215.0872 77.343 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4"
+			(at 213.0552 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 212.09 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS"
+			(at 212.09 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 212.09 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2895272"
+			(at 212.09 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "KNSCHA"
+			(at 212.09 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RVT47UF16V67RV0019"
+			(at 212.09 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 212.09 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.038"
+			(at 212.09 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 212.09 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 212.09 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "681ac311-1ec2-4fd4-b9dc-e0915438e668")
+		)
+		(pin "2"
+			(uuid "0ed236a1-8d15-4985-bcd4-1ce700ae5117")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "C505")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 198.12 76.2 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a7b874c2-dbaa-4154-94e4-129d0d686d8f")
+		(property "Reference" "C504"
+			(at 201.041 75.0316 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 201.041 77.343 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 199.0852 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 198.12 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 198.12 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 198.12 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 198.12 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 198.12 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 198.12 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 198.12 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 198.12 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 198.12 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 198.12 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "dfd4291c-8e1f-4151-ad1e-b1d2fd498eab")
+		)
+		(pin "2"
+			(uuid "7fc5ff51-17be-4708-8192-cf5554283a7a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "C504")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:22-23-2021")
+		(at 83.82 100.33 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a7ffc9e4-29b6-4404-8b57-e4a320a6171b")
+		(property "Reference" "J602"
+			(at 87.63 97.79 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "0.100_2Pin"
+			(at 80.01 106.68 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+			(at 78.74 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf"
+			(at 76.2 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "HEADER VERT 2POS 2.54MM"
+			(at 58.42 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "WM4200-ND"
+			(at 73.66 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "68000-102HLF"
+			(at 71.12 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Connectors, Interconnects"
+			(at 68.58 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Rectangular Connectors - Headers, Male Pins"
+			(at 66.04 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf"
+			(at 63.5 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/molex/22-23-2021/WM4200-ND/26667"
+			(at 60.96 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Amphenol ICC"
+			(at 55.88 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 53.34 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Assembly Type" ""
+			(at 195.58 -93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 83.82 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.1458"
+			(at 83.82 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 83.82 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C168673"
+			(at 83.82 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 83.82 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 83.82 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d76655a0-e1bc-409b-aa42-fe87a5ab3348")
+		)
+		(pin "2"
+			(uuid "296916b6-5830-433c-b793-70e426a6f6be")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "J602")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Micro_SD_Card_16GB_DFPLAYER")
+		(at 83.82 177.8 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a826fdd1-bd93-4895-b060-ee1258904523")
+		(property "Reference" "SD601"
+			(at 105.41 175.895 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Micro_SD_Card_16GB_DFPLAYER"
+			(at 105.41 178.435 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 113.03 170.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 90.17 177.8 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "SanDisk Flash 16 GB SDHC Flash Memory Card SDSDB-016G"
+			(at 83.82 177.8 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 83.82 177.8 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "7.11"
+			(at 83.82 177.8 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "Amazon"
+			(at 83.82 177.8 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "https://www.amazon.com/SanDisk-Flash-Memory-SDSDB-016G-Change/dp/B001W1BSM0"
+			(at 83.82 177.8 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "SDSDB-016G-E11"
+			(at 83.82 177.8 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "	SanDisk"
+			(at 83.82 177.8 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "SD601")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 176.53 93.98 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "aab0e578-7e02-4b63-8745-5ccb0f84d961")
+		(property "Reference" "R511"
+			(at 175.26 88.9 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 176.53 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 176.53 92.202 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 176.53 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 176.53 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 176.53 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 176.53 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 176.53 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 176.53 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 176.53 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 176.53 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 176.53 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 176.53 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "bf8543b5-7f8d-4eb4-81cd-ea8d340ac607")
+		)
+		(pin "2"
+			(uuid "83a91490-b9fe-4883-8a59-e670980eb27a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "R511")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 66.04 100.33 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "afb2a3a7-8a42-42dc-9b96-7abf88fd3410")
+		(property "Reference" "#PWR0501"
+			(at 66.04 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 66.04 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 66.04 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 66.04 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 66.04 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "80ada1bd-bbd7-4295-ab92-eaefbb9510d3")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "#PWR0501")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 218.44 58.42 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d699e5b6-efa6-44ef-b8ab-d06ce4a63a73")
+		(property "Reference" "TP501"
+			(at 208.28 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "5VDFP"
+			(at 208.28 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 223.52 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 223.52 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings ROHS red"
+			(at 218.44 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 218.44 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 218.44 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 218.44 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 218.44 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 218.44 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 218.44 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 218.44 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 218.44 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "48fe15b4-40d0-45e5-8b42-0c091ce9b28e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "TP501")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 78.74 105.41 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eccb4e8a-0780-42a2-b507-e7ea87df53ca")
+		(property "Reference" "#PWR0502"
+			(at 78.74 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 78.74 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 78.74 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f609fb85-cc55-41c0-8ecb-e7238e603ce5")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "#PWR0502")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:DFPlayermini_241116")
+		(at 199.39 113.03 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f985fcee-ed71-4e98-a839-904faf6a2732")
+		(property "Reference" "J603"
+			(at 209.55 99.695 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DFPlayermini"
+			(at 209.55 102.235 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:DFPlayer_mini_20241116"
+			(at 199.39 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://image.dfrobot.com/image/data/DFR0299/DFPlayer%20Mini%20Manul.pdf"
+			(at 199.39 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Mini MP3 Player"
+			(at 199.39 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 199.39 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "3.33"
+			(at 199.39 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "Amazon"
+			(at 199.39 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "Amazon"
+			(at 199.39 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "https://www.amazon.com/dp/B089D5NLW1"
+			(at 199.39 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 199.39 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "DFROBOT"
+			(at 199.39 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 199.39 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "9"
+			(uuid "9cf4e51e-e50b-436f-ae8d-efa8ca39ab65")
+		)
+		(pin "1"
+			(uuid "f2ad901a-9307-4b63-98e8-f2df1fc8c9be")
+		)
+		(pin "10"
+			(uuid "0c6ce936-bc44-4632-9068-16acc8d8b2a9")
+		)
+		(pin "11"
+			(uuid "ec896a63-ddc7-4069-a4eb-1c9bdce8a843")
+		)
+		(pin "12"
+			(uuid "00a0e3a7-b066-4d2f-8066-e3ef63601365")
+		)
+		(pin "13"
+			(uuid "91393068-d6c3-45ca-adde-c4acb71ad0b7")
+		)
+		(pin "14"
+			(uuid "d11d80e8-6a47-4add-880c-76bb65bf646c")
+		)
+		(pin "15"
+			(uuid "3604a44c-9d67-4ab9-95b6-e8072b1ff660")
+		)
+		(pin "16"
+			(uuid "f5a31259-2387-4d20-acfa-74c186e63d1e")
+		)
+		(pin "2"
+			(uuid "0b028a6a-b091-44cf-a134-1ae050e7f7c4")
+		)
+		(pin "3"
+			(uuid "68dd9a3b-7524-42cb-8712-121a4349f527")
+		)
+		(pin "4"
+			(uuid "7611a25a-2ea2-4acf-8574-20c88a0390ac")
+		)
+		(pin "5"
+			(uuid "e596e75e-9c8f-4fad-a668-dff8a78e9ad5")
+		)
+		(pin "6"
+			(uuid "04c17acd-f21c-4505-8502-646427aa5174")
+		)
+		(pin "7"
+			(uuid "0b20e192-efee-4c05-92ff-1a36463b53d7")
+		)
+		(pin "8"
+			(uuid "6244789d-8e44-4c13-8f1d-e758cff1f5e7")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
+					(reference "J603")
+					(unit 1)
+				)
+			)
+		)
+	)
 )

--- a/PWA_REV2/AlarmLights5.kicad_sch
+++ b/PWA_REV2/AlarmLights5.kicad_sch
@@ -1,2653 +1,6463 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid eb754b24-08d4-4186-b0bf-c7f5f4358e7b)
-
-  (paper "A4")
-
-  (title_block
-    (title "KRAKE_PCB")
-    (date "2025-07-18")
-    (rev "2.0")
-    (company "PublicInvention")
-    (comment 1 "GNU Affero General Public License v3.0")
-    (comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
-    (comment 3 "https://github.com/PubInv/krake")
-    (comment 4 "Inherited from the GPAD")
-  )
-
-  (lib_symbols
-    (symbol "Device:R" (pin_numbers hide) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "R" (at 2.032 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "R" (at 0 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at -1.778 0 90)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "R res resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "R_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "R_0_1"
-        (rectangle (start -1.016 -2.54) (end 1.016 2.54)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "R_1_1"
-        (pin passive line (at 0 3.81 270) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GND_1" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "GND_1" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"GND\" , ground" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "GND_1_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 -1.27)
-            (xy 1.27 -1.27)
-            (xy 0 -2.54)
-            (xy -1.27 -1.27)
-            (xy 0 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "GND_1_1_1"
-        (pin power_in line (at 0 0 270) (length 0) hide
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE" (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at -3.81 2.54 0)
-        (effects (font (size 1.524 1.524)))
-      )
-      (property "Value" "LED_T1.75_CLEAR_WHITE" (at -1.27 -3.81 0)
-        (effects (font (size 1.524 1.524)))
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial" (at 5.08 5.08 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 5.08 7.62 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Digi-Key_PN" "160-1772-ND" (at 5.08 10.16 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "MPN" "LTW-2R3D7" (at 5.08 12.7 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Category" "Optoelectronics" (at 5.08 15.24 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Family" "LED Indication - Discrete" (at 5.08 17.78 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 5.08 20.32 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121" (at 5.08 22.86 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Description" "LED WHITE CLEAR T-1 3/4 T/H" (at 5.08 25.4 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Manufacturer" "Lite-On Inc." (at 5.08 27.94 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Status" "Active" (at 5.08 30.48 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "ki_keywords" "160-1772-ND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "LED WHITE CLEAR T-1 3/4 T/H" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "LED_T1.75_CLEAR_WHITE_0_1"
-        (polyline
-          (pts
-            (xy 0 1.27)
-            (xy 0 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 3.81)
-            (xy -1.27 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 3.175)
-            (xy 0 1.905)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -0.635 3.81)
-            (xy 0 3.81)
-            (xy 0 3.175)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.635 3.175)
-            (xy 1.27 3.175)
-            (xy 1.27 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.54 1.27)
-            (xy -2.54 -1.27)
-            (xy 0 0)
-            (xy -2.54 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "LED_T1.75_CLEAR_WHITE_1_1"
-        (pin passive line (at -5.08 0 0) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 0 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:MMBT2222A-7-F" (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "Q" (at -3.2004 4.2164 0)
-        (effects (font (size 1.524 1.524)) (justify left))
-      )
-      (property "Value" "MMBT2222A-7-F" (at 5.2324 0 90)
-        (effects (font (size 1.524 1.524)))
-      )
-      (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 5.08 5.08 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 5.08 7.62 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Digi-Key_PN" "MMBT2222A-FDICT-ND" (at 5.08 10.16 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "MPN" "MMBT2222A-7-F" (at 5.08 12.7 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Category" "Discrete Semiconductor Products" (at 5.08 15.24 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Family" "Transistors - Bipolar (BJT) - Single" (at 5.08 17.78 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 5.08 20.32 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723" (at 5.08 22.86 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3" (at 5.08 25.4 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Manufacturer" "Diodes Incorporated" (at 5.08 27.94 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Status" "Active" (at 5.08 30.48 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "ki_keywords" "MMBT2222A-FDICT-ND Automotive, AEC-Q101" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "TRANS NPN 40V 0.6A SMD SOT23-3" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "MMBT2222A-7-F_0_1"
-        (polyline
-          (pts
-            (xy -3.81 0)
-            (xy -2.54 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.556 0)
-            (xy 0 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 -1.27)
-            (xy 2.54 -2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 1.27)
-            (xy 2.54 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.54)
-            (xy 0 -2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.524 -1.27)
-            (xy 2.032 -2.286)
-            (xy 1.016 -2.54)
-            (xy 1.524 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (circle (center 0 0) (radius 3.2512)
-          (stroke (width 0) (type default))
-          (fill (type background))
-        )
-      )
-      (symbol "MMBT2222A-7-F_1_1"
-        (pin input line (at -5.08 0 0) (length 2.54)
-          (name "B" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 -5.08 90) (length 2.54)
-          (name "E" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 5.08 270) (length 2.54)
-          (name "C" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff" (in_bom yes) (on_board yes)
-      (property "Reference" "MF" (at 0 0 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff" (at 0 0 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "U_Box_V104_General_Alarm_Device_LED_Standoff_0_1"
-        (circle (center -2.54 0) (radius 1.27)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 0 0) (radius 4.0161)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 2.54 0) (radius 1.27)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-    (symbol "power:+5V" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "+5V" (at 0 3.556 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"+5V\"" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "+5V_0_1"
-        (polyline
-          (pts
-            (xy -0.762 1.27)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.54)
-            (xy 0.762 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "+5V_1_1"
-        (pin power_in line (at 0 0 90) (length 0) hide
-          (name "+5V" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-  )
-
-  (junction (at 119.38 71.12) (diameter 0) (color 0 0 0 0)
-    (uuid 1112ab5c-42aa-4ea5-835a-5aa218728a14)
-  )
-  (junction (at 180.34 71.12) (diameter 0) (color 0 0 0 0)
-    (uuid 3ac97a3a-62bd-411b-87ea-39fc238e4799)
-  )
-  (junction (at 88.9 71.12) (diameter 0) (color 0 0 0 0)
-    (uuid b1f1192c-9056-4d66-8aa3-769c6efcca3d)
-  )
-  (junction (at 149.86 71.12) (diameter 0) (color 0 0 0 0)
-    (uuid d216c1d0-b285-4029-b1d6-e113b3d15575)
-  )
-
-  (wire (pts (xy 88.9 71.12) (xy 88.9 59.69))
-    (stroke (width 0) (type default))
-    (uuid 07de91d3-3912-4ef4-9dfc-9de0c35aa5a4)
-  )
-  (wire (pts (xy 149.86 74.93) (xy 149.86 71.12))
-    (stroke (width 0) (type default))
-    (uuid 0b7fed12-8933-4afb-83ac-7ba9f5fcf0f2)
-  )
-  (wire (pts (xy 209.55 74.93) (xy 210.82 74.93))
-    (stroke (width 0) (type default))
-    (uuid 0bcc9963-833a-46ac-b9ed-1eb29981839c)
-  )
-  (wire (pts (xy 119.38 85.09) (xy 119.38 82.55))
-    (stroke (width 0) (type default))
-    (uuid 14d1afe3-160c-4ba2-a1a9-cb03a788f03a)
-  )
-  (wire (pts (xy 180.34 85.09) (xy 180.34 82.55))
-    (stroke (width 0) (type default))
-    (uuid 15fb56b2-91a1-46f2-bfcf-b057aad785c3)
-  )
-  (wire (pts (xy 209.55 71.12) (xy 209.55 74.93))
-    (stroke (width 0) (type default))
-    (uuid 27385646-ed37-421d-a09a-d24c430a0053)
-  )
-  (wire (pts (xy 88.9 82.55) (xy 88.9 85.09))
-    (stroke (width 0) (type default))
-    (uuid 28ee582a-502f-432f-8fb0-08a24acd0a2f)
-  )
-  (wire (pts (xy 88.9 71.12) (xy 119.38 71.12))
-    (stroke (width 0) (type default))
-    (uuid 33d68ba6-b361-4a04-960a-5848fce78977)
-  )
-  (wire (pts (xy 167.64 81.28) (xy 167.64 90.17))
-    (stroke (width 0) (type default))
-    (uuid 36b084ab-ebff-4deb-a3ef-cd24713aa7b9)
-  )
-  (wire (pts (xy 137.16 97.79) (xy 137.16 100.33))
-    (stroke (width 0) (type default))
-    (uuid 37413a70-3c71-46b5-8d15-074179a20104)
-  )
-  (wire (pts (xy 180.34 71.12) (xy 209.55 71.12))
-    (stroke (width 0) (type default))
-    (uuid 38e23027-6a0b-4fe2-918e-e62c4fc1bae8)
-  )
-  (wire (pts (xy 198.12 100.33) (xy 203.2 100.33))
-    (stroke (width 0) (type default))
-    (uuid 392b8ab3-7e7d-497f-963a-d3e3e1f16883)
-  )
-  (wire (pts (xy 210.82 85.09) (xy 210.82 82.55))
-    (stroke (width 0) (type default))
-    (uuid 5268249f-43ae-41e4-bd63-03b636092743)
-  )
-  (wire (pts (xy 119.38 95.25) (xy 119.38 92.71))
-    (stroke (width 0) (type default))
-    (uuid 564f1f86-7f99-4c1d-a384-f9d167bcd16e)
-  )
-  (wire (pts (xy 137.16 100.33) (xy 142.24 100.33))
-    (stroke (width 0) (type default))
-    (uuid 5a7871f2-6337-4799-93e7-dfbacf24798d)
-  )
-  (wire (pts (xy 198.12 97.79) (xy 198.12 100.33))
-    (stroke (width 0) (type default))
-    (uuid 5e93fe8e-93e5-4ee2-a10b-1810bb9e1d0f)
-  )
-  (wire (pts (xy 76.2 81.28) (xy 76.2 90.17))
-    (stroke (width 0) (type default))
-    (uuid 650a2466-d51a-42bf-a937-9e8f849bdd19)
-  )
-  (wire (pts (xy 149.86 85.09) (xy 149.86 82.55))
-    (stroke (width 0) (type default))
-    (uuid 6900ecaa-557b-44cd-b927-a781ee08e94e)
-  )
-  (wire (pts (xy 119.38 74.93) (xy 119.38 71.12))
-    (stroke (width 0) (type default))
-    (uuid 697d9bac-95af-400c-8cfb-3aa09c390a33)
-  )
-  (wire (pts (xy 137.16 81.28) (xy 137.16 90.17))
-    (stroke (width 0) (type default))
-    (uuid 75ca2923-498d-4ada-a1ee-40fd164f5a62)
-  )
-  (wire (pts (xy 167.64 97.79) (xy 167.64 100.33))
-    (stroke (width 0) (type default))
-    (uuid 7887aab3-8d8d-4b04-884f-5c446c454b80)
-  )
-  (wire (pts (xy 210.82 95.25) (xy 210.82 92.71))
-    (stroke (width 0) (type default))
-    (uuid 78d8412b-cbcf-4cdd-b553-cb8f0df89b5e)
-  )
-  (wire (pts (xy 149.86 105.41) (xy 149.86 106.68))
-    (stroke (width 0) (type default))
-    (uuid 7a3f81c4-c9da-4eb7-8932-88307b32eb06)
-  )
-  (wire (pts (xy 106.68 81.28) (xy 106.68 90.17))
-    (stroke (width 0) (type default))
-    (uuid 7d8fdcbf-7ca4-4f0a-a7b5-d9b8d02c8461)
-  )
-  (wire (pts (xy 106.68 97.79) (xy 106.68 100.33))
-    (stroke (width 0) (type default))
-    (uuid 852e1ee4-ca8c-49fd-aae7-013c2e664146)
-  )
-  (wire (pts (xy 106.68 100.33) (xy 111.76 100.33))
-    (stroke (width 0) (type default))
-    (uuid a493a9cc-e521-4a16-8fed-29b8980133f3)
-  )
-  (wire (pts (xy 88.9 92.71) (xy 88.9 95.25))
-    (stroke (width 0) (type default))
-    (uuid b18260af-511a-4506-8450-46669f7f73ff)
-  )
-  (wire (pts (xy 119.38 71.12) (xy 149.86 71.12))
-    (stroke (width 0) (type default))
-    (uuid b51f7a88-79e8-45ac-b56b-177ccd2c4637)
-  )
-  (wire (pts (xy 180.34 74.93) (xy 180.34 71.12))
-    (stroke (width 0) (type default))
-    (uuid bbdcdec5-7e1e-4658-8db2-d831fb88e59b)
-  )
-  (wire (pts (xy 167.64 100.33) (xy 172.72 100.33))
-    (stroke (width 0) (type default))
-    (uuid bbed2049-c6e0-4842-bb27-8462cd63f583)
-  )
-  (wire (pts (xy 149.86 71.12) (xy 180.34 71.12))
-    (stroke (width 0) (type default))
-    (uuid c244b6af-9e45-4b02-ba07-b64fa152f710)
-  )
-  (wire (pts (xy 210.82 106.68) (xy 210.82 105.41))
-    (stroke (width 0) (type default))
-    (uuid cade5a29-846e-4e8c-86a8-ba40a5722bbf)
-  )
-  (wire (pts (xy 119.38 106.68) (xy 119.38 105.41))
-    (stroke (width 0) (type default))
-    (uuid dbfec2eb-51ea-4ca3-b68d-58edb66e8107)
-  )
-  (wire (pts (xy 76.2 97.79) (xy 76.2 100.33))
-    (stroke (width 0) (type default))
-    (uuid de1bb723-1a86-429f-866c-e45ab10bc964)
-  )
-  (wire (pts (xy 149.86 95.25) (xy 149.86 92.71))
-    (stroke (width 0) (type default))
-    (uuid deb00a2f-d8c2-4e83-bcac-a97abae21343)
-  )
-  (wire (pts (xy 180.34 95.25) (xy 180.34 92.71))
-    (stroke (width 0) (type default))
-    (uuid ea89519c-31f7-46a2-a300-d13a27ed6da5)
-  )
-  (wire (pts (xy 198.12 81.28) (xy 198.12 90.17))
-    (stroke (width 0) (type default))
-    (uuid eb143699-1e22-44bf-b668-233fb81adaaf)
-  )
-  (wire (pts (xy 180.34 106.68) (xy 180.34 105.41))
-    (stroke (width 0) (type default))
-    (uuid ed190ccd-1e3c-404a-93a0-7e4217b6d2af)
-  )
-  (wire (pts (xy 88.9 74.93) (xy 88.9 71.12))
-    (stroke (width 0) (type default))
-    (uuid ed6cb61c-2c80-49df-92de-5420348cece9)
-  )
-  (wire (pts (xy 88.9 106.68) (xy 88.9 105.41))
-    (stroke (width 0) (type default))
-    (uuid f7f34952-a2fb-4bcd-8c76-855d3e70f98b)
-  )
-  (wire (pts (xy 76.2 100.33) (xy 81.28 100.33))
-    (stroke (width 0) (type default))
-    (uuid fa883525-c2ec-433b-b290-aec6f11870f7)
-  )
-
-  (image (at 229.87 180.34) (scale 0.75)
-    (uuid da432c4d-19a0-43be-8f67-de6960a4724d)
-    (data
-      iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz
-      AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h
-      aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73
-      +/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA
-      xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y
-      Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h
-      xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO
-      GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful
-      fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv
-      4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ
-      EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R
-      Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM
-      vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H
-      cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0
-      6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT
-      O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA
-      4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86
-      sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+
-      oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/
-      55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0
-      qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+
-      KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn
-      Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4
-      mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii
-      P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr
-      voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6
-      bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO
-      h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da
-      4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y
-      YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC
-      0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP
-      SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb
-      WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw
-      v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay
-      PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX
-      Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh
-      oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD
-      7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da
-      43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l
-      zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl
-      pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS
-      H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV
-      ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY
-      MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2
-      NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx
-      fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl
-      tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew
-      iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj
-      jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI
-      cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo
-      XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R
-      9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv
-      8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV
-      RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY
-      l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf
-      YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN
-      EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU
-      sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z
-      7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs
-      OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs
-      qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7
-      G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6
-      wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7
-      zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln
-      Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX
-      apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk
-      lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw
-      TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb
-      54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID
-      qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd
-      P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l
-      UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD
-      zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH
-      Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1
-      QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/
-      ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX
-      08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC
-      KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ
-      SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu
-      h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp
-      VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf
-      G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK
-      dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO
-      uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2
-      DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn
-      byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc
-      dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N
-      iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP
-      NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4
-      wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8
-      K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s
-      xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS
-      Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC
-      Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5
-      m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm
-      aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj
-      gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn
-      p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL
-      ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx
-      u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+
-      FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa
-      ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h
-      1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj
-      DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy
-      +Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj
-      wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj
-      7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ
-      lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN
-      2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY
-      CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi
-      mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E
-      uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x
-      j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD
-      45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO
-      4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni
-      buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY
-      HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH
-      NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ
-      azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N
-      SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP
-      hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe
-      nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4
-      b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN
-      xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S
-      pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq
-      3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB
-      Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL
-      4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw
-      qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX
-      9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n
-      frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/
-      eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK
-      TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u
-      RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9
-      DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j
-      2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx
-      BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy
-      91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7
-      jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw
-      pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ
-      cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M
-      xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23
-      7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8
-      D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw
-      YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu
-      QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs
-      uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA
-      PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6
-      yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN
-      xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq
-      JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT
-      +HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg
-      hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K
-      hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt
-      g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z
-      5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf
-      u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO
-      Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG
-      gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK
-      hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x
-      moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56
-      KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp
-      ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz
-      eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO
-      0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA
-      BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ
-      2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB
-      4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF
-      6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI
-      gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv
-      OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt
-      8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI
-      bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM
-      500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4
-      CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V
-      aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5
-      yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF
-      zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss
-      tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q
-      r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj
-      xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h
-      6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y
-      9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE
-      XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh
-      oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk
-      Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4
-      ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW
-      zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr
-      wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV
-      BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7
-      LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr
-      owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX
-      hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j
-      1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF
-      5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw
-      a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6
-      Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN
-      +SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds
-      lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ
-      i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu
-      fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy
-      r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28
-      dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az
-      70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk
-      EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL
-      p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf
-      nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA
-      ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c
-      q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu
-      Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR
-      TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53
-      en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA
-      x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ
-      t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+
-      R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf
-      5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH
-      e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG
-      po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh
-      6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln
-      9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU
-      xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ
-      rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W
-      lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb
-      afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs
-      FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR
-      OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC
-      P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp
-      EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh
-      6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK
-      GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ
-      hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s
-      amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+
-      fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij
-      TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv
-      I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf
-      kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ
-      BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD
-      9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn
-      jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8
-      I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI
-      8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs
-      Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN
-      MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5
-      2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU
-      2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss
-      ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m
-      sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq
-      LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT
-      tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9
-      oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p
-      zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu
-      WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy
-      diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX
-      ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY
-      5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau
-      Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7
-      oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG
-      xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q
-      zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik
-      sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN
-      ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc
-      MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E
-      YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3
-      bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz
-      DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC
-      TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES
-      3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K
-      Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd
-      b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5
-      99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys
-      7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa
-      Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e
-      8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1
-      vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK
-      VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4
-      ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD
-      CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4
-      qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr
-      1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe
-      GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK
-      yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj
-      po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO
-      Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF
-      tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D
-      mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM
-      eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN
-      veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu
-      5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL
-      Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t
-      rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl
-      sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx
-      mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG
-      PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk
-      Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk
-      caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO
-      jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS
-      gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E
-      OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+
-      p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO
-      cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM
-      S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc
-      vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3
-      boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn
-      DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD
-      90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw
-      0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT
-      5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI
-      7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP
-      QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw
-      oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E
-      mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/
-      N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm
-      vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC
-      +OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp
-      gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz
-      gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni
-      R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3
-      j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo
-      BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl
-      IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4
-      jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA
-      Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS
-      AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz
-      6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H
-      qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp
-      cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa
-      M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv
-      4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M
-      IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD
-      Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r
-      un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr
-      2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/
-      kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF
-      7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8
-      YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk
-      zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp
-      8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF
-      o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt
-      Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA
-      hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx
-      LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk
-      iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2
-      HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5
-      K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo
-      XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/
-      D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j
-      MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c
-      O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB
-      fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X
-      /V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI
-      a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe
-      L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37
-      zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY
-      BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg==
-    )
-  )
-
-  (text "currect setting \nresistor, Base" (at 77.47 95.25 0)
-    (effects (font (size 0.762 0.762)) (justify left bottom))
-    (uuid 42dc2ae5-3c20-4a59-b485-462b1bfcebda)
-  )
-  (text "currect setting \nresistor, LED" (at 90.17 80.01 0)
-    (effects (font (size 0.762 0.762)) (justify left bottom))
-    (uuid 66ab364f-3dac-457d-a0bb-255f24170c2a)
-  )
-  (text "current sink\ntransistor" (at 91.44 105.41 0)
-    (effects (font (size 0.762 0.762)) (justify left bottom))
-    (uuid 989efb15-6cee-4824-b13a-c3397dd5de03)
-  )
-  (text "Alarm lights, 5 Levels" (at 128.27 69.85 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid f99ff8e1-46d7-44ac-8e03-2d3b0a573d00)
-  )
-
-  (hierarchical_label "Light3" (shape input) (at 167.64 81.28 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 0464d949-bdc1-4743-9657-04d380db509b)
-  )
-  (hierarchical_label "Light2" (shape input) (at 137.16 81.28 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 0565ac06-f4da-404e-9265-99760def4d8e)
-  )
-  (hierarchical_label "Light1" (shape input) (at 106.68 81.28 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 1e748145-f538-4854-9134-f367d2ff4fbe)
-  )
-  (hierarchical_label "Light4" (shape input) (at 198.12 81.28 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 306798b8-8a86-4659-9187-913a30a7d792)
-  )
-  (hierarchical_label "Light0" (shape input) (at 76.2 81.28 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid e4d17d3c-b46a-43ae-96d4-57f89e72b7dc)
-  )
-
-  (symbol (lib_id "Device:R") (at 76.2 93.98 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5a2ae)
-    (property "Reference" "R201" (at 78.74 88.9 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 80.01 91.44 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 77.978 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 76.2 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 76.2 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 76.2 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 76.2 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 76.2 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 76.2 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 76.2 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 76.2 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 76.2 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 76.2 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 73e33c7e-d704-4489-ad2e-e2975d475aaf))
-    (pin "2" (uuid 6f984ddc-7764-4214-b5f5-6c21e918c98d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "R201") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 88.9 78.74 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5a2bf)
-    (property "Reference" "R202" (at 91.44 73.66 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 92.71 76.2 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 90.678 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 88.9 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 88.9 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 88.9 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 88.9 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 88.9 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 88.9 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 88.9 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 88.9 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 88.9 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 88.9 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ebc64a72-e976-4db8-84ea-c6038af80d0e))
-    (pin "2" (uuid 739feca1-32f5-449c-9cf4-d68321a2f964))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "R202") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 106.68 93.98 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5a2e7)
-    (property "Reference" "R203" (at 111.76 92.71 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 110.49 95.25 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 108.458 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 106.68 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 106.68 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 106.68 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 106.68 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 106.68 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 106.68 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 106.68 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 106.68 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 106.68 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 106.68 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20f3b9a1-2522-449e-8f24-a8d4aab8a36d))
-    (pin "2" (uuid 76010e76-2ad3-4b9e-a79e-7c3ea369e15f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "R203") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 119.38 78.74 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5a2f8)
-    (property "Reference" "R204" (at 121.92 74.93 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 123.19 80.01 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 121.158 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 119.38 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 119.38 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 119.38 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 119.38 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 119.38 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 119.38 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 119.38 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 119.38 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 119.38 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 75ad144a-a236-483e-ab19-d60206c4d33c))
-    (pin "2" (uuid 417c0a15-dfb6-433f-82d7-1a1d5a6ba8a7))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "R204") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 137.16 93.98 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5a320)
-    (property "Reference" "R205" (at 142.24 92.71 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 140.97 95.25 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 138.938 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 137.16 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 137.16 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 137.16 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 137.16 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 137.16 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 137.16 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 137.16 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 137.16 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 137.16 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 137.16 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 368b3575-5012-4eaf-82a6-ae75a4399ca9))
-    (pin "2" (uuid 814caf41-3232-4c84-9cb4-13666dcedeb9))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "R205") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 149.86 78.74 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5a331)
-    (property "Reference" "R206" (at 152.4 74.93 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 153.67 80.01 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 151.638 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 149.86 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 149.86 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 149.86 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 149.86 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 149.86 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 149.86 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 149.86 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 149.86 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 149.86 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 149.86 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f82aa551-d388-482e-9875-39d4d7cb736e))
-    (pin "2" (uuid 613626ad-4a03-4120-9a77-7af76219e0a0))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "R206") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 167.64 93.98 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5a359)
-    (property "Reference" "R207" (at 172.72 92.71 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 171.45 95.25 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 169.418 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 167.64 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 167.64 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 167.64 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 167.64 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 167.64 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 167.64 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 167.64 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 167.64 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 167.64 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 167.64 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 699b9b76-8bd7-4b2d-a380-098ba032437b))
-    (pin "2" (uuid a5415f69-e91a-4fe8-92bb-defaa5af0a07))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "R207") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 180.34 78.74 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5a36a)
-    (property "Reference" "R208" (at 182.88 74.93 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 184.15 80.01 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 182.118 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 180.34 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 180.34 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 180.34 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 180.34 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 180.34 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 180.34 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 180.34 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 180.34 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 180.34 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 653f61e8-71ce-4fe6-a19b-4e4d2a584300))
-    (pin "2" (uuid 6b6284b3-e84b-4b5e-a3a4-945286d34207))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "R208") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 198.12 93.98 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5a392)
-    (property "Reference" "R209" (at 204.47 92.71 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 201.93 95.25 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 199.898 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 198.12 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 198.12 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 198.12 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 198.12 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 198.12 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 198.12 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 198.12 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 198.12 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 198.12 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 198.12 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8f1aa4b4-93d8-4f12-82f7-fd6ef9aa3bbe))
-    (pin "2" (uuid 4a294d30-d2cc-481b-a90f-f7a6f79ad53e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "R209") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 210.82 78.74 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5a3a3)
-    (property "Reference" "R210" (at 213.36 74.93 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 214.63 80.01 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 212.598 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 210.82 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 210.82 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 210.82 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 210.82 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 210.82 78.74 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 210.82 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 210.82 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 210.82 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 210.82 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 210.82 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 26c99403-f422-4ad8-9020-9c621293f258))
-    (pin "2" (uuid bd3da165-cd14-4981-a43d-ed909fa5e311))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "R210") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE") (at 119.38 90.17 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062c2d664)
-    (property "Reference" "D202" (at 123.9012 87.5538 90)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "LED_T1.75_CLEAR_WHITE" (at 123.9012 90.2462 90)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial" (at 124.46 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 127 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "160-1772-ND" (at 129.54 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "LTW-2R3D7" (at 132.08 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Optoelectronics" (at 134.62 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "LED Indication - Discrete" (at 137.16 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 139.7 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121" (at 142.24 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "LED WHITE CLEAR T-1 3/4 T/H" (at 144.78 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Lite-On Inc." (at 147.32 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 149.86 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "HAND" (at 119.38 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.65" (at 119.38 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DigiKey" (at 119.38 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "160-1772-ND" (at 119.38 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 119.38 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 119.38 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fe072f6d-f38d-4ccc-992d-8be15c713b17))
-    (pin "2" (uuid 935e2ea5-c1ed-4d32-b16a-64453ca66482))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "D202") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE") (at 149.86 90.17 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062c2dd8b)
-    (property "Reference" "D203" (at 154.3812 87.5538 90)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "LED_T1.75_CLEAR_WHITE" (at 154.3812 90.2462 90)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial" (at 154.94 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 157.48 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "160-1772-ND" (at 160.02 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "LTW-2R3D7" (at 162.56 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Optoelectronics" (at 165.1 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "LED Indication - Discrete" (at 167.64 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 170.18 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121" (at 172.72 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "LED WHITE CLEAR T-1 3/4 T/H" (at 175.26 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Lite-On Inc." (at 177.8 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 180.34 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "HAND" (at 149.86 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.65" (at 149.86 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DigiKey" (at 149.86 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "160-1772-ND" (at 149.86 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 149.86 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 149.86 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5f9467ec-6601-4436-98d3-d0abebb5f760))
-    (pin "2" (uuid d0427799-3a49-420c-b31b-8cf89063ad1d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "D203") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE") (at 180.34 90.17 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062c2e7da)
-    (property "Reference" "D204" (at 184.8612 87.5538 90)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "LED_T1.75_CLEAR_WHITE" (at 184.8612 90.2462 90)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial" (at 185.42 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 187.96 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "160-1772-ND" (at 190.5 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "LTW-2R3D7" (at 193.04 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Optoelectronics" (at 195.58 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "LED Indication - Discrete" (at 198.12 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 200.66 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121" (at 203.2 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "LED WHITE CLEAR T-1 3/4 T/H" (at 205.74 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Lite-On Inc." (at 208.28 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 210.82 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "HAND" (at 180.34 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.65" (at 180.34 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DigiKey" (at 180.34 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "160-1772-ND" (at 180.34 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 180.34 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 180.34 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8bded7fe-f26e-421d-b87a-d84696d7ae4f))
-    (pin "2" (uuid c8f806f1-2146-4c24-8f55-ba7981d0e964))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "D204") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE") (at 210.82 90.17 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062c2f233)
-    (property "Reference" "D205" (at 215.3412 87.5538 90)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "LED_T1.75_CLEAR_WHITE" (at 215.3412 90.2462 90)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial" (at 215.9 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 218.44 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "160-1772-ND" (at 220.98 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "LTW-2R3D7" (at 223.52 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Optoelectronics" (at 226.06 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "LED Indication - Discrete" (at 228.6 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 231.14 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121" (at 233.68 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "LED WHITE CLEAR T-1 3/4 T/H" (at 236.22 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Lite-On Inc." (at 238.76 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 241.3 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "HAND" (at 210.82 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.65" (at 210.82 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DigiKey" (at 210.82 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "160-1772-ND" (at 210.82 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 210.82 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 210.82 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 56afe54f-6e3c-4e4b-914a-500bce2e52fc))
-    (pin "2" (uuid 2391f688-d3b0-4cb6-84fa-833a260cdfb6))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "D205") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE") (at 88.9 90.17 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062c472da)
-    (property "Reference" "D201" (at 93.4212 87.5538 90)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "LED_T1.75_CLEAR_WHITE" (at 93.4212 90.2462 90)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial" (at 93.98 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 96.52 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "160-1772-ND" (at 99.06 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "LTW-2R3D7" (at 101.6 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Optoelectronics" (at 104.14 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "LED Indication - Discrete" (at 106.68 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 109.22 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121" (at 111.76 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "LED WHITE CLEAR T-1 3/4 T/H" (at 114.3 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Lite-On Inc." (at 116.84 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 119.38 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "HAND" (at 88.9 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.65" (at 88.9 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DigiKey" (at 88.9 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "160-1772-ND" (at 88.9 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 88.9 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 88.9 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9c8a7587-82c5-48ef-9353-0211d487e6fe))
-    (pin "2" (uuid ba0731ef-9aa4-417e-a7d6-45a01de20ac4))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "D201") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+5V") (at 88.9 59.69 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062cbf69c)
-    (property "Reference" "#PWR0201" (at 88.9 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+5V" (at 89.281 55.2958 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 88.9 59.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 88.9 59.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d3f5ff1b-062f-45d4-b725-e9b648da1b39))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "#PWR0201") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MMBT2222A-7-F") (at 86.36 100.33 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062d15bd1)
-    (property "Reference" "Q201" (at 91.1352 98.9838 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "MMBT2222A-7-F" (at 91.1352 101.6762 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 91.44 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 91.44 92.71 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "MMBT2222A-FDICT-ND" (at 91.44 90.17 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "MMBT2222A-7-F" (at 91.44 87.63 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Discrete Semiconductor Products" (at 91.44 85.09 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Transistors - Bipolar (BJT) - Single" (at 91.44 82.55 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 91.44 80.01 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723" (at 91.44 77.47 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3" (at 91.44 74.93 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Diodes Incorporated" (at 91.44 72.39 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 91.44 69.85 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "SMT" (at 86.36 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 86.36 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C94515" (at 86.36 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0475" (at 86.36 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 86.36 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 86.36 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 864b89b5-f327-47b2-83f8-0145802ac127))
-    (pin "2" (uuid ff0ee1fb-950a-40c8-9b3d-d224c7fb361d))
-    (pin "3" (uuid 0f7dc820-276d-409b-adb5-6fdc976906ad))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "Q201") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MMBT2222A-7-F") (at 208.28 100.33 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062d16689)
-    (property "Reference" "Q205" (at 213.0552 98.9838 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "MMBT2222A-7-F" (at 213.0552 101.6762 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 213.36 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 213.36 92.71 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "MMBT2222A-FDICT-ND" (at 213.36 90.17 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "MMBT2222A-7-F" (at 213.36 87.63 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Discrete Semiconductor Products" (at 213.36 85.09 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Transistors - Bipolar (BJT) - Single" (at 213.36 82.55 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 213.36 80.01 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723" (at 213.36 77.47 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3" (at 213.36 74.93 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Diodes Incorporated" (at 213.36 72.39 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 213.36 69.85 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "SMT" (at 208.28 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 208.28 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C94515" (at 208.28 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0475" (at 208.28 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 208.28 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 208.28 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 47e2a321-f3ce-49c2-bce3-51a6d21f4359))
-    (pin "2" (uuid a0aeb236-8ce4-4646-b26d-409726e680f6))
-    (pin "3" (uuid 4307edb2-e86f-4bef-b375-4474cdcf398b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "Q205") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MMBT2222A-7-F") (at 177.8 100.33 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062d176ae)
-    (property "Reference" "Q204" (at 182.5752 98.9838 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "MMBT2222A-7-F" (at 182.5752 101.6762 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 182.88 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 182.88 92.71 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "MMBT2222A-FDICT-ND" (at 182.88 90.17 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "MMBT2222A-7-F" (at 182.88 87.63 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Discrete Semiconductor Products" (at 182.88 85.09 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Transistors - Bipolar (BJT) - Single" (at 182.88 82.55 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 182.88 80.01 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723" (at 182.88 77.47 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3" (at 182.88 74.93 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Diodes Incorporated" (at 182.88 72.39 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 182.88 69.85 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "SMT" (at 177.8 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 177.8 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C94515" (at 177.8 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0475" (at 177.8 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 177.8 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 177.8 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7b1b1013-5bf8-448c-84a2-0c44e7702429))
-    (pin "2" (uuid f9ca9396-e664-45ab-998d-d896677f3eca))
-    (pin "3" (uuid 3fe76400-16f4-4e91-a854-f204893ef423))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "Q204") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MMBT2222A-7-F") (at 147.32 100.33 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062d18339)
-    (property "Reference" "Q203" (at 152.0952 98.9838 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "MMBT2222A-7-F" (at 152.0952 101.6762 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 152.4 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 152.4 92.71 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "MMBT2222A-FDICT-ND" (at 152.4 90.17 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "MMBT2222A-7-F" (at 152.4 87.63 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Discrete Semiconductor Products" (at 152.4 85.09 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Transistors - Bipolar (BJT) - Single" (at 152.4 82.55 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 152.4 80.01 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723" (at 152.4 77.47 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3" (at 152.4 74.93 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Diodes Incorporated" (at 152.4 72.39 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 152.4 69.85 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "SMT" (at 147.32 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 147.32 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C94515" (at 147.32 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0475" (at 147.32 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 147.32 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 147.32 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 64fac78c-cce5-40b3-91ab-45e5ad4a1ef6))
-    (pin "2" (uuid 177b7014-a0d1-4f01-988f-182af75cc265))
-    (pin "3" (uuid 4d4a40d0-a159-41fa-934e-11da34ff9f94))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "Q203") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MMBT2222A-7-F") (at 116.84 100.33 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062d18d24)
-    (property "Reference" "Q202" (at 121.6152 98.9838 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "MMBT2222A-7-F" (at 121.6152 101.6762 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 121.92 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 121.92 92.71 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "MMBT2222A-FDICT-ND" (at 121.92 90.17 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "MMBT2222A-7-F" (at 121.92 87.63 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Discrete Semiconductor Products" (at 121.92 85.09 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Transistors - Bipolar (BJT) - Single" (at 121.92 82.55 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 121.92 80.01 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723" (at 121.92 77.47 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3" (at 121.92 74.93 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Diodes Incorporated" (at 121.92 72.39 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 121.92 69.85 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "SMT" (at 116.84 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 116.84 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C94515" (at 116.84 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0475" (at 116.84 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 116.84 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 116.84 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 223b744e-7ffc-42d1-861e-cade5678b4c7))
-    (pin "2" (uuid 7e4ffb52-3e79-48d7-9b12-2b2809f8e523))
-    (pin "3" (uuid 311f4bac-e9c3-48bd-b0eb-7bfe8653c42e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "Q202") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 88.9 106.68 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0ffc1d1e-e3da-4cd0-adc4-47c42f98eb92)
-    (property "Reference" "#PWR0108" (at 88.9 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 88.9 111.76 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 88.9 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 88.9 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12420f87-26ee-40d3-84ba-682679740451))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "#PWR0601") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff") (at 210.82 124.46 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 420e9d6e-e67c-486c-8424-10e52e74b3ba)
-    (property "Reference" "MF605" (at 215.9 123.1899 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff" (at 215.9 125.7299 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff" (at 210.82 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 210.82 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 210.82 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 210.82 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 210.82 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "NA" (at 210.82 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "NA" (at 210.82 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 210.82 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 210.82 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 210.82 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 210.82 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "MF605") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 119.38 106.68 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7699fe31-5943-4828-94f7-d332448976eb)
-    (property "Reference" "#PWR0108" (at 119.38 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 119.38 111.76 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 119.38 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 119.38 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 464c3ebc-d193-40aa-8505-5451c69914fa))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "#PWR0602") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff") (at 180.34 130.81 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7e8dabd8-9dd3-4f9c-89bb-fae59fdcc0f5)
-    (property "Reference" "MF604" (at 185.42 129.5399 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff" (at 185.42 132.0799 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff" (at 180.34 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 180.34 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 180.34 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 180.34 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 180.34 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "NA" (at 180.34 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "NA" (at 180.34 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 180.34 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 180.34 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 180.34 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 180.34 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "MF604") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 210.82 106.68 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 880c642d-413e-4fb9-8a4e-54371bdd23c5)
-    (property "Reference" "#PWR0108" (at 210.82 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 210.82 111.76 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 210.82 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 210.82 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a687118c-ce21-4571-8b3c-10706a24c95f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "#PWR0605") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff") (at 151.13 123.19 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a2b6516e-9ff6-4381-a43b-e1824330249d)
-    (property "Reference" "MF603" (at 156.21 121.9199 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff" (at 156.21 124.4599 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff" (at 151.13 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 151.13 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 151.13 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 151.13 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 151.13 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "NA" (at 151.13 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "NA" (at 151.13 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 151.13 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 151.13 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 151.13 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 151.13 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "MF603") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 149.86 106.68 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3b3f40b-43f5-47bc-b413-f615b5e0794e)
-    (property "Reference" "#PWR0108" (at 149.86 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 149.86 111.76 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 149.86 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 149.86 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f26ad494-43fe-4876-827a-3be254de033d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "#PWR0603") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 180.34 106.68 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b960831b-8cdf-4f6c-9c54-d22eb82ff290)
-    (property "Reference" "#PWR0108" (at 180.34 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 180.34 111.76 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 180.34 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 180.34 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 17fdb06b-b10b-4d8c-a25e-e6138546076f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "#PWR0604") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff") (at 119.38 129.54 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid da8e7b02-3ac8-446f-b0c5-b1d9f9707be2)
-    (property "Reference" "MF602" (at 124.46 128.2699 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff" (at 124.46 130.8099 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff" (at 119.38 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 119.38 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 119.38 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 119.38 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 119.38 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "NA" (at 119.38 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "NA" (at 119.38 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 119.38 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 119.38 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 119.38 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 119.38 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "MF602") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff") (at 88.9 120.65 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ea964b5b-02f6-40ab-8892-c36a3db6b068)
-    (property "Reference" "MF601" (at 93.98 119.3799 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff" (at 93.98 121.9199 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff" (at 88.9 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 88.9 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 88.9 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 88.9 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 88.9 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "NA" (at 88.9 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "NA" (at 88.9 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 88.9 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 88.9 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 88.9 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 88.9 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "MF601") (unit 1)
-        )
-      )
-    )
-  )
+(kicad_sch
+	(version 20251012)
+	(generator "eeschema")
+	(generator_version "9.99")
+	(uuid "eb754b24-08d4-4186-b0bf-c7f5f4358e7b")
+	(paper "A4")
+	(title_block
+		(title "KRAKE_PCB")
+		(date "2025-07-18")
+		(rev "2.0")
+		(company "PublicInvention")
+		(comment 1 "GNU Affero General Public License v3.0")
+		(comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
+		(comment 3 "https://github.com/PubInv/krake")
+		(comment 4 "Inherited from the GPAD")
+	)
+	(lib_symbols
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GND_1"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND_1"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_1_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE"
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "D"
+				(at -3.81 2.54 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Value" "LED_T1.75_CLEAR_WHITE"
+				(at -1.27 -3.81 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial"
+				(at 5.08 5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+				(at 5.08 7.62 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Description" "LED WHITE CLEAR T-1 3/4 T/H"
+				(at 5.08 25.4 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Digi-Key_PN" "160-1772-ND"
+				(at 5.08 10.16 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "MPN" "LTW-2R3D7"
+				(at 5.08 12.7 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Category" "Optoelectronics"
+				(at 5.08 15.24 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Family" "LED Indication - Discrete"
+				(at 5.08 17.78 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+				(at 5.08 20.32 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121"
+				(at 5.08 22.86 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Manufacturer" "Lite-On Inc."
+				(at 5.08 27.94 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Status" "Active"
+				(at 5.08 30.48 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "ki_keywords" "160-1772-ND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "LED_T1.75_CLEAR_WHITE_0_1"
+				(polyline
+					(pts
+						(xy -2.54 1.27) (xy -2.54 -1.27) (xy 0 0) (xy -2.54 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy -0.635 3.81) (xy 0 3.81) (xy 0 3.175)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 3.81) (xy -1.27 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.635 3.175) (xy 1.27 3.175) (xy 1.27 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 3.175) (xy 0 1.905)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "LED_T1.75_CLEAR_WHITE_1_1"
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 0 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:MMBT2222A-7-F"
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "Q"
+				(at -3.2004 4.2164 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "MMBT2222A-7-F"
+				(at 5.2324 0 90)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+				(at 5.08 5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+				(at 5.08 7.62 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3"
+				(at 5.08 25.4 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Digi-Key_PN" "MMBT2222A-FDICT-ND"
+				(at 5.08 10.16 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "MPN" "MMBT2222A-7-F"
+				(at 5.08 12.7 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Category" "Discrete Semiconductor Products"
+				(at 5.08 15.24 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Family" "Transistors - Bipolar (BJT) - Single"
+				(at 5.08 17.78 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+				(at 5.08 20.32 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723"
+				(at 5.08 22.86 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Manufacturer" "Diodes Incorporated"
+				(at 5.08 27.94 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Status" "Active"
+				(at 5.08 30.48 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "ki_keywords" "MMBT2222A-FDICT-ND Automotive, AEC-Q101"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "MMBT2222A-7-F_0_1"
+				(polyline
+					(pts
+						(xy -3.81 0) (xy -2.54 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.556 0) (xy 0 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0 -2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 1.27) (xy 2.54 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 0)
+					(radius 3.2512)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -1.27) (xy 2.54 -2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.524 -1.27) (xy 2.032 -2.286) (xy 1.016 -2.54) (xy 1.524 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(symbol "MMBT2222A-7-F_1_1"
+				(pin input line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "B"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 -5.08 90)
+					(length 2.54)
+					(name "E"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 5.08 270)
+					(length 2.54)
+					(name "C"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "MF"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "U_Box_V104_General_Alarm_Device_LED_Standoff_0_1"
+				(circle
+					(center -2.54 0)
+					(radius 1.27)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 0)
+					(radius 4.0161)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.54 0)
+					(radius 1.27)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:+5V"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "+5V"
+				(at 0 3.556 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"+5V\""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "+5V_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "+5V_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(hide yes)
+					(name "+5V"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(text "currect setting \nresistor, Base"
+		(exclude_from_sim no)
+		(at 77.47 95.25 0)
+		(effects
+			(font
+				(size 0.762 0.762)
+			)
+			(justify left bottom)
+		)
+		(uuid "42dc2ae5-3c20-4a59-b485-462b1bfcebda")
+	)
+	(text "currect setting \nresistor, LED"
+		(exclude_from_sim no)
+		(at 90.17 80.01 0)
+		(effects
+			(font
+				(size 0.762 0.762)
+			)
+			(justify left bottom)
+		)
+		(uuid "66ab364f-3dac-457d-a0bb-255f24170c2a")
+	)
+	(text "current sink\ntransistor"
+		(exclude_from_sim no)
+		(at 91.44 105.41 0)
+		(effects
+			(font
+				(size 0.762 0.762)
+			)
+			(justify left bottom)
+		)
+		(uuid "989efb15-6cee-4824-b13a-c3397dd5de03")
+	)
+	(text "Alarm lights, 5 Levels"
+		(exclude_from_sim no)
+		(at 128.27 69.85 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f99ff8e1-46d7-44ac-8e03-2d3b0a573d00")
+	)
+	(junction
+		(at 119.38 71.12)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1112ab5c-42aa-4ea5-835a-5aa218728a14")
+	)
+	(junction
+		(at 180.34 71.12)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3ac97a3a-62bd-411b-87ea-39fc238e4799")
+	)
+	(junction
+		(at 88.9 71.12)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b1f1192c-9056-4d66-8aa3-769c6efcca3d")
+	)
+	(junction
+		(at 149.86 71.12)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d216c1d0-b285-4029-b1d6-e113b3d15575")
+	)
+	(wire
+		(pts
+			(xy 88.9 71.12) (xy 88.9 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "07de91d3-3912-4ef4-9dfc-9de0c35aa5a4")
+	)
+	(wire
+		(pts
+			(xy 149.86 74.93) (xy 149.86 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0b7fed12-8933-4afb-83ac-7ba9f5fcf0f2")
+	)
+	(wire
+		(pts
+			(xy 209.55 74.93) (xy 210.82 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0bcc9963-833a-46ac-b9ed-1eb29981839c")
+	)
+	(wire
+		(pts
+			(xy 119.38 85.09) (xy 119.38 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "14d1afe3-160c-4ba2-a1a9-cb03a788f03a")
+	)
+	(wire
+		(pts
+			(xy 180.34 85.09) (xy 180.34 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "15fb56b2-91a1-46f2-bfcf-b057aad785c3")
+	)
+	(wire
+		(pts
+			(xy 209.55 71.12) (xy 209.55 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "27385646-ed37-421d-a09a-d24c430a0053")
+	)
+	(wire
+		(pts
+			(xy 88.9 82.55) (xy 88.9 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "28ee582a-502f-432f-8fb0-08a24acd0a2f")
+	)
+	(wire
+		(pts
+			(xy 88.9 71.12) (xy 119.38 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "33d68ba6-b361-4a04-960a-5848fce78977")
+	)
+	(wire
+		(pts
+			(xy 167.64 81.28) (xy 167.64 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "36b084ab-ebff-4deb-a3ef-cd24713aa7b9")
+	)
+	(wire
+		(pts
+			(xy 137.16 97.79) (xy 137.16 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "37413a70-3c71-46b5-8d15-074179a20104")
+	)
+	(wire
+		(pts
+			(xy 180.34 71.12) (xy 209.55 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "38e23027-6a0b-4fe2-918e-e62c4fc1bae8")
+	)
+	(wire
+		(pts
+			(xy 198.12 100.33) (xy 203.2 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "392b8ab3-7e7d-497f-963a-d3e3e1f16883")
+	)
+	(wire
+		(pts
+			(xy 210.82 85.09) (xy 210.82 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5268249f-43ae-41e4-bd63-03b636092743")
+	)
+	(wire
+		(pts
+			(xy 119.38 95.25) (xy 119.38 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "564f1f86-7f99-4c1d-a384-f9d167bcd16e")
+	)
+	(wire
+		(pts
+			(xy 137.16 100.33) (xy 142.24 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5a7871f2-6337-4799-93e7-dfbacf24798d")
+	)
+	(wire
+		(pts
+			(xy 198.12 97.79) (xy 198.12 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5e93fe8e-93e5-4ee2-a10b-1810bb9e1d0f")
+	)
+	(wire
+		(pts
+			(xy 76.2 81.28) (xy 76.2 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "650a2466-d51a-42bf-a937-9e8f849bdd19")
+	)
+	(wire
+		(pts
+			(xy 149.86 85.09) (xy 149.86 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6900ecaa-557b-44cd-b927-a781ee08e94e")
+	)
+	(wire
+		(pts
+			(xy 119.38 74.93) (xy 119.38 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "697d9bac-95af-400c-8cfb-3aa09c390a33")
+	)
+	(wire
+		(pts
+			(xy 137.16 81.28) (xy 137.16 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "75ca2923-498d-4ada-a1ee-40fd164f5a62")
+	)
+	(wire
+		(pts
+			(xy 167.64 97.79) (xy 167.64 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7887aab3-8d8d-4b04-884f-5c446c454b80")
+	)
+	(wire
+		(pts
+			(xy 210.82 95.25) (xy 210.82 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "78d8412b-cbcf-4cdd-b553-cb8f0df89b5e")
+	)
+	(wire
+		(pts
+			(xy 149.86 105.41) (xy 149.86 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a3f81c4-c9da-4eb7-8932-88307b32eb06")
+	)
+	(wire
+		(pts
+			(xy 106.68 81.28) (xy 106.68 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7d8fdcbf-7ca4-4f0a-a7b5-d9b8d02c8461")
+	)
+	(wire
+		(pts
+			(xy 106.68 97.79) (xy 106.68 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "852e1ee4-ca8c-49fd-aae7-013c2e664146")
+	)
+	(wire
+		(pts
+			(xy 106.68 100.33) (xy 111.76 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a493a9cc-e521-4a16-8fed-29b8980133f3")
+	)
+	(wire
+		(pts
+			(xy 88.9 92.71) (xy 88.9 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b18260af-511a-4506-8450-46669f7f73ff")
+	)
+	(wire
+		(pts
+			(xy 119.38 71.12) (xy 149.86 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b51f7a88-79e8-45ac-b56b-177ccd2c4637")
+	)
+	(wire
+		(pts
+			(xy 180.34 74.93) (xy 180.34 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bbdcdec5-7e1e-4658-8db2-d831fb88e59b")
+	)
+	(wire
+		(pts
+			(xy 167.64 100.33) (xy 172.72 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bbed2049-c6e0-4842-bb27-8462cd63f583")
+	)
+	(wire
+		(pts
+			(xy 149.86 71.12) (xy 180.34 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c244b6af-9e45-4b02-ba07-b64fa152f710")
+	)
+	(wire
+		(pts
+			(xy 210.82 106.68) (xy 210.82 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cade5a29-846e-4e8c-86a8-ba40a5722bbf")
+	)
+	(wire
+		(pts
+			(xy 119.38 106.68) (xy 119.38 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dbfec2eb-51ea-4ca3-b68d-58edb66e8107")
+	)
+	(wire
+		(pts
+			(xy 76.2 97.79) (xy 76.2 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de1bb723-1a86-429f-866c-e45ab10bc964")
+	)
+	(wire
+		(pts
+			(xy 149.86 95.25) (xy 149.86 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "deb00a2f-d8c2-4e83-bcac-a97abae21343")
+	)
+	(wire
+		(pts
+			(xy 180.34 95.25) (xy 180.34 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ea89519c-31f7-46a2-a300-d13a27ed6da5")
+	)
+	(wire
+		(pts
+			(xy 198.12 81.28) (xy 198.12 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "eb143699-1e22-44bf-b668-233fb81adaaf")
+	)
+	(wire
+		(pts
+			(xy 180.34 106.68) (xy 180.34 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ed190ccd-1e3c-404a-93a0-7e4217b6d2af")
+	)
+	(wire
+		(pts
+			(xy 88.9 74.93) (xy 88.9 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ed6cb61c-2c80-49df-92de-5420348cece9")
+	)
+	(wire
+		(pts
+			(xy 88.9 106.68) (xy 88.9 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f7f34952-a2fb-4bcd-8c76-855d3e70f98b")
+	)
+	(wire
+		(pts
+			(xy 76.2 100.33) (xy 81.28 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa883525-c2ec-433b-b290-aec6f11870f7")
+	)
+	(image
+		(at 229.87 180.34)
+		(scale 0.2225)
+		(uuid "da432c4d-19a0-43be-8f67-de6960a4724d")
+		(data "iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz"
+			"AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h"
+			"aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73"
+			"+/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA"
+			"xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y"
+			"Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h"
+			"xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO"
+			"GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful"
+			"fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv"
+			"4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ"
+			"EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R"
+			"Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM"
+			"vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H"
+			"cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0"
+			"6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT"
+			"O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA"
+			"4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86"
+			"sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+"
+			"oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/"
+			"55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0"
+			"qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+"
+			"KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn"
+			"Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4"
+			"mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii"
+			"P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr"
+			"voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6"
+			"bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO"
+			"h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da"
+			"4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y"
+			"YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC"
+			"0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP"
+			"SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb"
+			"WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw"
+			"v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay"
+			"PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX"
+			"Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh"
+			"oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD"
+			"7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da"
+			"43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l"
+			"zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl"
+			"pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS"
+			"H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV"
+			"ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY"
+			"MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2"
+			"NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx"
+			"fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl"
+			"tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew"
+			"iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj"
+			"jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI"
+			"cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo"
+			"XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R"
+			"9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv"
+			"8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV"
+			"RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY"
+			"l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf"
+			"YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN"
+			"EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU"
+			"sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z"
+			"7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs"
+			"OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs"
+			"qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7"
+			"G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6"
+			"wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7"
+			"zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln"
+			"Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX"
+			"apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk"
+			"lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw"
+			"TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb"
+			"54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID"
+			"qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd"
+			"P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l"
+			"UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD"
+			"zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH"
+			"Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1"
+			"QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/"
+			"ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX"
+			"08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC"
+			"KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ"
+			"SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu"
+			"h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp"
+			"VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf"
+			"G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK"
+			"dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO"
+			"uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2"
+			"DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn"
+			"byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc"
+			"dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N"
+			"iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP"
+			"NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4"
+			"wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8"
+			"K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s"
+			"xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS"
+			"Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC"
+			"Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5"
+			"m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm"
+			"aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj"
+			"gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn"
+			"p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL"
+			"ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx"
+			"u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+"
+			"FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa"
+			"ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h"
+			"1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj"
+			"DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy"
+			"+Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj"
+			"wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj"
+			"7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ"
+			"lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN"
+			"2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY"
+			"CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi"
+			"mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E"
+			"uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x"
+			"j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD"
+			"45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO"
+			"4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni"
+			"buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY"
+			"HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH"
+			"NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ"
+			"azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N"
+			"SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP"
+			"hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe"
+			"nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4"
+			"b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN"
+			"xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S"
+			"pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq"
+			"3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB"
+			"Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL"
+			"4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw"
+			"qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX"
+			"9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n"
+			"frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/"
+			"eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK"
+			"TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u"
+			"RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9"
+			"DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j"
+			"2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx"
+			"BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy"
+			"91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7"
+			"jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw"
+			"pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ"
+			"cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M"
+			"xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23"
+			"7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8"
+			"D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw"
+			"YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu"
+			"QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs"
+			"uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA"
+			"PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6"
+			"yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN"
+			"xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq"
+			"JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT"
+			"+HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg"
+			"hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K"
+			"hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt"
+			"g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z"
+			"5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf"
+			"u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO"
+			"Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG"
+			"gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK"
+			"hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x"
+			"moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56"
+			"KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp"
+			"ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz"
+			"eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO"
+			"0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA"
+			"BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ"
+			"2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB"
+			"4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF"
+			"6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI"
+			"gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv"
+			"OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt"
+			"8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI"
+			"bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM"
+			"500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4"
+			"CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V"
+			"aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5"
+			"yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF"
+			"zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss"
+			"tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q"
+			"r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj"
+			"xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h"
+			"6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y"
+			"9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE"
+			"XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh"
+			"oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk"
+			"Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4"
+			"ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW"
+			"zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr"
+			"wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV"
+			"BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7"
+			"LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr"
+			"owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX"
+			"hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j"
+			"1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF"
+			"5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw"
+			"a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6"
+			"Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN"
+			"+SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds"
+			"lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ"
+			"i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu"
+			"fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy"
+			"r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28"
+			"dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az"
+			"70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk"
+			"EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL"
+			"p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf"
+			"nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA"
+			"ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c"
+			"q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu"
+			"Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR"
+			"TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53"
+			"en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA"
+			"x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ"
+			"t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+"
+			"R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf"
+			"5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH"
+			"e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG"
+			"po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh"
+			"6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln"
+			"9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU"
+			"xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ"
+			"rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W"
+			"lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb"
+			"afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs"
+			"FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR"
+			"OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC"
+			"P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp"
+			"EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh"
+			"6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK"
+			"GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ"
+			"hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s"
+			"amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+"
+			"fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij"
+			"TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv"
+			"I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf"
+			"kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ"
+			"BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD"
+			"9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn"
+			"jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8"
+			"I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI"
+			"8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs"
+			"Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN"
+			"MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5"
+			"2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU"
+			"2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss"
+			"ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m"
+			"sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq"
+			"LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT"
+			"tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9"
+			"oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p"
+			"zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu"
+			"WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy"
+			"diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX"
+			"ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY"
+			"5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau"
+			"Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7"
+			"oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG"
+			"xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q"
+			"zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik"
+			"sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN"
+			"ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc"
+			"MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E"
+			"YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3"
+			"bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz"
+			"DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC"
+			"TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES"
+			"3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K"
+			"Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd"
+			"b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5"
+			"99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys"
+			"7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa"
+			"Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e"
+			"8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1"
+			"vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK"
+			"VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4"
+			"ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD"
+			"CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4"
+			"qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr"
+			"1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe"
+			"GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK"
+			"yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj"
+			"po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO"
+			"Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF"
+			"tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D"
+			"mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM"
+			"eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN"
+			"veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu"
+			"5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL"
+			"Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t"
+			"rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl"
+			"sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx"
+			"mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG"
+			"PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk"
+			"Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk"
+			"caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO"
+			"jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS"
+			"gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E"
+			"OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+"
+			"p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO"
+			"cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM"
+			"S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc"
+			"vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3"
+			"boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn"
+			"DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD"
+			"90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw"
+			"0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT"
+			"5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI"
+			"7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP"
+			"QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw"
+			"oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E"
+			"mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/"
+			"N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm"
+			"vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC"
+			"+OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp"
+			"gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz"
+			"gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni"
+			"R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3"
+			"j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo"
+			"BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl"
+			"IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4"
+			"jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA"
+			"Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS"
+			"AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz"
+			"6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H"
+			"qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp"
+			"cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa"
+			"M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv"
+			"4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M"
+			"IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD"
+			"Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r"
+			"un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr"
+			"2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/"
+			"kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF"
+			"7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8"
+			"YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk"
+			"zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp"
+			"8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF"
+			"o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt"
+			"Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA"
+			"hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx"
+			"LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk"
+			"iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2"
+			"HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5"
+			"K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo"
+			"XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/"
+			"D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j"
+			"MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c"
+			"O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB"
+			"fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X"
+			"/V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI"
+			"a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe"
+			"L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37"
+			"zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY"
+			"BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg=="
+		)
+	)
+	(hierarchical_label "Light3"
+		(shape input)
+		(at 167.64 81.28 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0464d949-bdc1-4743-9657-04d380db509b")
+	)
+	(hierarchical_label "Light2"
+		(shape input)
+		(at 137.16 81.28 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "0565ac06-f4da-404e-9265-99760def4d8e")
+	)
+	(hierarchical_label "Light1"
+		(shape input)
+		(at 106.68 81.28 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1e748145-f538-4854-9134-f367d2ff4fbe")
+	)
+	(hierarchical_label "Light4"
+		(shape input)
+		(at 198.12 81.28 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "306798b8-8a86-4659-9187-913a30a7d792")
+	)
+	(hierarchical_label "Light0"
+		(shape input)
+		(at 76.2 81.28 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e4d17d3c-b46a-43ae-96d4-57f89e72b7dc")
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 76.2 93.98 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5a2ae")
+		(property "Reference" "R201"
+			(at 78.74 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 80.01 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 77.978 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 76.2 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 76.2 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 76.2 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 76.2 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 76.2 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 76.2 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 76.2 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 76.2 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 76.2 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 76.2 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "73e33c7e-d704-4489-ad2e-e2975d475aaf")
+		)
+		(pin "2"
+			(uuid "6f984ddc-7764-4214-b5f5-6c21e918c98d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "R201")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 88.9 78.74 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5a2bf")
+		(property "Reference" "R202"
+			(at 91.44 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 92.71 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 90.678 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 88.9 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 88.9 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 88.9 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 88.9 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 88.9 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 88.9 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 88.9 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 88.9 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 88.9 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 88.9 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ebc64a72-e976-4db8-84ea-c6038af80d0e")
+		)
+		(pin "2"
+			(uuid "739feca1-32f5-449c-9cf4-d68321a2f964")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "R202")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 106.68 93.98 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5a2e7")
+		(property "Reference" "R203"
+			(at 111.76 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 110.49 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 108.458 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 106.68 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 106.68 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 106.68 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 106.68 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 106.68 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 106.68 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 106.68 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 106.68 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 106.68 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 106.68 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "20f3b9a1-2522-449e-8f24-a8d4aab8a36d")
+		)
+		(pin "2"
+			(uuid "76010e76-2ad3-4b9e-a79e-7c3ea369e15f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "R203")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 119.38 78.74 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5a2f8")
+		(property "Reference" "R204"
+			(at 121.92 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 123.19 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 121.158 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 119.38 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 119.38 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 119.38 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 119.38 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 119.38 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 119.38 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 119.38 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 119.38 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 119.38 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 119.38 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "75ad144a-a236-483e-ab19-d60206c4d33c")
+		)
+		(pin "2"
+			(uuid "417c0a15-dfb6-433f-82d7-1a1d5a6ba8a7")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "R204")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 137.16 93.98 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5a320")
+		(property "Reference" "R205"
+			(at 142.24 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 140.97 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 138.938 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 137.16 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 137.16 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 137.16 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 137.16 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 137.16 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 137.16 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 137.16 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 137.16 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 137.16 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 137.16 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "368b3575-5012-4eaf-82a6-ae75a4399ca9")
+		)
+		(pin "2"
+			(uuid "814caf41-3232-4c84-9cb4-13666dcedeb9")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "R205")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 149.86 78.74 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5a331")
+		(property "Reference" "R206"
+			(at 152.4 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 153.67 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 151.638 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 149.86 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 149.86 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 149.86 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 149.86 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 149.86 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 149.86 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 149.86 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 149.86 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 149.86 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 149.86 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f82aa551-d388-482e-9875-39d4d7cb736e")
+		)
+		(pin "2"
+			(uuid "613626ad-4a03-4120-9a77-7af76219e0a0")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "R206")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 167.64 93.98 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5a359")
+		(property "Reference" "R207"
+			(at 172.72 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 171.45 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 169.418 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 167.64 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 167.64 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 167.64 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 167.64 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 167.64 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 167.64 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 167.64 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 167.64 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 167.64 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 167.64 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "699b9b76-8bd7-4b2d-a380-098ba032437b")
+		)
+		(pin "2"
+			(uuid "a5415f69-e91a-4fe8-92bb-defaa5af0a07")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "R207")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 180.34 78.74 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5a36a")
+		(property "Reference" "R208"
+			(at 182.88 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 184.15 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 182.118 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 180.34 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 180.34 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 180.34 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 180.34 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 180.34 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 180.34 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 180.34 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 180.34 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 180.34 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 180.34 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "653f61e8-71ce-4fe6-a19b-4e4d2a584300")
+		)
+		(pin "2"
+			(uuid "6b6284b3-e84b-4b5e-a3a4-945286d34207")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "R208")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 198.12 93.98 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5a392")
+		(property "Reference" "R209"
+			(at 204.47 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 201.93 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 199.898 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 198.12 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 198.12 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 198.12 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 198.12 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 198.12 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 198.12 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 198.12 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 198.12 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 198.12 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 198.12 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "8f1aa4b4-93d8-4f12-82f7-fd6ef9aa3bbe")
+		)
+		(pin "2"
+			(uuid "4a294d30-d2cc-481b-a90f-f7a6f79ad53e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "R209")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 210.82 78.74 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5a3a3")
+		(property "Reference" "R210"
+			(at 213.36 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 214.63 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 212.598 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 210.82 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 210.82 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 210.82 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 210.82 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 210.82 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 210.82 78.74 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 210.82 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 210.82 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 210.82 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 210.82 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "26c99403-f422-4ad8-9020-9c621293f258")
+		)
+		(pin "2"
+			(uuid "bd3da165-cd14-4981-a43d-ed909fa5e311")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "R210")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE")
+		(at 119.38 90.17 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062c2d664")
+		(property "Reference" "D202"
+			(at 123.9012 87.5538 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "LED_T1.75_CLEAR_WHITE"
+			(at 123.9012 90.2462 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial"
+			(at 124.46 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 127 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "LED WHITE CLEAR T-1 3/4 T/H"
+			(at 144.78 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "160-1772-ND"
+			(at 129.54 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "LTW-2R3D7"
+			(at 132.08 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Optoelectronics"
+			(at 134.62 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "LED Indication - Discrete"
+			(at 137.16 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 139.7 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121"
+			(at 142.24 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Lite-On Inc."
+			(at 147.32 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 149.86 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 119.38 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.65"
+			(at 119.38 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DigiKey"
+			(at 119.38 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "160-1772-ND"
+			(at 119.38 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 119.38 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 119.38 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "fe072f6d-f38d-4ccc-992d-8be15c713b17")
+		)
+		(pin "2"
+			(uuid "935e2ea5-c1ed-4d32-b16a-64453ca66482")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "D202")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE")
+		(at 149.86 90.17 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062c2dd8b")
+		(property "Reference" "D203"
+			(at 154.3812 87.5538 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "LED_T1.75_CLEAR_WHITE"
+			(at 154.3812 90.2462 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial"
+			(at 154.94 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 157.48 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "LED WHITE CLEAR T-1 3/4 T/H"
+			(at 175.26 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "160-1772-ND"
+			(at 160.02 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "LTW-2R3D7"
+			(at 162.56 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Optoelectronics"
+			(at 165.1 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "LED Indication - Discrete"
+			(at 167.64 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 170.18 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121"
+			(at 172.72 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Lite-On Inc."
+			(at 177.8 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 180.34 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 149.86 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.65"
+			(at 149.86 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DigiKey"
+			(at 149.86 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "160-1772-ND"
+			(at 149.86 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 149.86 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 149.86 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "5f9467ec-6601-4436-98d3-d0abebb5f760")
+		)
+		(pin "2"
+			(uuid "d0427799-3a49-420c-b31b-8cf89063ad1d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "D203")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE")
+		(at 180.34 90.17 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062c2e7da")
+		(property "Reference" "D204"
+			(at 184.8612 87.5538 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "LED_T1.75_CLEAR_WHITE"
+			(at 184.8612 90.2462 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial"
+			(at 185.42 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 187.96 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "LED WHITE CLEAR T-1 3/4 T/H"
+			(at 205.74 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "160-1772-ND"
+			(at 190.5 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "LTW-2R3D7"
+			(at 193.04 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Optoelectronics"
+			(at 195.58 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "LED Indication - Discrete"
+			(at 198.12 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 200.66 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121"
+			(at 203.2 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Lite-On Inc."
+			(at 208.28 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 210.82 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 180.34 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.65"
+			(at 180.34 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DigiKey"
+			(at 180.34 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "160-1772-ND"
+			(at 180.34 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 180.34 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 180.34 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "8bded7fe-f26e-421d-b87a-d84696d7ae4f")
+		)
+		(pin "2"
+			(uuid "c8f806f1-2146-4c24-8f55-ba7981d0e964")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "D204")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE")
+		(at 210.82 90.17 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062c2f233")
+		(property "Reference" "D205"
+			(at 215.3412 87.5538 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "LED_T1.75_CLEAR_WHITE"
+			(at 215.3412 90.2462 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial"
+			(at 215.9 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 218.44 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "LED WHITE CLEAR T-1 3/4 T/H"
+			(at 236.22 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "160-1772-ND"
+			(at 220.98 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "LTW-2R3D7"
+			(at 223.52 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Optoelectronics"
+			(at 226.06 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "LED Indication - Discrete"
+			(at 228.6 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 231.14 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121"
+			(at 233.68 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Lite-On Inc."
+			(at 238.76 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 241.3 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 210.82 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.65"
+			(at 210.82 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DigiKey"
+			(at 210.82 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "160-1772-ND"
+			(at 210.82 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 210.82 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 210.82 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "56afe54f-6e3c-4e4b-914a-500bce2e52fc")
+		)
+		(pin "2"
+			(uuid "2391f688-d3b0-4cb6-84fa-833a260cdfb6")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "D205")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE")
+		(at 88.9 90.17 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062c472da")
+		(property "Reference" "D201"
+			(at 93.4212 87.5538 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "LED_T1.75_CLEAR_WHITE"
+			(at 93.4212 90.2462 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial"
+			(at 93.98 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 96.52 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "LED WHITE CLEAR T-1 3/4 T/H"
+			(at 114.3 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "160-1772-ND"
+			(at 99.06 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "LTW-2R3D7"
+			(at 101.6 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Optoelectronics"
+			(at 104.14 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "LED Indication - Discrete"
+			(at 106.68 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 109.22 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121"
+			(at 111.76 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Lite-On Inc."
+			(at 116.84 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 119.38 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 88.9 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.65"
+			(at 88.9 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DigiKey"
+			(at 88.9 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "160-1772-ND"
+			(at 88.9 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 88.9 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 88.9 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "9c8a7587-82c5-48ef-9353-0211d487e6fe")
+		)
+		(pin "2"
+			(uuid "ba0731ef-9aa4-417e-a7d6-45a01de20ac4")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "D201")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 88.9 59.69 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062cbf69c")
+		(property "Reference" "#PWR0201"
+			(at 88.9 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+5V"
+			(at 89.281 55.2958 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 88.9 59.69 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 88.9 59.69 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 88.9 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d3f5ff1b-062f-45d4-b725-e9b648da1b39")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "#PWR0201")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MMBT2222A-7-F")
+		(at 86.36 100.33 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062d15bd1")
+		(property "Reference" "Q201"
+			(at 91.1352 98.9838 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MMBT2222A-7-F"
+			(at 91.1352 101.6762 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 91.44 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 91.44 92.71 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3"
+			(at 91.44 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "MMBT2222A-FDICT-ND"
+			(at 91.44 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "MMBT2222A-7-F"
+			(at 91.44 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Discrete Semiconductor Products"
+			(at 91.44 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Transistors - Bipolar (BJT) - Single"
+			(at 91.44 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 91.44 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723"
+			(at 91.44 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Diodes Incorporated"
+			(at 91.44 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 91.44 69.85 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 86.36 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 86.36 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C94515"
+			(at 86.36 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0475"
+			(at 86.36 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 86.36 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 86.36 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "864b89b5-f327-47b2-83f8-0145802ac127")
+		)
+		(pin "2"
+			(uuid "ff0ee1fb-950a-40c8-9b3d-d224c7fb361d")
+		)
+		(pin "3"
+			(uuid "0f7dc820-276d-409b-adb5-6fdc976906ad")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "Q201")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MMBT2222A-7-F")
+		(at 208.28 100.33 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062d16689")
+		(property "Reference" "Q205"
+			(at 213.0552 98.9838 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MMBT2222A-7-F"
+			(at 213.0552 101.6762 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 213.36 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 213.36 92.71 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3"
+			(at 213.36 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "MMBT2222A-FDICT-ND"
+			(at 213.36 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "MMBT2222A-7-F"
+			(at 213.36 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Discrete Semiconductor Products"
+			(at 213.36 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Transistors - Bipolar (BJT) - Single"
+			(at 213.36 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 213.36 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723"
+			(at 213.36 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Diodes Incorporated"
+			(at 213.36 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 213.36 69.85 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 208.28 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 208.28 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C94515"
+			(at 208.28 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0475"
+			(at 208.28 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 208.28 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 208.28 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "47e2a321-f3ce-49c2-bce3-51a6d21f4359")
+		)
+		(pin "2"
+			(uuid "a0aeb236-8ce4-4646-b26d-409726e680f6")
+		)
+		(pin "3"
+			(uuid "4307edb2-e86f-4bef-b375-4474cdcf398b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "Q205")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MMBT2222A-7-F")
+		(at 177.8 100.33 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062d176ae")
+		(property "Reference" "Q204"
+			(at 182.5752 98.9838 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MMBT2222A-7-F"
+			(at 182.5752 101.6762 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 182.88 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 182.88 92.71 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3"
+			(at 182.88 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "MMBT2222A-FDICT-ND"
+			(at 182.88 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "MMBT2222A-7-F"
+			(at 182.88 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Discrete Semiconductor Products"
+			(at 182.88 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Transistors - Bipolar (BJT) - Single"
+			(at 182.88 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 182.88 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723"
+			(at 182.88 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Diodes Incorporated"
+			(at 182.88 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 182.88 69.85 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 177.8 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 177.8 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C94515"
+			(at 177.8 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0475"
+			(at 177.8 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 177.8 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 177.8 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7b1b1013-5bf8-448c-84a2-0c44e7702429")
+		)
+		(pin "2"
+			(uuid "f9ca9396-e664-45ab-998d-d896677f3eca")
+		)
+		(pin "3"
+			(uuid "3fe76400-16f4-4e91-a854-f204893ef423")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "Q204")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MMBT2222A-7-F")
+		(at 147.32 100.33 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062d18339")
+		(property "Reference" "Q203"
+			(at 152.0952 98.9838 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MMBT2222A-7-F"
+			(at 152.0952 101.6762 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 152.4 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 152.4 92.71 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3"
+			(at 152.4 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "MMBT2222A-FDICT-ND"
+			(at 152.4 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "MMBT2222A-7-F"
+			(at 152.4 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Discrete Semiconductor Products"
+			(at 152.4 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Transistors - Bipolar (BJT) - Single"
+			(at 152.4 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 152.4 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723"
+			(at 152.4 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Diodes Incorporated"
+			(at 152.4 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 152.4 69.85 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 147.32 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 147.32 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C94515"
+			(at 147.32 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0475"
+			(at 147.32 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 147.32 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 147.32 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "64fac78c-cce5-40b3-91ab-45e5ad4a1ef6")
+		)
+		(pin "2"
+			(uuid "177b7014-a0d1-4f01-988f-182af75cc265")
+		)
+		(pin "3"
+			(uuid "4d4a40d0-a159-41fa-934e-11da34ff9f94")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "Q203")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MMBT2222A-7-F")
+		(at 116.84 100.33 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062d18d24")
+		(property "Reference" "Q202"
+			(at 121.6152 98.9838 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MMBT2222A-7-F"
+			(at 121.6152 101.6762 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 121.92 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 121.92 92.71 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3"
+			(at 121.92 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "MMBT2222A-FDICT-ND"
+			(at 121.92 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "MMBT2222A-7-F"
+			(at 121.92 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Discrete Semiconductor Products"
+			(at 121.92 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Transistors - Bipolar (BJT) - Single"
+			(at 121.92 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 121.92 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723"
+			(at 121.92 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Diodes Incorporated"
+			(at 121.92 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 121.92 69.85 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 116.84 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 116.84 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C94515"
+			(at 116.84 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0475"
+			(at 116.84 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 116.84 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 116.84 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "223b744e-7ffc-42d1-861e-cade5678b4c7")
+		)
+		(pin "2"
+			(uuid "7e4ffb52-3e79-48d7-9b12-2b2809f8e523")
+		)
+		(pin "3"
+			(uuid "311f4bac-e9c3-48bd-b0eb-7bfe8653c42e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "Q202")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 88.9 106.68 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0ffc1d1e-e3da-4cd0-adc4-47c42f98eb92")
+		(property "Reference" "#PWR0601"
+			(at 88.9 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 88.9 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 88.9 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 88.9 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 88.9 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "12420f87-26ee-40d3-84ba-682679740451")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "#PWR0601")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff")
+		(at 210.82 124.46 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "420e9d6e-e67c-486c-8424-10e52e74b3ba")
+		(property "Reference" "MF605"
+			(at 215.9 123.1899 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 215.9 125.7299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 210.82 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 210.82 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "NA"
+			(at 210.82 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 210.82 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 210.82 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 210.82 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "NA"
+			(at 210.82 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 210.82 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 210.82 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 210.82 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 210.82 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "MF605")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 119.38 106.68 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7699fe31-5943-4828-94f7-d332448976eb")
+		(property "Reference" "#PWR0602"
+			(at 119.38 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 119.38 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 119.38 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "464c3ebc-d193-40aa-8505-5451c69914fa")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "#PWR0602")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff")
+		(at 180.34 130.81 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7e8dabd8-9dd3-4f9c-89bb-fae59fdcc0f5")
+		(property "Reference" "MF604"
+			(at 185.42 129.5399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 185.42 132.0799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 180.34 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 180.34 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "NA"
+			(at 180.34 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 180.34 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 180.34 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 180.34 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "NA"
+			(at 180.34 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 180.34 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 180.34 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 180.34 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 180.34 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "MF604")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 210.82 106.68 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "880c642d-413e-4fb9-8a4e-54371bdd23c5")
+		(property "Reference" "#PWR0605"
+			(at 210.82 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 210.82 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 210.82 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 210.82 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 210.82 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a687118c-ce21-4571-8b3c-10706a24c95f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "#PWR0605")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff")
+		(at 151.13 123.19 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a2b6516e-9ff6-4381-a43b-e1824330249d")
+		(property "Reference" "MF603"
+			(at 156.21 121.9199 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 156.21 124.4599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 151.13 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 151.13 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "NA"
+			(at 151.13 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 151.13 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 151.13 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 151.13 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "NA"
+			(at 151.13 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 151.13 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 151.13 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 151.13 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 151.13 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "MF603")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 149.86 106.68 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3b3f40b-43f5-47bc-b413-f615b5e0794e")
+		(property "Reference" "#PWR0603"
+			(at 149.86 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 149.86 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 149.86 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 149.86 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 149.86 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f26ad494-43fe-4876-827a-3be254de033d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "#PWR0603")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 180.34 106.68 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b960831b-8cdf-4f6c-9c54-d22eb82ff290")
+		(property "Reference" "#PWR0604"
+			(at 180.34 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 180.34 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 180.34 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "17fdb06b-b10b-4d8c-a25e-e6138546076f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "#PWR0604")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff")
+		(at 119.38 129.54 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "da8e7b02-3ac8-446f-b0c5-b1d9f9707be2")
+		(property "Reference" "MF602"
+			(at 124.46 128.2699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 124.46 130.8099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 119.38 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 119.38 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "NA"
+			(at 119.38 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 119.38 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 119.38 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 119.38 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "NA"
+			(at 119.38 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 119.38 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 119.38 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 119.38 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 119.38 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "MF602")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff")
+		(at 88.9 120.65 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ea964b5b-02f6-40ab-8892-c36a3db6b068")
+		(property "Reference" "MF601"
+			(at 93.98 119.3799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 93.98 121.9199 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 88.9 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 88.9 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "NA"
+			(at 88.9 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 88.9 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 88.9 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 88.9 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "NA"
+			(at 88.9 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 88.9 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 88.9 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 88.9 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 88.9 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
+					(reference "MF601")
+					(unit 1)
+				)
+			)
+		)
+	)
 )

--- a/PWA_REV2/Enclosure.kicad_sch
+++ b/PWA_REV2/Enclosure.kicad_sch
@@ -1,290 +1,670 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid afb1369f-27c0-47eb-8ca6-f518840d07d4)
-
-  (paper "A4")
-
-  (title_block
-    (title "KRAKE_PCB")
-    (date "2025-07-18")
-    (rev "2.0")
-    (company "PublicInvention")
-    (comment 1 "GNU Affero General Public License v3.0")
-    (comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
-    (comment 3 "https://github.com/PubInv/krake")
-    (comment 4 "Inherited from the GPAD")
-  )
-
-  (lib_symbols
-    (symbol "GPAD_SCH_LIB:ENCLOSURE_GPAD_VER1" (in_bom yes) (on_board no)
-      (property "Reference" "MF102" (at -3.81 11.43 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "ENCLOSURE_GPAD_VER1" (at -10.16 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "PublicInvention" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "ENCLOSURE_GPAD_VER1" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "1000000" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "GPAD Enclosure" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "ENCLOSURE_GPAD_VER1" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "ENCLOSURE_GPAD_VER1_0_1"
-        (rectangle (start -15.24 10.16) (end 15.24 -12.7)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center -11.43 -8.89) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center -11.43 6.35) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 0)
-            (xy 1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 -1.27)
-            (xy 0 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 15.24 10.16)
-            (xy 16.51 12.7)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -15.24 10.16)
-            (xy -12.7 12.7)
-            (xy 16.51 12.7)
-            (xy 16.51 -10.16)
-            (xy 15.24 -12.7)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 11.43 -8.89) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 11.43 6.35) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:PCB_GPAD_VER1" (in_bom yes) (on_board no)
-      (property "Reference" "MF" (at 0 0 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "PCB_GPAD_VER1" (at 0 0 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "PublicInvention" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "PCB_GPAD_V1" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "1000000" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "GPAD PCB" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Raw PCB for GPAD" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "PCB_GPAD_VER1_0_0"
-        (text "PCB RAW" (at 0 5.08 0)
-          (effects (font (size 1.27 1.27)))
-        )
-      )
-      (symbol "PCB_GPAD_VER1_0_1"
-        (rectangle (start -15.24 10.16) (end 15.24 -12.7)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center -11.43 -8.89) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center -11.43 6.35) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 0)
-            (xy 1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 -1.27)
-            (xy 0 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 11.43 -8.89) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 11.43 6.35) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-  )
-
-
-  (symbol (lib_id "GPAD_SCH_LIB:ENCLOSURE_GPAD_VER1") (at 118.11 65.405 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no)
-    (uuid 59856b1f-2288-4fb2-a056-010bfaa184c2)
-    (property "Reference" "MF102" (at 114.3 53.975 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "ENCLOSURE_KRAKE_VER1" (at 107.95 62.865 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "PublicInvention" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "ENCLOSURE_KRAKE_VER1" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "1000000" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2" "" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2 PN" "" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "NA" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 118.11 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "MF102") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b8d8fd1d-0a30-4b7d-ac57-549b73ec2592"
-          (reference "MF801") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:PCB_GPAD_VER1") (at 160.02 64.135 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no)
-    (uuid 8287a88d-cc38-47ff-b118-f07fefb8f50f)
-    (property "Reference" "MF101" (at 157.48 52.705 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "PCB_KRAKE_VER1" (at 153.67 62.865 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 160.02 64.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "Gerbers2501181555.zip" (at 160.02 64.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "PublicInvention" (at 160.02 64.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "PCB_KRAKE_V1" (at 160.02 64.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "1000000" (at 160.02 64.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 160.02 64.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "PCB for KRAKE Version 1" (at 160.02 64.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "Gerbers2501181555.zip" (at 160.02 64.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 160.02 64.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 160.02 64.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "MF101") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b8d8fd1d-0a30-4b7d-ac57-549b73ec2592"
-          (reference "MF802") (unit 1)
-        )
-      )
-    )
-  )
+(kicad_sch
+	(version 20251012)
+	(generator "eeschema")
+	(generator_version "9.99")
+	(uuid "afb1369f-27c0-47eb-8ca6-f518840d07d4")
+	(paper "A4")
+	(title_block
+		(title "KRAKE_PCB")
+		(date "2025-07-18")
+		(rev "2.0")
+		(company "PublicInvention")
+		(comment 1 "GNU Affero General Public License v3.0")
+		(comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
+		(comment 3 "https://github.com/PubInv/krake")
+		(comment 4 "Inherited from the GPAD")
+	)
+	(lib_symbols
+		(symbol "GPAD_SCH_LIB:ENCLOSURE_GPAD_VER1"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board no)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "MF102"
+				(at -3.81 11.43 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "ENCLOSURE_GPAD_VER1"
+				(at -10.16 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "ENCLOSURE_GPAD_VER1"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "PublicInvention"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "ENCLOSURE_GPAD_VER1"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "1000000"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "GPAD Enclosure"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "ENCLOSURE_GPAD_VER1_0_1"
+				(rectangle
+					(start -15.24 10.16)
+					(end 15.24 -12.7)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -15.24 10.16) (xy -12.7 12.7) (xy 16.51 12.7) (xy 16.51 -10.16) (xy 15.24 -12.7)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -11.43 6.35)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -11.43 -8.89)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 0) (xy 1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -1.27) (xy 0 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 11.43 6.35)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 11.43 -8.89)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 15.24 10.16) (xy 16.51 12.7)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:PCB_GPAD_VER1"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board no)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "MF"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "PCB_GPAD_VER1"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Raw PCB for GPAD"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "PublicInvention"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "PCB_GPAD_V1"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "1000000"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "GPAD PCB"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "PCB_GPAD_VER1_0_0"
+				(text "PCB RAW"
+					(at 0 5.08 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(symbol "PCB_GPAD_VER1_0_1"
+				(rectangle
+					(start -15.24 10.16)
+					(end 15.24 -12.7)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -11.43 6.35)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -11.43 -8.89)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 0) (xy 1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -1.27) (xy 0 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 11.43 6.35)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 11.43 -8.89)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:ENCLOSURE_GPAD_VER1")
+		(at 118.11 65.405 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(uuid "59856b1f-2288-4fb2-a056-010bfaa184c2")
+		(property "Reference" "MF801"
+			(at 114.3 53.975 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "ENCLOSURE_KRAKE_VER1"
+			(at 107.95 62.865 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "NA"
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "PublicInvention"
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "ENCLOSURE_KRAKE_VER1"
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "1000000"
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2" ""
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2 PN" ""
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 118.11 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b8d8fd1d-0a30-4b7d-ac57-549b73ec2592"
+					(reference "MF801")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:PCB_GPAD_VER1")
+		(at 160.02 64.135 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(uuid "8287a88d-cc38-47ff-b118-f07fefb8f50f")
+		(property "Reference" "MF802"
+			(at 157.48 52.705 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "PCB_KRAKE_VER1"
+			(at 153.67 62.865 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 64.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "Gerbers2501181555.zip"
+			(at 160.02 64.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "PCB for KRAKE Version 1"
+			(at 160.02 64.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "PublicInvention"
+			(at 160.02 64.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "PCB_KRAKE_V1"
+			(at 160.02 64.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "1000000"
+			(at 160.02 64.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 160.02 64.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "Gerbers2501181555.zip"
+			(at 160.02 64.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 160.02 64.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 160.02 64.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b8d8fd1d-0a30-4b7d-ac57-549b73ec2592"
+					(reference "MF802")
+					(unit 1)
+				)
+			)
+		)
+	)
 )

--- a/PWA_REV2/LCD And I2C Interface.kicad_sch
+++ b/PWA_REV2/LCD And I2C Interface.kicad_sch
@@ -1,6289 +1,14244 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid d6e66b98-e037-42d7-96c2-757b973a5a2d)
-
-  (paper "A4")
-
-  (title_block
-    (title "KRAKE_PCB")
-    (date "2025-07-18")
-    (rev "2.0")
-    (company "PublicInvention")
-    (comment 1 "GNU Affero General Public License v3.0")
-    (comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
-    (comment 3 "https://github.com/PubInv/krake")
-    (comment 4 "Inherited from the GPAD")
-  )
-
-  (lib_symbols
-    (symbol "Connector:TestPoint" (pin_numbers hide) (pin_names (offset 0.762) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "TP" (at 0 6.858 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "TestPoint" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "test point tp" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "test point" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "Pin* Test*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "TestPoint_0_1"
-        (circle (center 0 3.302) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "TestPoint_1_1"
-        (pin passive line (at 0 0 90) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Connector_Generic:Conn_01x16" (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "J" (at 0 20.32 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "Conn_01x16" (at 0 -22.86 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "connector" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Generic connector, single row, 01x16, script generated (kicad-library-utils/schlib/autogen/connector/)" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "Connector*:*_1x??_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Conn_01x16_1_1"
-        (rectangle (start -1.27 -20.193) (end 0 -20.447)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -17.653) (end 0 -17.907)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -15.113) (end 0 -15.367)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -12.573) (end 0 -12.827)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -10.033) (end 0 -10.287)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -7.493) (end 0 -7.747)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -4.953) (end 0 -5.207)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -2.413) (end 0 -2.667)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 0.127) (end 0 -0.127)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 2.667) (end 0 2.413)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 5.207) (end 0 4.953)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 7.747) (end 0 7.493)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 10.287) (end 0 10.033)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 12.827) (end 0 12.573)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 15.367) (end 0 15.113)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 17.907) (end 0 17.653)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 19.05) (end 1.27 -21.59)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-        (pin passive line (at -5.08 17.78 0) (length 3.81)
-          (name "Pin_1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -5.08 0) (length 3.81)
-          (name "Pin_10" (effects (font (size 1.27 1.27))))
-          (number "10" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -7.62 0) (length 3.81)
-          (name "Pin_11" (effects (font (size 1.27 1.27))))
-          (number "11" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -10.16 0) (length 3.81)
-          (name "Pin_12" (effects (font (size 1.27 1.27))))
-          (number "12" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -12.7 0) (length 3.81)
-          (name "Pin_13" (effects (font (size 1.27 1.27))))
-          (number "13" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -15.24 0) (length 3.81)
-          (name "Pin_14" (effects (font (size 1.27 1.27))))
-          (number "14" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -17.78 0) (length 3.81)
-          (name "Pin_15" (effects (font (size 1.27 1.27))))
-          (number "15" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -20.32 0) (length 3.81)
-          (name "Pin_16" (effects (font (size 1.27 1.27))))
-          (number "16" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 15.24 0) (length 3.81)
-          (name "Pin_2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 12.7 0) (length 3.81)
-          (name "Pin_3" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 10.16 0) (length 3.81)
-          (name "Pin_4" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 7.62 0) (length 3.81)
-          (name "Pin_5" (effects (font (size 1.27 1.27))))
-          (number "5" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 5.08 0) (length 3.81)
-          (name "Pin_6" (effects (font (size 1.27 1.27))))
-          (number "6" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 2.54 0) (length 3.81)
-          (name "Pin_7" (effects (font (size 1.27 1.27))))
-          (number "7" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 0 0) (length 3.81)
-          (name "Pin_8" (effects (font (size 1.27 1.27))))
-          (number "8" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -2.54 0) (length 3.81)
-          (name "Pin_9" (effects (font (size 1.27 1.27))))
-          (number "9" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:C" (pin_numbers hide) (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C" (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Unpolarized capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "C_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_0_1"
-        (polyline
-          (pts
-            (xy -2.032 -0.762)
-            (xy 2.032 -0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.032 0.762)
-            (xy 2.032 0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "C_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:C_Polarized" (pin_numbers hide) (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C_Polarized" (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Polarized capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "CP_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_Polarized_0_1"
-        (rectangle (start -2.286 0.508) (end 2.286 1.016)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.778 2.286)
-            (xy -0.762 2.286)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 2.794)
-            (xy -1.27 1.778)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 2.286 -0.508) (end -2.286 -1.016)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "C_Polarized_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:R" (pin_numbers hide) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "R" (at 2.032 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "R" (at 0 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at -1.778 0 90)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "R res resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "R_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "R_0_1"
-        (rectangle (start -1.016 -2.54) (end 1.016 2.54)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "R_1_1"
-        (pin passive line (at 0 3.81 270) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GND_1" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "GND_1" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"GND\" , ground" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "GND_1_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 -1.27)
-            (xy 1.27 -1.27)
-            (xy 0 -2.54)
-            (xy -1.27 -1.27)
-            (xy 0 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "GND_1_1_1"
-        (pin power_in line (at 0 0 270) (length 0) hide
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:LCD_20x4_Character-GPAD_SCH_LIB" (in_bom yes) (on_board yes)
-      (property "Reference" "U" (at -6.35 19.05 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "LCD_20x4_Character-GPAD_SCH_LIB" (at 5.08 19.05 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "GPAD:LCD_2004A" (at 0 -22.86 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 2.54 -2.54 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "Aliexpress" (at -27.432 -17.526 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "https://www.aliexpress.com/item/3256803213374992.html" (at -2.54 -20.066 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 2" "Amazon" (at -28.448 -23.114 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 2 PN" "https://www.amazon.com/GeeekPi-Interface-Adapter-Backlight-Raspberry/dp/B07QLRD3TM/ref=sr_1_2" (at 20.066 -25.4 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "4.99" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "Display, LCD," (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "NHD*0420H1Z*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "LCD_20x4_Character-GPAD_SCH_LIB_0_1"
-        (rectangle (start -7.62 17.78) (end 7.62 -17.78)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-      )
-      (symbol "LCD_20x4_Character-GPAD_SCH_LIB_1_1"
-        (pin power_in line (at 0 -20.32 90) (length 2.54)
-          (name "VSS" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -10.16 -5.08 0) (length 2.54)
-          (name "DB3" (effects (font (size 1.27 1.27))))
-          (number "10" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -10.16 -7.62 0) (length 2.54)
-          (name "DB4" (effects (font (size 1.27 1.27))))
-          (number "11" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -10.16 -10.16 0) (length 2.54)
-          (name "DB5" (effects (font (size 1.27 1.27))))
-          (number "12" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -10.16 -12.7 0) (length 2.54)
-          (name "DB6" (effects (font (size 1.27 1.27))))
-          (number "13" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -10.16 -15.24 0) (length 2.54)
-          (name "DB7" (effects (font (size 1.27 1.27))))
-          (number "14" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 10.16 -7.62 180) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "15" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 10.16 -5.08 180) (length 2.54)
-          (name "K" (effects (font (size 1.27 1.27))))
-          (number "16" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 10.16 11.43 180) (length 2.54)
-          (name "MH1" (effects (font (size 1.27 1.27))))
-          (number "17" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 10.16 8.89 180) (length 2.54)
-          (name "MH2" (effects (font (size 1.27 1.27))))
-          (number "18" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 10.16 6.35 180) (length 2.54)
-          (name "MH3" (effects (font (size 1.27 1.27))))
-          (number "19" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 0 20.32 270) (length 2.54)
-          (name "VDD" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 10.16 3.81 180) (length 2.54)
-          (name "MH4" (effects (font (size 1.27 1.27))))
-          (number "20" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 2.54 20.32 270) (length 2.54)
-          (name "VO" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -10.16 15.24 0) (length 2.54)
-          (name "RS" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -10.16 12.7 0) (length 2.54)
-          (name "R/W" (effects (font (size 1.27 1.27))))
-          (number "5" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -10.16 10.16 0) (length 2.54)
-          (name "E" (effects (font (size 1.27 1.27))))
-          (number "6" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -10.16 2.54 0) (length 2.54)
-          (name "DB0" (effects (font (size 1.27 1.27))))
-          (number "7" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -10.16 0 0) (length 2.54)
-          (name "DB1" (effects (font (size 1.27 1.27))))
-          (number "8" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -10.16 -2.54 0) (length 2.54)
-          (name "DB2" (effects (font (size 1.27 1.27))))
-          (number "9" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:Nut_4-40_0.1875" (in_bom yes) (on_board no)
-      (property "Reference" "MF409" (at 6.35 1.2701 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "Nut_4-40_0.1875" (at 6.35 -1.2699 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "36-4694-ND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "DigiKey" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "$0.10000" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "AssemblyType" "HAND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN" "4694" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer" "Keystone Electronics" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Description" "#4-40 Hex Nut 0.187\" (4.75mm) 3/16\" Steel" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "Nut_4-40_0.1875" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Nut_4-40_0.1875" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Nut_4-40_0.1875_0_1"
-        (polyline
-          (pts
-            (xy -2.54 3.81)
-            (xy 2.54 3.81)
-            (xy 5.08 0)
-            (xy 2.54 -3.81)
-            (xy -2.54 -3.81)
-            (xy -5.08 0)
-            (xy -2.54 3.81)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 0 0) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:PCF8574AT_3_518" (in_bom yes) (on_board yes)
-      (property "Reference" "U301" (at 2.0194 20.32 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "PCF8574AT_3_518" (at 2.0194 17.78 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "Package_SO:SOIC-16W_7.5x10.3mm_P1.27mm" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811151526_NXP-Semicon-PCF8574AT-3-518_C86832.pdf" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "AssemblyType" "SMT" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "1.87" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "JLCPCB" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "C86832" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN" "PCF8574AT_3_518" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "I2C Expander" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "8 Bit Port/Expander to I2C Bus, DIP/SOIC-16" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "DIP*W7.62mm* SOIC*7.5x10.3mm*P1.27mm*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "PCF8574AT_3_518_0_1"
-        (rectangle (start -10.16 15.24) (end 10.16 -15.24)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-      )
-      (symbol "PCF8574AT_3_518_1_1"
-        (pin input line (at -12.7 2.54 0) (length 2.54)
-          (name "A0" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 12.7 -2.54 180) (length 2.54)
-          (name "P5" (effects (font (size 1.27 1.27))))
-          (number "10" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 12.7 -5.08 180) (length 2.54)
-          (name "P6" (effects (font (size 1.27 1.27))))
-          (number "11" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 12.7 -7.62 180) (length 2.54)
-          (name "P7" (effects (font (size 1.27 1.27))))
-          (number "12" (effects (font (size 1.27 1.27))))
-        )
-        (pin open_collector output_low (at -12.7 -10.16 0) (length 2.54)
-          (name "~{INT}" (effects (font (size 1.27 1.27))))
-          (number "13" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -12.7 10.16 0) (length 2.54)
-          (name "SCL" (effects (font (size 1.27 1.27))))
-          (number "14" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -12.7 7.62 0) (length 2.54)
-          (name "SDA" (effects (font (size 1.27 1.27))))
-          (number "15" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 0 17.78 270) (length 2.54)
-          (name "VDD" (effects (font (size 1.27 1.27))))
-          (number "16" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -12.7 0 0) (length 2.54)
-          (name "A1" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -12.7 -2.54 0) (length 2.54)
-          (name "A2" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 12.7 10.16 180) (length 2.54)
-          (name "P0" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 12.7 7.62 180) (length 2.54)
-          (name "P1" (effects (font (size 1.27 1.27))))
-          (number "5" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 12.7 5.08 180) (length 2.54)
-          (name "P2" (effects (font (size 1.27 1.27))))
-          (number "6" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 12.7 2.54 180) (length 2.54)
-          (name "P3" (effects (font (size 1.27 1.27))))
-          (number "7" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 0 -17.78 90) (length 2.54)
-          (name "VSS" (effects (font (size 1.27 1.27))))
-          (number "8" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 12.7 0 180) (length 2.54)
-          (name "P4" (effects (font (size 1.27 1.27))))
-          (number "9" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:POT_0.375_10K" (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "RV301" (at -1.27 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify right))
-      )
-      (property "Value" "POT 0.375 10K" (at -1.27 0 0)
-        (effects (font (size 1.27 1.27)) (justify right))
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:Potentiometer_Bourns_3386P_Vertical" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://www.bourns.com/docs/Product-Datasheets/3386.pdf" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "C116281" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "JLCPCB" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN" "3386P-1-103LF" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Assembly Type" "" (at 2.54 -1.1429 0)
-        (effects (font (size 1.27 1.27)) (justify right))
-      )
-      (property "Distributor 2" "Digi-Key" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 2 PN" "3386P-103LF-ND" (at 3.81 6.35 0)
-        (effects (font (size 1.27 1.27)) (justify right) hide)
-      )
-      (property "Cost" "0.6963" (at 7.62 1.27 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer" "BOURNS" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "AssemblyType" "SMT" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Description" "±10% ±100ppm/℃ 10kΩ Plugin Variable Resistors/Potentiometers ROHS" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "resistor variable" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Potentiometer" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "Potentiometer*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "POT_0.375_10K_0_0"
-        (text "CCW" (at 3.302 2.794 0)
-          (effects (font (size 1.27 1.27)))
-        )
-        (text "CW" (at 2.794 -3.048 0)
-          (effects (font (size 1.27 1.27)))
-        )
-      )
-      (symbol "POT_0.375_10K_0_1"
-        (polyline
-          (pts
-            (xy 2.54 0)
-            (xy 1.524 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.143 0)
-            (xy 2.286 0.508)
-            (xy 2.286 -0.508)
-            (xy 1.143 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start 1.016 2.54) (end -1.016 -2.54)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "POT_0.375_10K_1_1"
-        (pin passive line (at 0 3.81 270) (length 1.27)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 3.81 0 180) (length 1.27)
-          (name "2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 1.27)
-          (name "3" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:Screw_4-40_0.375_Phillips" (in_bom yes) (on_board no)
-      (property "Reference" "MF407" (at 3.81 1.2701 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "Screw_4-40_0.375_Phillips" (at 3.81 -1.2699 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "90272A108" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "McMaster-Carr" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "0.0182" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "AssemblyType" "HAND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Description" "Zinc-Plated Steel Pan Head Phillips Screw, 4-40 Thread, 3/8\" Long" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN" "90272A108" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer" "McMaster-Carr" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "Screw_4-40_0.375_Phillips" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Screw_4-40_0.375_Phillips" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Screw_4-40_0.375_Phillips_0_1"
-        (polyline
-          (pts
-            (xy -1.27 0)
-            (xy 1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 -1.27)
-            (xy 0 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 0 0) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:Spacer_0.0182x0.125_inch" (in_bom yes) (on_board no)
-      (property "Reference" "MF411" (at 6.35 1.2701 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "Spacer_0.0182x0.125 inch" (at 6.35 -1.2699 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "94639A702" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "McMaster-Carr" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "0.1145" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "AssemblyType" "HAND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Description" "Off-White Nylon Unthreaded Spacer, 0.1875\" OD, 1/8\" Long, for Number 4 Screw Size" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN" "94639A702" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer" "McMaster-Carr" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "Spacer_0.0182x0.125 inch" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Spacer_0.0182x0.125 inch" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Spacer_0.0182x0.125_inch_0_1"
-        (circle (center 0 0) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 0 0) (radius 4.5791)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-    (symbol "Nut_4-40_0.1875" (in_bom yes) (on_board no)
-      (property "Reference" "MF" (at 0 0 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "Nut_4-40_0.1875_3" (at 0 0 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "DigiKey" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "36-4694-ND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "$0.10000" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "Nut_4-40_0.1875" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Nut_4-40_0.1875" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Nut_4-40_0.1875_0_1"
-        (polyline
-          (pts
-            (xy -2.54 3.81)
-            (xy 2.54 3.81)
-            (xy 5.08 0)
-            (xy 2.54 -3.81)
-            (xy -2.54 -3.81)
-            (xy -5.08 0)
-            (xy -2.54 3.81)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 0 0) (radius 2.8398)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-    (symbol "Transistor_FET:BSS138" (pin_names hide) (in_bom yes) (on_board yes)
-      (property "Reference" "Q" (at 5.08 1.905 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "BSS138" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 5.08 -1.905 0)
-        (effects (font (size 1.27 1.27) italic) (justify left) hide)
-      )
-      (property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) (justify left) hide)
-      )
-      (property "ki_keywords" "N-Channel MOSFET" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "50V Vds, 0.22A Id, N-Channel MOSFET, SOT-23" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "SOT?23*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "BSS138_0_1"
-        (polyline
-          (pts
-            (xy 0.254 0)
-            (xy -2.54 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.254 1.905)
-            (xy 0.254 -1.905)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.762 -1.27)
-            (xy 0.762 -2.286)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.762 0.508)
-            (xy 0.762 -0.508)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.762 2.286)
-            (xy 0.762 1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 2.54)
-            (xy 2.54 1.778)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 -2.54)
-            (xy 2.54 0)
-            (xy 0.762 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.762 -1.778)
-            (xy 3.302 -1.778)
-            (xy 3.302 1.778)
-            (xy 0.762 1.778)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.016 0)
-            (xy 2.032 0.381)
-            (xy 2.032 -0.381)
-            (xy 1.016 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (polyline
-          (pts
-            (xy 2.794 0.508)
-            (xy 2.921 0.381)
-            (xy 3.683 0.381)
-            (xy 3.81 0.254)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.302 0.381)
-            (xy 2.921 -0.254)
-            (xy 3.683 -0.254)
-            (xy 3.302 0.381)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 1.651 0) (radius 2.794)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (circle (center 2.54 -1.778) (radius 0.254)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (circle (center 2.54 1.778) (radius 0.254)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "BSS138_1_1"
-        (pin input line (at -5.08 0 0) (length 2.54)
-          (name "G" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 -5.08 90) (length 2.54)
-          (name "S" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 5.08 270) (length 2.54)
-          (name "D" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "power:+5V" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "+5V" (at 0 3.556 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"+5V\"" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "+5V_0_1"
-        (polyline
-          (pts
-            (xy -0.762 1.27)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.54)
-            (xy 0.762 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "+5V_1_1"
-        (pin power_in line (at 0 0 90) (length 0) hide
-          (name "+5V" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "power:PWR_FLAG" (power) (pin_numbers hide) (pin_names (offset 0) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "#FLG" (at 0 1.905 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "PWR_FLAG" (at 0 3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "flag power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Special symbol for telling ERC where power comes from" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "PWR_FLAG_0_0"
-        (pin power_out line (at 0 0 90) (length 0)
-          (name "pwr" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-      (symbol "PWR_FLAG_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 1.27)
-            (xy -1.016 1.905)
-            (xy 0 2.54)
-            (xy 1.016 1.905)
-            (xy 0 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-  )
-
-  (junction (at 173.99 80.01) (diameter 0) (color 0 0 0 0)
-    (uuid 006a337c-25fe-4614-8a1d-ab5651cb5aa1)
-  )
-  (junction (at 116.84 87.63) (diameter 0) (color 0 0 0 0)
-    (uuid 0732a23d-820a-438d-9d4c-055ac14e1e9c)
-  )
-  (junction (at 156.21 52.07) (diameter 0) (color 0 0 0 0)
-    (uuid 0e98f068-49ed-4294-a81d-a5ef36601031)
-  )
-  (junction (at 31.75 53.34) (diameter 0) (color 0 0 0 0)
-    (uuid 1086b71b-19bc-44cf-a77e-4a74c76529a5)
-  )
-  (junction (at 53.34 53.34) (diameter 0) (color 0 0 0 0)
-    (uuid 12ce9d48-b071-47d6-95cb-4e885232f79c)
-  )
-  (junction (at 78.74 74.93) (diameter 0) (color 0 0 0 0)
-    (uuid 1835fb5b-0886-40d3-a050-1ee448fd430f)
-  )
-  (junction (at 173.99 77.47) (diameter 0) (color 0 0 0 0)
-    (uuid 2824dbb9-53e5-4246-af26-fd6a5e5d27e4)
-  )
-  (junction (at 232.41 50.8) (diameter 0) (color 0 0 0 0)
-    (uuid 2d178082-0252-4969-a394-9d05d786b92d)
-  )
-  (junction (at 69.85 77.47) (diameter 0) (color 0 0 0 0)
-    (uuid 30a9a5f4-7c80-42a3-93d0-cd7912057c39)
-  )
-  (junction (at 59.69 74.93) (diameter 0) (color 0 0 0 0)
-    (uuid 3c15097b-077b-4ba7-9315-283872281692)
-  )
-  (junction (at 226.06 64.77) (diameter 0) (color 0 0 0 0)
-    (uuid 3c7f5362-0368-4bdd-a369-f12389d1e29b)
-  )
-  (junction (at 69.85 86.36) (diameter 0) (color 0 0 0 0)
-    (uuid 4313b860-9864-4308-ac9c-f97b93c39600)
-  )
-  (junction (at 139.7 95.25) (diameter 0) (color 0 0 0 0)
-    (uuid 4d27bf88-0810-451f-990a-d6135a10cfb1)
-  )
-  (junction (at 129.54 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 4e0948f6-c0ae-4d51-a397-01598c4e3bbc)
-  )
-  (junction (at 125.73 85.09) (diameter 0) (color 0 0 0 0)
-    (uuid 5d57bccc-55a8-4bde-80fb-98eb73bd9953)
-  )
-  (junction (at 214.63 62.23) (diameter 0) (color 0 0 0 0)
-    (uuid 6334eaa3-5f76-4df2-a559-2994bb9e04be)
-  )
-  (junction (at 97.79 52.07) (diameter 0) (color 0 0 0 0)
-    (uuid 6e0a20b1-9ce4-4818-b1bf-0ebbabf5ce1f)
-  )
-  (junction (at 31.75 86.36) (diameter 0) (color 0 0 0 0)
-    (uuid 750effde-46e9-4b2b-a15a-055079e9bb5f)
-  )
-  (junction (at 185.42 52.07) (diameter 0) (color 0 0 0 0)
-    (uuid 77869278-8f2d-49c4-a8c1-bf38aaef8cb1)
-  )
-  (junction (at 196.85 73.66) (diameter 0) (color 0 0 0 0)
-    (uuid 785e5a8e-10bf-438d-8900-69972c79f93a)
-  )
-  (junction (at 185.42 97.79) (diameter 0) (color 0 0 0 0)
-    (uuid 7a47eb90-b9b3-4224-9661-653239d29f3c)
-  )
-  (junction (at 173.99 82.55) (diameter 0) (color 0 0 0 0)
-    (uuid 7be97bd0-5007-4244-a1eb-f236329ad5f0)
-  )
-  (junction (at 195.58 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 8954dc85-9394-4820-ae69-780a31ccea3a)
-  )
-  (junction (at 88.9 52.07) (diameter 0) (color 0 0 0 0)
-    (uuid 8d70acb0-b9e6-4de2-8101-9b183eab5f5f)
-  )
-  (junction (at 203.2 106.68) (diameter 0) (color 0 0 0 0)
-    (uuid 9575c4cc-f98e-4ca5-bdb6-53004a8a890e)
-  )
-  (junction (at 133.35 82.55) (diameter 0) (color 0 0 0 0)
-    (uuid 9b7f52eb-a782-42e7-befc-f63c946687a8)
-  )
-  (junction (at 107.95 52.07) (diameter 0) (color 0 0 0 0)
-    (uuid 9f6e4daf-b5f6-4893-b66e-04429b24ec1e)
-  )
-  (junction (at 196.85 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 9f777e86-af67-4436-bba2-39b027ffd02c)
-  )
-  (junction (at 40.64 53.34) (diameter 0) (color 0 0 0 0)
-    (uuid a1ade272-fc95-4882-abc4-d0d5bfb4497a)
-  )
-  (junction (at 40.64 74.93) (diameter 0) (color 0 0 0 0)
-    (uuid a3791ff5-7f68-497e-aa5d-17c343c708ce)
-  )
-  (junction (at 55.88 86.36) (diameter 0) (color 0 0 0 0)
-    (uuid a38bddbe-28a0-476c-a7d4-4370b0114814)
-  )
-  (junction (at 195.58 52.07) (diameter 0) (color 0 0 0 0)
-    (uuid acc208bd-ab17-4939-b0c5-5dc39a154b8f)
-  )
-  (junction (at 129.54 74.93) (diameter 0) (color 0 0 0 0)
-    (uuid b14fd83f-ab09-4df7-b413-c4bb7ef0ea11)
-  )
-  (junction (at 198.12 59.69) (diameter 0) (color 0 0 0 0)
-    (uuid bf627c07-4f67-41ce-8d02-4968fcd27a25)
-  )
-  (junction (at 116.84 52.07) (diameter 0) (color 0 0 0 0)
-    (uuid bfe329dd-1e9a-48d3-9d25-ad147d2d60c7)
-  )
-  (junction (at 198.12 62.23) (diameter 0) (color 0 0 0 0)
-    (uuid c2bcf197-174c-49fe-8db3-8818d57448c4)
-  )
-  (junction (at 203.2 85.09) (diameter 0) (color 0 0 0 0)
-    (uuid d3903c92-cb85-44ce-ade0-e813d12492c8)
-  )
-  (junction (at 134.62 77.47) (diameter 0) (color 0 0 0 0)
-    (uuid d6db5469-5a73-4024-b470-f5c9b1faebdb)
-  )
-  (junction (at 125.73 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid d774ef8a-fafe-4294-b14a-ef23c2c8b2bc)
-  )
-  (junction (at 223.52 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid dc915a8c-95c7-4451-8ad1-7174d3e67bfb)
-  )
-  (junction (at 215.9 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid e308b888-6aa8-4d1a-8ded-3949757c3594)
-  )
-  (junction (at 203.2 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid e66c91aa-4498-4a8c-9f6c-07cfc12799ac)
-  )
-  (junction (at 44.45 74.93) (diameter 0) (color 0 0 0 0)
-    (uuid eaf43176-bbef-4c64-858d-0b0f7fc48010)
-  )
-  (junction (at 196.85 71.12) (diameter 0) (color 0 0 0 0)
-    (uuid edb3de21-79b1-4c6b-a399-27e4112a640b)
-  )
-  (junction (at 78.74 52.07) (diameter 0) (color 0 0 0 0)
-    (uuid f8581ce5-d2a3-40c2-afc7-c8b784d3baa4)
-  )
-  (junction (at 167.64 52.07) (diameter 0) (color 0 0 0 0)
-    (uuid fb105db6-9db9-4fdb-92a0-ce2fc25e94cb)
-  )
-
-  (no_connect (at 247.65 81.28) (uuid 0d7bd46c-729b-4dca-915f-addc2468fb80))
-  (no_connect (at 247.65 86.36) (uuid 14021638-de6d-4ff3-9ca2-21674e349441))
-  (no_connect (at 247.65 91.44) (uuid 14560989-699b-4a44-a9ba-b09c1d510c17))
-  (no_connect (at 247.65 68.58) (uuid 35a8ca10-3b67-419f-aab0-172b5788e16e))
-  (no_connect (at 247.65 76.2) (uuid 48c8f9ff-32be-4bd5-b9ea-8d60aaabc2ea))
-  (no_connect (at 247.65 73.66) (uuid 7d493c38-f742-45e0-83af-772d87c01e3c))
-  (no_connect (at 247.65 63.5) (uuid 86b78d04-aa45-43c3-86e9-38bd311c37c8))
-  (no_connect (at 247.65 93.98) (uuid 8fd5cc9b-77a4-44d7-9d4a-abfd0c1fa412))
-  (no_connect (at 247.65 88.9) (uuid 9b019e72-98d9-46ec-a050-43de18351068))
-  (no_connect (at 247.65 99.06) (uuid a76473f2-db8f-4a4c-afc1-7723dbd47b39))
-  (no_connect (at 247.65 101.6) (uuid b59c4135-0aee-4752-8cd1-4b0547267a5c))
-  (no_connect (at 247.65 66.04) (uuid c2ae0133-8913-411f-aea2-d9cd16c7bf13))
-  (no_connect (at 247.65 71.12) (uuid cfae85cf-9d89-4c21-8512-c5f5f3adbc33))
-  (no_connect (at 247.65 78.74) (uuid d372e9be-1ff7-4b47-93c7-58c243980f45))
-  (no_connect (at 247.65 96.52) (uuid e02a9c43-97f6-4478-bfa9-bcf2b9d469c6))
-  (no_connect (at 247.65 83.82) (uuid f8b6ea35-596b-4e8d-b3ce-c0710df9a5c7))
-
-  (wire (pts (xy 175.26 77.47) (xy 173.99 77.47))
-    (stroke (width 0) (type default))
-    (uuid 008bdd3a-b81a-4699-bd1c-f92c6c4d9c52)
-  )
-  (wire (pts (xy 232.41 85.09) (xy 203.2 85.09))
-    (stroke (width 0) (type default))
-    (uuid 073eec33-3077-4a8d-82ca-b534fe2dc484)
-  )
-  (wire (pts (xy 138.43 95.25) (xy 139.7 95.25))
-    (stroke (width 0) (type default))
-    (uuid 080abc10-2483-4c57-9a3e-37b1fb94bf27)
-  )
-  (wire (pts (xy 55.88 86.36) (xy 58.42 86.36))
-    (stroke (width 0) (type default))
-    (uuid 096c8ee4-01c3-4ef6-895e-1e0df1a276f5)
-  )
-  (wire (pts (xy 78.74 67.31) (xy 78.74 74.93))
-    (stroke (width 0) (type default))
-    (uuid 098ea7bc-690b-4a51-8a04-baab32c421b2)
-  )
-  (wire (pts (xy 134.62 77.47) (xy 143.51 77.47))
-    (stroke (width 0) (type default))
-    (uuid 09b2f4ac-e5f0-4069-99b1-5bac1f1e6feb)
-  )
-  (wire (pts (xy 168.91 80.01) (xy 172.72 80.01))
-    (stroke (width 0) (type default))
-    (uuid 09d7b137-59d5-4c8b-846e-acfbbacbefea)
-  )
-  (wire (pts (xy 196.85 73.66) (xy 199.39 73.66))
-    (stroke (width 0) (type default))
-    (uuid 0a1247b8-d9c6-4987-b787-8f52a8525b9e)
-  )
-  (wire (pts (xy 195.58 66.04) (xy 196.85 66.04))
-    (stroke (width 0) (type default))
-    (uuid 0b6b7e0f-4afa-43cc-873e-967e7d723df7)
-  )
-  (wire (pts (xy 97.79 59.69) (xy 97.79 52.07))
-    (stroke (width 0) (type default))
-    (uuid 0bdf910c-bb1b-4e7d-a5d7-5e3047724f16)
-  )
-  (wire (pts (xy 187.96 55.88) (xy 198.12 55.88))
-    (stroke (width 0) (type default))
-    (uuid 0bff4e3c-1738-48d8-b52c-79544a1bd28d)
-  )
-  (wire (pts (xy 31.75 59.69) (xy 31.75 53.34))
-    (stroke (width 0) (type default))
-    (uuid 0e77b8be-e75b-467f-b9a5-909960e0df2b)
-  )
-  (wire (pts (xy 223.52 40.64) (xy 232.41 40.64))
-    (stroke (width 0) (type default))
-    (uuid 0f9c324b-1266-463c-9406-f7243791a44e)
-  )
-  (wire (pts (xy 214.63 62.23) (xy 220.98 62.23))
-    (stroke (width 0) (type default))
-    (uuid 13bc7ced-1f29-4677-86ec-73012264cdea)
-  )
-  (wire (pts (xy 20.32 86.36) (xy 31.75 86.36))
-    (stroke (width 0) (type default))
-    (uuid 161cdd39-58e2-45a2-a66a-8432e8179869)
-  )
-  (wire (pts (xy 185.42 52.07) (xy 185.42 57.15))
-    (stroke (width 0) (type default))
-    (uuid 16f783d4-bed4-4351-b6f9-464552a06198)
-  )
-  (wire (pts (xy 59.69 74.93) (xy 78.74 74.93))
-    (stroke (width 0) (type default))
-    (uuid 18260755-070a-4d95-b482-50d2df2ddb06)
-  )
-  (wire (pts (xy 116.84 91.44) (xy 116.84 87.63))
-    (stroke (width 0) (type default))
-    (uuid 1ad38b58-8e4e-4768-8a3f-6d628e1beddc)
-  )
-  (wire (pts (xy 167.64 49.53) (xy 167.64 52.07))
-    (stroke (width 0) (type default))
-    (uuid 1af19294-66e9-4563-bf51-569cb516a5cd)
-  )
-  (wire (pts (xy 220.98 109.22) (xy 220.98 111.76))
-    (stroke (width 0) (type default))
-    (uuid 1c35f332-cef2-4ceb-ae7d-b0bfe83f33b0)
-  )
-  (wire (pts (xy 175.26 80.01) (xy 173.99 80.01))
-    (stroke (width 0) (type default))
-    (uuid 1d6fffe9-3353-4d21-ae1a-68964d183086)
-  )
-  (wire (pts (xy 198.12 62.23) (xy 198.12 68.58))
-    (stroke (width 0) (type default))
-    (uuid 1d8e5fde-74c4-4113-bc6b-90dde1f29821)
-  )
-  (wire (pts (xy 20.32 74.93) (xy 40.64 74.93))
-    (stroke (width 0) (type default))
-    (uuid 1f669b75-c7c4-4f52-bb97-b54fdce1b183)
-  )
-  (wire (pts (xy 200.66 57.15) (xy 209.55 57.15))
-    (stroke (width 0) (type default))
-    (uuid 2225b221-acbb-457c-8c5b-4dea86ecff40)
-  )
-  (wire (pts (xy 196.85 71.12) (xy 196.85 73.66))
-    (stroke (width 0) (type default))
-    (uuid 230069ab-6bb1-439b-8543-78ce5bf10bd5)
-  )
-  (wire (pts (xy 78.74 59.69) (xy 78.74 52.07))
-    (stroke (width 0) (type default))
-    (uuid 254826f2-0a6f-4c81-9f03-08db99a4a1c6)
-  )
-  (wire (pts (xy 171.45 82.55) (xy 171.45 106.68))
-    (stroke (width 0) (type default))
-    (uuid 25791ba3-9b8c-44ca-b39e-e43fecd63389)
-  )
-  (wire (pts (xy 40.64 53.34) (xy 40.64 59.69))
-    (stroke (width 0) (type default))
-    (uuid 29e827e0-b584-4e69-963c-a5d1ddbf784e)
-  )
-  (wire (pts (xy 88.9 87.63) (xy 88.9 67.31))
-    (stroke (width 0) (type default))
-    (uuid 2b0d5ad9-e0f6-43b2-9b15-be1d10d407d2)
-  )
-  (wire (pts (xy 172.72 67.31) (xy 175.26 67.31))
-    (stroke (width 0) (type default))
-    (uuid 2b86384e-8ea6-48af-bb38-89c180c7e0e0)
-  )
-  (wire (pts (xy 167.64 52.07) (xy 185.42 52.07))
-    (stroke (width 0) (type default))
-    (uuid 2db90e54-6119-4af5-ba68-6dccee291a29)
-  )
-  (wire (pts (xy 209.55 64.77) (xy 209.55 57.15))
-    (stroke (width 0) (type default))
-    (uuid 315afea8-e29d-4f8f-bf76-a90b680ab867)
-  )
-  (wire (pts (xy 195.58 82.55) (xy 220.98 82.55))
-    (stroke (width 0) (type default))
-    (uuid 318435ee-0084-41f1-ba04-b9435ddaa498)
-  )
-  (wire (pts (xy 199.39 73.66) (xy 199.39 76.2))
-    (stroke (width 0) (type default))
-    (uuid 324aa349-16cf-4fc0-85ba-dbbbd9aa8f4d)
-  )
-  (wire (pts (xy 31.75 53.34) (xy 40.64 53.34))
-    (stroke (width 0) (type default))
-    (uuid 32dc1403-8095-4bd2-b193-dcd39e47d072)
-  )
-  (wire (pts (xy 171.45 77.47) (xy 171.45 64.77))
-    (stroke (width 0) (type default))
-    (uuid 3507e91b-2b1f-458c-9f7d-cb091894c360)
-  )
-  (wire (pts (xy 195.58 40.64) (xy 203.2 40.64))
-    (stroke (width 0) (type default))
-    (uuid 3914746d-cfa9-4b65-95f9-e88ad5ba53cc)
-  )
-  (wire (pts (xy 203.2 106.68) (xy 204.47 106.68))
-    (stroke (width 0) (type default))
-    (uuid 3b00d74a-d04b-4258-a61e-a3b0dc92c6a1)
-  )
-  (wire (pts (xy 125.73 99.06) (xy 125.73 101.6))
-    (stroke (width 0) (type default))
-    (uuid 3b378689-a8e3-41f4-a4c2-0cb8a8101e31)
-  )
-  (wire (pts (xy 133.35 91.44) (xy 133.35 82.55))
-    (stroke (width 0) (type default))
-    (uuid 3bdd3739-dfee-4973-a967-77c13d08bd71)
-  )
-  (wire (pts (xy 125.73 85.09) (xy 97.79 85.09))
-    (stroke (width 0) (type default))
-    (uuid 3c4254b0-2121-4dd5-b884-e67bed4a06db)
-  )
-  (wire (pts (xy 31.75 67.31) (xy 31.75 86.36))
-    (stroke (width 0) (type default))
-    (uuid 3d1e5d3a-438b-4d59-bff8-579ed9dbbbc4)
-  )
-  (wire (pts (xy 196.85 66.04) (xy 196.85 68.58))
-    (stroke (width 0) (type default))
-    (uuid 3e4ffcd1-0bb4-4b0a-88e3-e19049a6ba94)
-  )
-  (wire (pts (xy 175.26 82.55) (xy 173.99 82.55))
-    (stroke (width 0) (type default))
-    (uuid 3e8afb99-45b3-4ba6-a2c4-5288c06e86b6)
-  )
-  (wire (pts (xy 116.84 59.69) (xy 116.84 52.07))
-    (stroke (width 0) (type default))
-    (uuid 3f44639a-3d33-4a51-af43-796cfc906faf)
-  )
-  (wire (pts (xy 125.73 91.44) (xy 125.73 85.09))
-    (stroke (width 0) (type default))
-    (uuid 4041712a-5081-4dcb-8900-aa3e4c10db02)
-  )
-  (wire (pts (xy 40.64 74.93) (xy 40.64 67.31))
-    (stroke (width 0) (type default))
-    (uuid 43528e26-4d0c-4965-8d51-bc41f45b107d)
-  )
-  (wire (pts (xy 88.9 52.07) (xy 97.79 52.07))
-    (stroke (width 0) (type default))
-    (uuid 43a1ba09-4cb0-4737-8975-65905cd7d5e5)
-  )
-  (wire (pts (xy 215.9 48.26) (xy 215.9 49.53))
-    (stroke (width 0) (type default))
-    (uuid 43af2c86-314f-43e5-9b0a-63dfd715c409)
-  )
-  (wire (pts (xy 156.21 105.41) (xy 156.21 102.87))
-    (stroke (width 0) (type default))
-    (uuid 440af2a6-ceda-4b9a-a704-d60e314d0ba5)
-  )
-  (wire (pts (xy 143.51 87.63) (xy 116.84 87.63))
-    (stroke (width 0) (type default))
-    (uuid 460c2f51-0bb3-4c5d-911a-4b15d04b6acc)
-  )
-  (wire (pts (xy 69.85 52.07) (xy 78.74 52.07))
-    (stroke (width 0) (type default))
-    (uuid 4695d358-133c-4233-abf2-21be8c981366)
-  )
-  (wire (pts (xy 78.74 74.93) (xy 129.54 74.93))
-    (stroke (width 0) (type default))
-    (uuid 4c00a07c-0e21-4cb3-ad81-2e4093277b6b)
-  )
-  (wire (pts (xy 68.58 86.36) (xy 69.85 86.36))
-    (stroke (width 0) (type default))
-    (uuid 4d386865-9145-4197-a577-3496b0914474)
-  )
-  (wire (pts (xy 125.73 101.6) (xy 129.54 101.6))
-    (stroke (width 0) (type default))
-    (uuid 4e55b9ef-ab30-4a8f-964e-4a0b0811040c)
-  )
-  (wire (pts (xy 107.95 52.07) (xy 116.84 52.07))
-    (stroke (width 0) (type default))
-    (uuid 4f0416b7-77df-4af5-98a8-1595cedcbb1d)
-  )
-  (wire (pts (xy 44.45 74.93) (xy 44.45 82.55))
-    (stroke (width 0) (type default))
-    (uuid 5021ef44-61d8-4d36-b1ee-2d0b09d5a4a8)
-  )
-  (wire (pts (xy 44.45 82.55) (xy 46.99 82.55))
-    (stroke (width 0) (type default))
-    (uuid 50f53b89-0c46-4df8-93dc-c645abf17785)
-  )
-  (wire (pts (xy 59.69 82.55) (xy 59.69 74.93))
-    (stroke (width 0) (type default))
-    (uuid 53dc84ec-55af-4fa3-9b77-8d8a07c73e62)
-  )
-  (wire (pts (xy 44.45 74.93) (xy 48.26 74.93))
-    (stroke (width 0) (type default))
-    (uuid 55089a63-b7a3-47f6-a7ab-c925f5710969)
-  )
-  (wire (pts (xy 66.04 93.98) (xy 69.85 93.98))
-    (stroke (width 0) (type default))
-    (uuid 56de1817-59ec-4395-9a00-7cdb8ac294f7)
-  )
-  (wire (pts (xy 196.85 68.58) (xy 196.85 71.12))
-    (stroke (width 0) (type default))
-    (uuid 58176eee-d9fb-4488-b2a3-6012ddb01b11)
-  )
-  (wire (pts (xy 226.06 55.88) (xy 226.06 50.8))
-    (stroke (width 0) (type default))
-    (uuid 5a6a7136-60be-45ad-9edc-c11f1a7b7fa1)
-  )
-  (wire (pts (xy 143.51 82.55) (xy 133.35 82.55))
-    (stroke (width 0) (type default))
-    (uuid 5aefe056-768b-4f65-887a-d44267a180a8)
-  )
-  (wire (pts (xy 69.85 77.47) (xy 69.85 67.31))
-    (stroke (width 0) (type default))
-    (uuid 5cca0a25-ccf8-48db-8126-cb37838c24c7)
-  )
-  (wire (pts (xy 226.06 64.77) (xy 226.06 63.5))
-    (stroke (width 0) (type default))
-    (uuid 5d3300be-2cf1-471c-bc9e-13414d01ff0f)
-  )
-  (wire (pts (xy 168.91 77.47) (xy 171.45 77.47))
-    (stroke (width 0) (type default))
-    (uuid 5d46e26b-7b2f-450e-825a-dd334182a711)
-  )
-  (wire (pts (xy 173.99 77.47) (xy 173.99 74.93))
-    (stroke (width 0) (type default))
-    (uuid 5ed7ba09-3d98-48bc-a81c-5b132f4a5eda)
-  )
-  (wire (pts (xy 220.98 82.55) (xy 220.98 99.06))
-    (stroke (width 0) (type default))
-    (uuid 5f751036-c3b9-40e1-9c80-551fc89ab237)
-  )
-  (wire (pts (xy 203.2 106.68) (xy 203.2 104.14))
-    (stroke (width 0) (type default))
-    (uuid 6004ca5c-8b01-4214-b4d1-6621fb4f4776)
-  )
-  (wire (pts (xy 168.91 90.17) (xy 175.26 90.17))
-    (stroke (width 0) (type default))
-    (uuid 605a9bed-2a00-45b1-a309-fb956113b4b5)
-  )
-  (wire (pts (xy 116.84 101.6) (xy 125.73 101.6))
-    (stroke (width 0) (type default))
-    (uuid 65ba4950-c779-4fe2-8a7b-e09d86aac682)
-  )
-  (wire (pts (xy 129.54 74.93) (xy 143.51 74.93))
-    (stroke (width 0) (type default))
-    (uuid 683730a6-e936-4ec0-9cb8-3c223e9cceb1)
-  )
-  (wire (pts (xy 195.58 68.58) (xy 196.85 68.58))
-    (stroke (width 0) (type default))
-    (uuid 685cf876-58f8-4085-a39b-1f62a7a77e82)
-  )
-  (wire (pts (xy 133.35 82.55) (xy 107.95 82.55))
-    (stroke (width 0) (type default))
-    (uuid 6c4aabb1-ab02-4555-9600-91ed64a6f5cf)
-  )
-  (wire (pts (xy 116.84 87.63) (xy 88.9 87.63))
-    (stroke (width 0) (type default))
-    (uuid 6df45332-a220-4834-9469-e802c05ecfe4)
-  )
-  (wire (pts (xy 173.99 80.01) (xy 173.99 77.47))
-    (stroke (width 0) (type default))
-    (uuid 6e73c6a1-7fc7-4bfd-bf78-58ff52671ed6)
-  )
-  (wire (pts (xy 173.99 82.55) (xy 173.99 97.79))
-    (stroke (width 0) (type default))
-    (uuid 740ee9f0-5549-415c-8eb3-dd81bc4824a3)
-  )
-  (wire (pts (xy 226.06 77.47) (xy 226.06 76.2))
-    (stroke (width 0) (type default))
-    (uuid 79ff1507-d922-4014-a0d4-e3962d5f0e74)
-  )
-  (wire (pts (xy 168.91 92.71) (xy 175.26 92.71))
-    (stroke (width 0) (type default))
-    (uuid 7aeaa9bf-2c98-4708-af8b-cd249810a187)
-  )
-  (wire (pts (xy 63.5 78.74) (xy 63.5 53.34))
-    (stroke (width 0) (type default))
-    (uuid 7af25b63-c68e-4dae-bb93-ddc37fb635c0)
-  )
-  (wire (pts (xy 69.85 86.36) (xy 69.85 77.47))
-    (stroke (width 0) (type default))
-    (uuid 7f9cb05d-f67d-421a-ac68-38189759b0be)
-  )
-  (wire (pts (xy 78.74 52.07) (xy 88.9 52.07))
-    (stroke (width 0) (type default))
-    (uuid 811895b1-b12e-4630-bb95-596ea3759896)
-  )
-  (wire (pts (xy 226.06 50.8) (xy 232.41 50.8))
-    (stroke (width 0) (type default))
-    (uuid 82d4de34-23d5-4a46-83b7-16eb611fc91c)
-  )
-  (wire (pts (xy 170.18 62.23) (xy 170.18 74.93))
-    (stroke (width 0) (type default))
-    (uuid 8953df68-99db-4abe-b946-aab894d8142c)
-  )
-  (wire (pts (xy 180.34 40.64) (xy 185.42 40.64))
-    (stroke (width 0) (type default))
-    (uuid 8959acee-068d-42dd-af9f-d19c745f6292)
-  )
-  (wire (pts (xy 198.12 62.23) (xy 214.63 62.23))
-    (stroke (width 0) (type default))
-    (uuid 89d919dc-f6cb-4d67-a62f-a5472bd47e2f)
-  )
-  (wire (pts (xy 232.41 40.64) (xy 232.41 50.8))
-    (stroke (width 0) (type default))
-    (uuid 8ad4ab84-c2a1-41ff-9d2f-a728c2569264)
-  )
-  (wire (pts (xy 63.5 53.34) (xy 53.34 53.34))
-    (stroke (width 0) (type default))
-    (uuid 8d611956-cfd7-4305-90c5-d5d34f615971)
-  )
-  (wire (pts (xy 215.9 40.64) (xy 223.52 40.64))
-    (stroke (width 0) (type default))
-    (uuid 8de77463-b6d0-42f1-8c7a-14a3b3de1051)
-  )
-  (wire (pts (xy 212.09 106.68) (xy 213.36 106.68))
-    (stroke (width 0) (type default))
-    (uuid 8e0d7597-215d-4b52-ac25-083fb802c72b)
-  )
-  (wire (pts (xy 55.88 93.98) (xy 55.88 86.36))
-    (stroke (width 0) (type default))
-    (uuid 95e41dff-c38f-42cc-9e41-04c0ef0ab7b4)
-  )
-  (wire (pts (xy 107.95 82.55) (xy 107.95 67.31))
-    (stroke (width 0) (type default))
-    (uuid 96cc55d7-0ca8-4036-b85a-326d66f02395)
-  )
-  (wire (pts (xy 116.84 52.07) (xy 156.21 52.07))
-    (stroke (width 0) (type default))
-    (uuid 972612bb-2a95-4abe-8f94-55580dae5ed4)
-  )
-  (wire (pts (xy 173.99 74.93) (xy 175.26 74.93))
-    (stroke (width 0) (type default))
-    (uuid 986f604a-cb17-4afc-a9e7-2ebf0e8ab006)
-  )
-  (wire (pts (xy 195.58 40.64) (xy 195.58 52.07))
-    (stroke (width 0) (type default))
-    (uuid 9a16c4f2-7424-4c91-82e4-0afb120fd9f3)
-  )
-  (wire (pts (xy 226.06 68.58) (xy 226.06 64.77))
-    (stroke (width 0) (type default))
-    (uuid 9b03cdcd-9bb5-405b-a191-784b238940ea)
-  )
-  (wire (pts (xy 213.36 104.14) (xy 213.36 106.68))
-    (stroke (width 0) (type default))
-    (uuid 9cc5598b-2e0b-4f7c-9413-464f9875e405)
-  )
-  (wire (pts (xy 54.61 82.55) (xy 59.69 82.55))
-    (stroke (width 0) (type default))
-    (uuid 9d1ead57-d620-4ab5-95c9-65f0346d0ad6)
-  )
-  (wire (pts (xy 53.34 53.34) (xy 53.34 67.31))
-    (stroke (width 0) (type default))
-    (uuid 9dff7048-bb7a-4753-8423-50507c298e77)
-  )
-  (wire (pts (xy 175.26 62.23) (xy 170.18 62.23))
-    (stroke (width 0) (type default))
-    (uuid 9e6df786-506b-4de8-9a59-344340b9d7ae)
-  )
-  (wire (pts (xy 168.91 82.55) (xy 171.45 82.55))
-    (stroke (width 0) (type default))
-    (uuid ab4ed50b-42cd-4983-818a-257e3b33706b)
-  )
-  (wire (pts (xy 168.91 85.09) (xy 175.26 85.09))
-    (stroke (width 0) (type default))
-    (uuid ae989c2b-4a84-4885-b890-f85cd7dbf401)
-  )
-  (wire (pts (xy 187.96 57.15) (xy 187.96 55.88))
-    (stroke (width 0) (type default))
-    (uuid b4401739-8c86-4c0d-9669-62ef4755f714)
-  )
-  (wire (pts (xy 138.43 95.25) (xy 138.43 80.01))
-    (stroke (width 0) (type default))
-    (uuid ba445c7a-e6a9-40b7-89dc-efdd56d159d6)
-  )
-  (wire (pts (xy 203.2 85.09) (xy 195.58 85.09))
-    (stroke (width 0) (type default))
-    (uuid ba47b6a3-272e-41d8-9e90-9e9468f06554)
-  )
-  (wire (pts (xy 55.88 86.36) (xy 31.75 86.36))
-    (stroke (width 0) (type default))
-    (uuid ba8e623d-95f0-4c94-a869-1d2cb1968353)
-  )
-  (wire (pts (xy 97.79 85.09) (xy 97.79 67.31))
-    (stroke (width 0) (type default))
-    (uuid bad0e315-c603-4d52-9357-ab64320d7933)
-  )
-  (wire (pts (xy 193.04 40.64) (xy 195.58 40.64))
-    (stroke (width 0) (type default))
-    (uuid badea7f8-6028-40ec-ae9d-7dfd3ed23fee)
-  )
-  (wire (pts (xy 195.58 71.12) (xy 196.85 71.12))
-    (stroke (width 0) (type default))
-    (uuid bb456279-7e27-4cf8-9fad-5c7e7b7415cc)
-  )
-  (wire (pts (xy 138.43 80.01) (xy 116.84 80.01))
-    (stroke (width 0) (type default))
-    (uuid bf36015e-e427-4765-a532-fd9023e4031e)
-  )
-  (wire (pts (xy 69.85 93.98) (xy 69.85 86.36))
-    (stroke (width 0) (type default))
-    (uuid c03cea06-654f-4cb1-8b69-417361deea8b)
-  )
-  (wire (pts (xy 58.42 74.93) (xy 59.69 74.93))
-    (stroke (width 0) (type default))
-    (uuid c0aa1839-876b-4b5f-b9ce-4fe82d436709)
-  )
-  (wire (pts (xy 107.95 59.69) (xy 107.95 52.07))
-    (stroke (width 0) (type default))
-    (uuid c144ca66-599c-48ca-b402-2fffc403a14a)
-  )
-  (wire (pts (xy 58.42 93.98) (xy 55.88 93.98))
-    (stroke (width 0) (type default))
-    (uuid c2ccef5a-4d4d-49c2-8fa3-8b7f1e59c76a)
-  )
-  (wire (pts (xy 129.54 101.6) (xy 133.35 101.6))
-    (stroke (width 0) (type default))
-    (uuid c3e87a41-7065-443c-84fd-ad6763a2eb4c)
-  )
-  (wire (pts (xy 198.12 59.69) (xy 198.12 62.23))
-    (stroke (width 0) (type default))
-    (uuid c6f655ec-70ac-48f1-a834-619d1cefea21)
-  )
-  (wire (pts (xy 173.99 82.55) (xy 173.99 80.01))
-    (stroke (width 0) (type default))
-    (uuid c722c434-85f8-4fc9-98eb-f9e49b60217d)
-  )
-  (wire (pts (xy 223.52 35.56) (xy 223.52 40.64))
-    (stroke (width 0) (type default))
-    (uuid c847124c-4c1c-4056-a097-c57097f52fb9)
-  )
-  (wire (pts (xy 129.54 104.14) (xy 129.54 101.6))
-    (stroke (width 0) (type default))
-    (uuid c96dd83f-70e2-437b-8352-b501ea16d769)
-  )
-  (wire (pts (xy 40.64 74.93) (xy 44.45 74.93))
-    (stroke (width 0) (type default))
-    (uuid c98355fe-019a-4690-b373-94d41f43b684)
-  )
-  (wire (pts (xy 97.79 52.07) (xy 107.95 52.07))
-    (stroke (width 0) (type default))
-    (uuid c9f2caad-3499-4089-8a70-a3e67c33a7f1)
-  )
-  (wire (pts (xy 88.9 59.69) (xy 88.9 52.07))
-    (stroke (width 0) (type default))
-    (uuid cac5c1e8-57fd-4c56-8e0a-7e6e9ae2bade)
-  )
-  (wire (pts (xy 214.63 60.96) (xy 214.63 62.23))
-    (stroke (width 0) (type default))
-    (uuid cb504c8f-e8ae-439b-a690-e434d2862ef2)
-  )
-  (wire (pts (xy 200.66 52.07) (xy 200.66 57.15))
-    (stroke (width 0) (type default))
-    (uuid cb8cc4e3-1f44-4f65-a3f4-522d4025c201)
-  )
-  (wire (pts (xy 195.58 52.07) (xy 200.66 52.07))
-    (stroke (width 0) (type default))
-    (uuid cfb56ac0-b283-411b-beb5-9b6ca9df1b59)
-  )
-  (wire (pts (xy 116.84 67.31) (xy 116.84 80.01))
-    (stroke (width 0) (type default))
-    (uuid d1c2cf19-2577-4a6b-8022-8a1f719a663d)
-  )
-  (wire (pts (xy 156.21 52.07) (xy 167.64 52.07))
-    (stroke (width 0) (type default))
-    (uuid d220b500-e5bf-47da-ba1c-eb9fe5460652)
-  )
-  (wire (pts (xy 69.85 59.69) (xy 69.85 52.07))
-    (stroke (width 0) (type default))
-    (uuid d6bb833b-c0cf-4785-a0f1-205b8d2129eb)
-  )
-  (wire (pts (xy 173.99 97.79) (xy 185.42 97.79))
-    (stroke (width 0) (type default))
-    (uuid dc368b4f-7051-4d0c-8cce-085563fa03d7)
-  )
-  (wire (pts (xy 21.59 53.34) (xy 31.75 53.34))
-    (stroke (width 0) (type default))
-    (uuid dd7f75f1-9ae6-47aa-ba72-02cb187ecccb)
-  )
-  (wire (pts (xy 203.2 49.53) (xy 203.2 48.26))
-    (stroke (width 0) (type default))
-    (uuid dde0360b-08a3-46ea-a7da-35fd0a32cb26)
-  )
-  (wire (pts (xy 168.91 87.63) (xy 175.26 87.63))
-    (stroke (width 0) (type default))
-    (uuid debbbcab-1923-45de-8b3c-f81ca07967d9)
-  )
-  (wire (pts (xy 143.51 85.09) (xy 125.73 85.09))
-    (stroke (width 0) (type default))
-    (uuid df64eb95-b936-461d-8032-502b1f2a6074)
-  )
-  (wire (pts (xy 134.62 67.31) (xy 134.62 77.47))
-    (stroke (width 0) (type default))
-    (uuid dfbf037b-7be1-42b4-b6af-ae313d825faf)
-  )
-  (wire (pts (xy 129.54 71.12) (xy 129.54 74.93))
-    (stroke (width 0) (type default))
-    (uuid e0554f3b-1a48-4c78-bde8-d6951467f7a6)
-  )
-  (wire (pts (xy 209.55 72.39) (xy 209.55 74.93))
-    (stroke (width 0) (type default))
-    (uuid e1281661-8e64-43bc-a95f-dbfe5fdd665b)
-  )
-  (wire (pts (xy 116.84 99.06) (xy 116.84 101.6))
-    (stroke (width 0) (type default))
-    (uuid e3e6815c-d14d-40d2-b5dc-44d7bfe96478)
-  )
-  (wire (pts (xy 203.2 96.52) (xy 203.2 85.09))
-    (stroke (width 0) (type default))
-    (uuid e71442e7-1300-4524-8850-4673965388bf)
-  )
-  (wire (pts (xy 220.98 62.23) (xy 220.98 64.77))
-    (stroke (width 0) (type default))
-    (uuid e7c48bec-d59f-429c-ac22-b0c92dc431fc)
-  )
-  (wire (pts (xy 139.7 95.25) (xy 143.51 95.25))
-    (stroke (width 0) (type default))
-    (uuid e7dcd6d2-1131-42d7-8791-e82bbabb6170)
-  )
-  (wire (pts (xy 133.35 101.6) (xy 133.35 99.06))
-    (stroke (width 0) (type default))
-    (uuid e7fd0444-b47f-4760-ac75-dc2f9da89bf2)
-  )
-  (wire (pts (xy 198.12 55.88) (xy 198.12 59.69))
-    (stroke (width 0) (type default))
-    (uuid e8463605-bd2f-4188-b118-069a4f89bc2e)
-  )
-  (wire (pts (xy 232.41 50.8) (xy 232.41 85.09))
-    (stroke (width 0) (type default))
-    (uuid e8d78172-28d8-44b0-9b8d-4e1ab48eb435)
-  )
-  (wire (pts (xy 170.18 74.93) (xy 168.91 74.93))
-    (stroke (width 0) (type default))
-    (uuid f0075947-43b9-4a1b-8b9c-d38c0dda7412)
-  )
-  (wire (pts (xy 171.45 106.68) (xy 203.2 106.68))
-    (stroke (width 0) (type default))
-    (uuid f089ba46-8363-40fb-bc16-85bb20707181)
-  )
-  (wire (pts (xy 139.7 106.68) (xy 139.7 95.25))
-    (stroke (width 0) (type default))
-    (uuid f36fb2a6-0f48-405c-b0de-5fbe4f2f012b)
-  )
-  (wire (pts (xy 171.45 64.77) (xy 175.26 64.77))
-    (stroke (width 0) (type default))
-    (uuid f398c1c2-4929-4669-8754-04662947e2ad)
-  )
-  (wire (pts (xy 69.85 77.47) (xy 134.62 77.47))
-    (stroke (width 0) (type default))
-    (uuid f4456118-0581-438e-be0f-8958e5ac2419)
-  )
-  (wire (pts (xy 195.58 52.07) (xy 185.42 52.07))
-    (stroke (width 0) (type default))
-    (uuid f4685cc5-7d7f-4464-a820-55998b62794d)
-  )
-  (wire (pts (xy 185.42 100.33) (xy 185.42 97.79))
-    (stroke (width 0) (type default))
-    (uuid f5005ee0-dad0-45a4-b43d-537969f99867)
-  )
-  (wire (pts (xy 156.21 67.31) (xy 156.21 52.07))
-    (stroke (width 0) (type default))
-    (uuid f577ac61-5f6c-4e31-8013-7aac1acd7feb)
-  )
-  (wire (pts (xy 195.58 73.66) (xy 196.85 73.66))
-    (stroke (width 0) (type default))
-    (uuid f626a8f6-a6b5-4bf1-9cf0-fdf755d8fe7b)
-  )
-  (wire (pts (xy 203.2 40.64) (xy 215.9 40.64))
-    (stroke (width 0) (type default))
-    (uuid f646cf5f-9c0a-4a65-82ab-d45cfbb6b31f)
-  )
-  (wire (pts (xy 198.12 68.58) (xy 205.74 68.58))
-    (stroke (width 0) (type default))
-    (uuid fa364e93-70ae-4bea-8ce2-c984e9cbe28f)
-  )
-  (wire (pts (xy 172.72 80.01) (xy 172.72 67.31))
-    (stroke (width 0) (type default))
-    (uuid fd7cc602-0557-4028-a36e-ad5d8693650f)
-  )
-  (wire (pts (xy 220.98 64.77) (xy 226.06 64.77))
-    (stroke (width 0) (type default))
-    (uuid fea9a6db-58f2-4032-b2bb-d8b108e36602)
-  )
-  (wire (pts (xy 40.64 53.34) (xy 53.34 53.34))
-    (stroke (width 0) (type default))
-    (uuid ffb5c72d-3de5-4793-a369-f2913723dc38)
-  )
-
-  (image (at 124.46 137.16) (scale 1.35089)
-    (uuid c55b7e6d-ffe3-4f11-805c-2b986f9696bf)
-    (data
-      iVBORw0KGgoAAAANSUhEUgAAA20AAAGWCAIAAABkWvxuAAAAA3NCSVQICAjb4U/gAAAACXBIWXMA
-      ABXgAAAV4AGNVCw4AAAgAElEQVR4nOyddVwVWRvHfzfo7gZBUECwAzsQu3vtrnXNNde11jVX19i1
-      27UTu1CRUEwURARJ6a57udx8/ziX8Xq5ICLW6/l+7h8zZ86ceebOnJlnnvM8z2HJZDJQKBQKhUKh
-      UCgfCftrC0ChUCgUCoVC+S6heiSFQqFQKBQKpSpQPZJCoVAoFAqFUhWoHkmhUCgUCoVCqQpUj6RQ
-      KBQKhUKhVAWqR1IoFAqFQqFQqgLVIykUCoVCoVAoVYHqkRQKhUKhUCiUqkD1SAqFQqFQKBRKVaB6
-      JIVCoVAoFAqlKlA9kkKhUCgUCoVSFageSaFQKBQKhUKpClSPpFAoFAqFQqFUBapHUigUCoVCoVCq
-      AtUjKRQKhUKhUChVgfu1BaBQlGB9bQE+H7KvLQCFQqFQKNUJtUdSKBQKhUKhUKpCVeyRxSLxwkv+
-      FVRwNjWa1rphBRWOPo2YeuomgCMjenR3r6myzrDDly5HxADIWz2jCkICSMorfJOVq1ToaWVmoqNV
-      tQY/Bf+Yt+deRCmWaKpxbQz0vBysmthbKVWWymQXwt+cD4t+lZ5dIpaY6Wq1qWk33quulb4uU+ef
-      gKdlz47Qxc2pi6sjWc4s4l+PjEvMK9TkcupZm7d3sWez3hn8wlOzsnh8pd1bO9lx2KwsXnF4aqbK
-      9uvbWBhqaSiWpOQX3XgdD8BYW7OXh7NS/cwi/p8375NlLTW11T3aqGz2Uxh2GJcjACBhKQw0Vddx
-      WIH8YnhaI+CXaj8+hUKhUCg/IlXRI0vEks33nlRQoW1Nu4r1SKFYmi8oASCSSMurwxOKSJ0qs/N+
-      6Mob95UKH88e+VX0yGdJ6eX9aU3trY6M6OFsakRWk/OLBuw//yAhRbHOraiEdbcfHhrWva+nCyk5
-      /fy1f8xblQ0aamkSPXLPgxe/nLklEIuZTe6WJr7j+jHHmnL6RmBskuK+uhrqhWtmAgiMTeq775zK
-      9kNmjWj6vu47/dytM8+jANSzNi+rR54MjVQ89wH1ajWys1TZcpXhCZEvAABZ+UPH+cXIF6BQUL1H
-      plAoFArlx6UqeqSOutq5sX3JckYRf9LJ6wDqWJqu7NaaFJp+DUWtLJHpOQAMtTQcjAyYQhcz468n
-      EQD81NCtU21HGWSpBbxjTyPCU7MeJqb23nv2xdyxHDaLJxR13HYiMiMbwJimnjPaNjLW1roSETPz
-      3O2iEuGQgxcezR5Z19pMscGdgzqb62orlrhaGAN4kZI58eQ1mQxG2pqTmtdPzC04+jQiIi172OFL
-      IbNGkJqR6dkAbA31TLTll6yWuVzFVOOwDTTfMzoWCYUSqcxYW7OR7Xta4N03iUSJLI/jzyIBtHO2
-      f/I2rbBEePTpq2rXIykUCoVCoXx5qqJHqnHYfUqtYvE5+WTBVEeLKSTIZAhJTIlIyxZKJDYGuu2d
-      7XU11Mu2llnE94tOKBAI61qbeTlYV3zoHL7AP+ZteiHPSEuzrbOdpZ5OBZXJsO+oJh6b+npX/uw+
-      N03trUY39SDLM9s0qrf+wJus3Ii07Pvxya2cbLcGPCFK5KgmHvt+6kqqTWpRnycUzfG9I5RIVtwI
-      Oj26j2KDnWrXqGFsgDJcjoghxrlNfbxHNqkDIDm/0D/m7cPE1LRCnqWeTr6gJItXDGBrv45K1w5A
-      d/eaih4FIonUYsk/uXxBN/eaHPa7kXGxVDr9rB8ADS6nRCwpK0ZibgExeXZ3dzLU0jgfFn0yNHJ9
-      r3aKw+tlkckQkoiINAglsDFAe2fovqfTgieEXxTSCmFvhA7KsstJK8SdaBSWoL4Nmtq/tylfgLhs
-      ALAxAF+EW69RwxjeteRbc/jwj0F6IYy00NYZlnrKhw6Mxds8SKRwMEbbmtBSUz5ucBwyiqDOgbsl
-      mtqDXc65phXy0gp4AJxNDTW43Hsxb2Oz82wM9TrVrsFlsyVS2b3Yt1EZORZ6Ot3cndQ5HGbHzCL+
-      vZiktMIiA02NejbmnlbvPi1Ij9NS47qYGQXEJkWmZ+trarRztlN0iqBQKBQKpVr4XPHasdl5/fef
-      D03OYEqMtTXPje3bpqadYrVtQc9+OnSRGXjt4OJwdmwfJTMYw/rbD5dcDWQqq3HYi31aLOncojwZ
-      ojNzAdQy/8oGyArQVldr62xH9N34nPxWTrb7Q8LJpt87vXdeY5vVjc7MtTHQq2GsX8nGuWx5EJWT
-      iVzLtDOS7yuVylD6/wCoVQkb7bXI2Fy+AEDPOu/5s+66/zwsNbOLq+Or9OyE3IKyO554FkkWfGrX
-      0NVQPx8WnZRXGBSX3NrJtrxjxWaj/36EJr8rMdbGubFoU3rk4DgMOIDU0qPZG0GjzI28PQizz0NQ
-      OqTf0hEl74b3cScaffcBQF9PXH0FgRgmOshaCQDrb2PJ1Xc7qnGw2AdLOstX9z/ErHPyMXSCiQ52
-      DMSAegAgkWLWeWwLgqK/Rh1LHB8JD2UnWADYERS6/HoQgFXd2+wNeRGTlUfKvWs5rOjSasyxq1GZ
-      OaSkkZ1l0PRhGlwOgLV+Ib9fDVD0CRncwPXI8J5Ev++261RCboG1ga65rjbTAdU47PW92s9o00iF
-      EBQKhUKhVJXPFa894sjl0OQMLpu9/6dulyb0N9TSyOELxp+4plTt5ut4DyvThR29iFZxOzphzNEr
-      Khs89vTVvIt3BWLxsEbuQdOHTW5RXySRLr0WeOjRS5X1k/OLeEIRADaLteRq4LQztw4+ChdKVBjM
-      vi7EHAXAQEsjo4hP9AY7Q72apoaK1Qy1NLYP7LS4U/PhjetUsuX2LnIT3KWIGAAZRfzb0QkAXM1N
-      rA10AbzOyAHAZrGS8gvn+N6Zff72zdfx5bV29MkrAGocdhdXJ6Ywhy/4/UoAgN87tSjPL/H4s1cA
-      LPR06lqZM9E/R59EVCD5iCMITQaXjf0/4dIEGGohh4/xJ+RbM4vQcw9SC8BhY5wXZrRBiRjR70cE
-      +UVh6mm5djinHUY1weO371RDRc6FgcVCp9qobwMAx55i3kUIxBjWCEHTMbkFRBIsvYZDjwDgZRrG
-      H0e+AMMaIX4J4n7H6KbI4WPmOSTlAcDuB9gaAIkUG/sg/Q88+xWN7RCVicmnKjhdAFh0+V5aAa+d
-      szwKyi8qoeWWI3E5ee2c7XXU1QA8eZvmGx4N4Obr+AWX/EUSacdaDgG/DB3T1BPAiWeRJ0JfKTaY
-      kl8Un5M/uUX9mW0bG2hqiCTSmef8/KISPiAHhUKhUCgfw2exRxaWCFvUsHE1N65pakTGcHt7uBx8
-      FB6dmUtGVJmac9o1Wd+rPYsFiVTWfPN/jxJTz4VFv0rPdrMwUWpz9a0HAIy1NfcO6arB5TR1sLoc
-      EfM2r3DFjSAyaKtEdKkhZ8qpG0zhrvvP/aYO1uR+E1kzJVLZkScR1yJjAWhwOS0dbZPzC8kmB1Xj
-      1OXRassRxvQIIH7JZLLQ2M7ywNBu8y/6r/ULOfAwvEBQUiwSN7az3P9TN1KB2COlMlnnHSdJyd/+
-      j2e3a7Khd3ulQxSVCC++fAOgbU07fc13zglLrgbm8AUdXBxaONrkF6sIinqdkfM0KR1AF1dHFgs1
-      jA1czU0iM7LPvIja2r+jotgMhSVoUQOu5qhpitFNAaC3Bw4+QnQm0gphqYcdwcjhA8Dq7pjbAQCW
-      dkbLLXiV/q6RVbfkC1cnook9AMxuhyYbISzzHWFvBL+pcDaVb1p9CwCMtbF3CDS4aOqAyxF4m4cV
-      NzCyCR6/hVRG/ls4GAHAnsHYPRjc0vMIKdXT2jvDXBfmugicrsJWWpam9lYXJ/Q319We43tn491H
-      AGqaGl6ZOKCWmfHBR+Gjj14BEJaaOai+K08omtqyQTa/eFX3Nk4mhraGevsfhgG4F5M0tKE706Cp
-      jtbTX0fbGeoB6Fe3VputRwFsvvfEu5bDh6WhUCgUCqVyfBaNSk9DfX2vdgCEEklQXPLTpPTwtCyy
-      Kf19PbKVky1xk+OwWSMa13mUmArg7ptEJT0ym1cclpoJoIm9FRna47LZnVwd9z54EZOVF5OVp2S9
-      g8KgbS8P5151nLcFPXualB4cl7zJ//ECb6/PcdaVZMWN4E3+j2VARiGfGaNf27OdsbYmk8eHU6Hv
-      oBLJ+UXlbUor4BWLRADSC+VWT4FYTEqg8BfN7dDUzlB/xfWgLF7xxruPBtavreSoevFlDDHu9vJ4
-      54oYnpq1I/gZgLU925YnADOo3aN0NLyrm2NkRnZmEf9WVAJjnlRETwPrewGAUIKgODxNQniafFN6
-      ISz1cDtavjqyiXzBSBu1zN7pkUIJAmMBwNVcrkQCqGsNLTUVeuTMtnA2BQB1DrJ5CEsFgCb2cuWP
-      y0YnV+x9gJgsxGShXum/MscXQXHo44kurjBR8NElRk0AbbZiVFN0c0P7cnw3lVjTsy0JlqpnbU5K
-      fvNpTvwNXM3lfaFQIATQx9OFOLMm5RWeeBbJjFwzl5hgY6BHlEgArZ1szXW1M4r4gXHvxeZTKBQK
-      hfKJfC7LXHohb9m1oKNPIwoEQgBMZEYFaVkcSr33kvIKlTallb4jb0cnGC7cTJYZJSwmW4UeOaF5
-      vZ4ezvE5+Y1sLdU47FZOtq6r9wA4+yL66+qRuXwBcTQEYKyt2crJdnrrRsRKxARN56my7ZXH87lj
-      7I1UOE0eeRKx4JI/gN4eLqu6t0kv4g0+eCE8NavrrtOxiyfpa6ofHNbtz+6tc4sFDWwsAKhz2JNP
-      3QBw9kWUkh559Kl8GFrROXLGOT+JVDaovmvj8oOvmR2D4pLDU7MAvC29uMeeRqjUIwGkF2LZNRx9
-      igIBAHBKrX3k5knJBwB1Diz0VO6NbJ5cX7Q3Kk+udygq7Gml993taBgulC8zo+Ex2ehUG5v7Yv5F
-      CMQ4/Rynn4PNQpuaWNQRPrUBYGpLPE3CoUcoLME/AfgnADrq6FEHf3SFy3tB9uWKwZh7WaVl5MNJ
-      kdPPX6/1C3n8Ng2V61kAbA31Mor4uXyBSCJV49DZBygUCoVSPXwWPTIlv6jp34eS84t01NXW9mw7
-      oF7tLfeeVJxyEoBYKo8bYJeJbmUGQF3MjAbWc1Xaam+kWqGw1NNhbJ+1zY0NNDXyBSXM2PHXYlX3
-      NlNaNgCgxmET1zcGeyN9HXU1nlD0OiOnRCxRUiCOPo2w1NNxNDZ0MNZXDHbW11RXygpOYGyBG3q3
-      r2lq6A6TSS3qrbxxP5tX7Bed0NfThctm1zA2qAH5GHqzUt0xOe89A2cOX3DtVRwATyszJjA8r7iE
-      eFueDI08GRrJVH6eksGatU729zwAockZxAUTwCb/x0rinQ+LLnuOAFLy0fRvJOdDRx1re2JAPWy5
-      h8333lUgp16B1sT8Nx87CyEzPO1ihoH1lLcSrXR6G4xojEsRuBIBv2hkFuHuG/jH4MZkdKwFNQ4O
-      DsXyLjgXhuuRuBcDnhAnnuFWFCIWwLw6AqZXXA9eei0QQHtn+0U+zd0tTGyWbavEqcnPjVNe6DiF
-      QqFQKB/PZ9EjtwU9I4Ote4Z0GdLArZJ7xWbLg1UV0z0SrPR1WSzIZNDX0FjWpWVlWtsZHJqYW8Bm
-      s/7oKs9qKZJKAWipfWXnSC01rkq1D4Aah92xVg3f8GiBWHz6+ethjd65u71IyRx2+BIACz2dpGVT
-      Kk6aQ8jhF5MFI235BC/6GvLj5vIF+YKS7UHPcvkl7pYmo5p4ABCVBiFpqb/3F50KjSQqvqIxks1i
-      ObxvBE3MK5DJoMZhW5fmlyERNgBGNqlDTJ6Esy+iAmKTCgTCSy9j+terhffZFoTkfADYMwRDGqg4
-      LztDvM6ASIKEXLmTohKmOtDkQlAm+OaDWOmj9DbDsi7lVjPSxojGGNEYQgmWXMVaP8hk2B+CjqWn
-      UsMYs9piVltk8TD0MG6+RjYPvmGY0Pzj5CkLTygiMwO5W5rcnDKYw2ZV0nRN8nNZ6ulU5s6hUCgU
-      CqWSfBalihmYtjeUqxp8kapYWeC/Jy871a6hra5WIBDuuv8cIMGzNZSq6WuqN7W3CklIfZKUllpQ
-      RDLhTTx5PSojR09TfWu/jmUTKF59FUfiW4c0cKtjaRqSkMoXigAwCs2K68E5/GJPK7NxXnWr46Sr
-      hwUdmxGxf/W909DWgviJ5vIF445fJRV+82muMjylLI4mhkFxyQDOPH89oXk9gVh8tnRixhrG+jrq
-      an/deZTNK7Yx0B3SwE2Dy7kdnUi2NrAxV2zn2FO5OqjoHKmvqc4E9BAMF27OF5S4W5iGzh0NQCbD
-      8dId/+jaWnHk3UpfNyA2CcCJ0Fdl9cgk+dcE7EtdFfii9yp418KtKADYcg8begNAdOa7ABcAXDba
-      OuN6JOJzcPEletYBAN9wFH5I49LXRFN7hCTgSRJSC2ClDwATTyIqA3qa2NoPZrpIykNGERraQkcd
-      6hyMaoK1fgCgxgGAbB7SCpHLRysnADDVQV9P3Hz9rsInklnEJzkHbAz0iGWR3NVlicvJe5SYSqbc
-      PB8WnVHEB9DO2V5lZQqFQqFQqsZn0SPr25gffAQAE09e7+PpEpqcQWbKBiB9343rzPOowNjkpvZW
-      ocnpxHNuTFNPld5+y7u06rrrlEgi7b7rzLTWDYPjk/c+eAFgUH1XlVm4F3b0uhTxRiKVddx2opWT
-      7d03iQDYLNbMto1JhX0hLxJyC3p7uHxTeqSXg/WyLi2XXQtKK+TVW7/f28VBX1PjVlR8Dl8AYHRT
-      j2mtKppwUpGpLRscfRIhlckmnry+/2FYcn5RYm4BAE8rszY17bhs9sKOXr/63knOL2q88WBNE6Mr
-      r2IAWOjpDGv0Lv49Ob/oXuxbUt7E/iMmoQlJTCHpJOtYmipd0M6ujhw2SyKVXQyPKSoRKmWnr2+D
-      0psHfTwRmiyfOBuQx0pPao5N/kgvxMa7uB8PXQ3cfQPR+wE0i31w8zWkMvTbB5/ayObhYWKlxF7e
-      BV13QSRB912Y1hrB8dj7AAAG1UcNY9x5g47bIJWhvTNmtQOHjfW3AYDNwthmAPBvIJZeA4DJLdC/
-      HjKL5FqmuS56eVT+zysXW0M9Ex2tbF7xraj4KaduqHHYzLeBUs8qEAibbTrc2slOW417MyoeAIfN
-      mtuhaTUIQaFQKBRKKZ/F435Si/rEzvQyLevPm/cDY5MYEyMTI0wY28xTncO++PLN27xCDps1pqnn
-      tgGdVLbZ2dXx5Kje9kb6z5LTxx2/uvfBC211tXkdmh0e3l1l/WYOVmfH9LU11Esr5J1+/jqLV2yl
-      r3t8ZK+WjjYq6387LO3c8uL4/g1tLUQS6bXIuJOhkTl8gaOJwa5BnfcN6Vb5YcnmNax9x/VzMTMC
-      cD8+JTG3gMVCbw+Xq5MGEovm7LZN/ujaWkddLTw1yzc8WiSRNrCxuDllkOKw+/Fnr4h+0t3d6aOG
-      RI+UZojs5u6ktMlQS6OVoy0AgVh8PixaaeukFuhfDwBepuHPmwiMRafa8k1knNpIG7emwNMKAO7H
-      4+ZrtHJEs/ez2bRywolRMNOFWIqrr/A0CeO9YKD5YbE7u+LkKNgb4Vkyxh3H3gfQVse8Djg8HADa
-      O+P8OLiY4c4b9NqD7rtw9w3cLXFhvDxH+u+dsKo7jLWxIxg+2zH0MBLz4FMb/r/AWLviI1cKLpt9
-      aFh3M11tmQw7gkO3BjytbW5C5otX6lkORvrd3Grei3l7LTJOIpVZ6eueGdOnoa1FOQ1TKBQKhVIV
-      WLKK4zw/gZT8ojdZudrqap5WZhw2q6hEBEBTjaPJ5QolEr5QDEBHXY3NYoWnZfJKRLXMjT84MbdU
-      JnuTlZuSX6SvqeFuafLBTJBSmSwyPSejiGeuq1Pb3Pj7CjJILSgiATf2Rvqu5iZVdmyLzc5LyitU
-      53JqmRkbaysrUwKxODw1iy8UORgbOKiyBH9xWABS8vEmC9rq8LQCh42iEgDQVIOmwgWPykRaAWoY
-      w94IPKHcJGmg+S7ORiTByzTwhHCzgLE28gWQycBhQ0+1e+o7pDK8yUJKPvQ14W753kEJiblIKYBY
-      AnsjFVHhEineZCGzCFwOapkpapDV09eEEkl4alZRidDRxNDOUK+oRCiWygCQD4AaK3Yk5BbUszYP
-      nTs6Ob/oTVaukZZmHUvT7+vmp1AoFMp3wWfUIymUKvF/rO58ib6mqEd+gcNRKBQK5UeGZpKjUCgU
-      CoVCoVQFqkdSKBQKhUKhUKrCNzHTNIVCqS68aljXMDZwNqvEZD4UCoVCoXwa1D+S8q1B/SMpFAqF
-      Qvk+oPZIyrcGVbYoFAqFQvk+oP6RFAqFQqFQKJSqQPVICoVCoVAoFEpVqMq4NmvWumqXg0KhUCgU
-      CoXyhZH9Pe9Tdq9KnE1iPu9TDkn5XnBY9m/Csp+/thQUCuX7gD4xKFWA3jZfHXsDnU/ZnY5rUygU
-      CoVCoVCqAtUjKRQKhUKhUChVgeqRFAqFQqFQKJSqQPVICoVCoVAoFEpVoHnIKRQAul9bgC9A0dcW
-      gPIDQnsWhfJ/zpfWIyUSCa+oCICGhoaGpuYXPvq3D5/PE4vEAPQNDCpTv7CgQCaTcbhcHZ1Pirei
-      UComPS2VzWIbm5pyOJyvLQuFQqF86whLSgQCAQBtHR0u9//ZZled57Z2+VJBcbFiibGJiaOzS5sO
-      3oxW9DriZdfWLQDMXLBo1oJF1Xj0/w9mjB9348olAAl5lfrGbe7hWlhQ4NWy1YnL1z6zaD8K2Vn4
-      5y/5sqYW5i/98C6H92LtcgDYshsdOquu09wDhQVwdcfp7+1CXbt4YcncOelpqQB09fQCn780MjZW
-      rFCZjs+QmpJ88vChxyEPMjMyuFxubTf3br37dOjchcWSz6seHxt7cNeO8oRZukaevFYmkz0JCXkR
-      +pRXWGhhbd3Wu6OFpRVTjcfjhT17qrSvlY2tg6OjWCx+/OC+ysZt7e1t7R2UCu/cuJ6VlQmgZZu2
-      1rZ2Sls3rv6zMD+fLE+aMdPSyro8ySlPH+LiWfmyax0MHvHhXaZPwO3rAHA/HHr6qut8gz3L99TJ
-      3+bMBLBl974Onbt8bXGqyOG9e9YuXwJg/8kzTbyaf21xPiPxsbFpKckqN3m1aq2yvDKX+PC+PSsW
-      zgdw4tLV8tr5/6A69cjDe3cXFhSULdfQ1Jy98LfJM2YB0NTUcvPwBGBmbl6Nh/5O2bv9XwAOjo4d
-      u3QjJXYODuT/qSSu7nWKioocnGqS1Su+51NTktXVNUaMG1/t0v4gXD6HfQpqTLfe8Kz/gV2EQhQW
-      AIBIXG6dwgIUFqDoexsBKywomDlxfHExn8vltmrXPiM9XUmJROU6fmnNPcsXzhMJhUxJWOiz08eO
-      tOvos+3AYR1dXQBpKcn7dmwrTx6iR2ZnZY0fOvjpwxCmnMPhzJy/cPq8BWQ19PGjob17KO27eOWq
-      CdOm83m8wT26qmx84fI/FKUF8Co8bOyQgVKpFMCuI8eU9MioyFeb165mVq1tbSdMm16e5JTd/+KK
-      r3zZwBD9h4Cr9oFdinnynlVBmuNvsGcJRULSI0RiUZUbKft2+MIIhSXkLCTi8p9r/xcc3LVD5TNH
-      U1PrdVqmyl0qc4lNTEzJ21xbRwdAakryFd/zALxatqpTt161SP6NUP22Vk1NrZUb/wYgKBaEPw89
-      fexIiUCweunv1rZ2vfoPcHJxuRao2hjwA0I+Vjp168E8KZasXvtRLZy+dlNx9eCuHQ+CAvX09ake
-      WWUunAEAr1YICwWvCL6nPqxH/h/z6mV4cTEfwPBx45ev/auCaQsq7vgATv53aPGcmQAsLK0W/7m6
-      aYsWGWlpa5YtCfK/e/fWzQUzpm3de0Cxweat24yZPEXlsX6bPYMoke06+ng2aHj2+LHkt4kbVq2s
-      26BhO59OAGKiogBwuVwXVzdmL/LsZrFYevrvmbZKSkqEJSUA2nTwVjrQsvlziRKpkgtnTgPQ1tap
-      37hx8D3/86dOUj2yPHg8+F0HAJ+uuHkV+Xm464eO36up7ktQ9u1A+UxoamkpPROIjlj2gfBR9Bk0
-      uM+gwcxqQmwsuaZLVq+leuQHUFNXGzh0OLNav1GjBTN+AXD80IFe/QcIBMWx0dEAzMwtzCwsmFVj
-      U1NLK+vszMz7gQH5ebm13Nw/aEh/8/p1WOgzHq/I3NLSq2VrpRE0kVD45NHDhNgYiURibWPbpHkL
-      Yu0gREa8lEokmppaTi4uAkFxsL9/akqyuaVlO28fNXV1AJUXLC83NyQoIDMjw8DQyKtlKzMLCyU5
-      M9PTH94Pzs3J1jcwbNS0qY2dPSmPCHtBFgoK8iPCXljb2hkaGb1NiCd3sLtn3ZTkpLycHACW1jbG
-      JiakcmFBwduEeAB6+vp2DjXIiWjr6NZwcoqPjeXxeACkEklE2AtDIyN9A8PE+DgA6uoazrVrMyKR
-      Q6upqbu4ulb8J/9opCTh0QMA8O4MAwNcv4xL57DoD7DfT2wgleLhfcRGw8AQrdqpbiozHcEB4BXB
-      3RP1G723SSLB6wgA0NOHsQluXIaGJrw7Q0MTAIQleHgfifFQU0eDRnCurbzv8yeIiwWvEGYWaNoc
-      JmbKx33yEFmZUFeHS23Ua6QsfFkiwl5EvnzJ4/FMTE0bNWvGDBAXFhS8KB0dVlfXiAh7Udu9Tnn+
-      kRV3fB6Pt2rJYgDqGhrHLlyuWasWAEsr6z3HTrRpUDczPf3CmdPTfp1X282dacHG1q5z954qj3Xr
-      2lUADo6O+0+eYbPZrdq2IybGG1cuEz0yPjYGgIurW9mvVj19/fDEFMWSsUMG+l27amVt4+5ZV7H8
-      0rmzD4ICNTQ1SwQClWL4njoJwKt169btOwTf8w9/HhoXE+NYs6bKyj841y+iRAAA037FowfIy8WF
-      Myr0SD4fQf7ITIe1LVq2Ud1UlXtWXi5CgpCZAQNDeLWEmYXyvtXeswBkZ2UF+d8tKixwq+PRoElT
-      Uhj75o2gmA/Axs7ewNCwtP30zIx0ANa2dilJb0mh4tuBlLxNiH/68GFhYYGVtU3zNm20tVV7xr95
-      /VooLKvYCBkAACAASURBVAFQ06UWE4qQlpqSk5UFwMLK2sTUFECJQHA/MCD5bSKHw3F0dmnczKu8
-      Ds7s6+TioqmpRQpTkt7m5eYCcKntSl6dlZfw22H+0uXzly5nVsNCn/Vo1xpAx66qBy6UUHmJSXl6
-      agoAMmBIHkoA0lJSIsJeKP5j3zuf3feTPNYBJCUmAIiNjlb0j2RWh48dz+awjx7YLxbJrcR9Bw/Z
-      tHOPyjazMzOnTxgbePcOU6KpqbVw+R+jJ00mq9cuXlj866zM9HSmgo6OzqxFiyf8/AtZHdDFp7Cg
-      oG6Dhv0G/7R53ercnBxS7uLqev7mHV09vUoKtnPLpg2rVjKvGa6a2vRf582Yv5CsisXilYsXHtq9
-      SyKRkBIWizXgp2GrN21RU1cn7QN4EBjQtXWLv7btGDh0+IqFCxj/yIDbfvN++RnA6EmTl6+Vu+wd
-      PbCPvI9nLVg0c8EiciLEP3L+L1PDQp8B4PF4XVu3GPDTsKVr1vXv7MPn87hc7sNX0SZmZgBioqLI
-      odt36nzg5JlKXscfBMZ/q3V7aOvg+mWkpuBxCJoqfDtkpmPCMDx7LF/V1kbtOsrtHN6LP36TvzgB
-      NPaCwlgueEXo2lpenpKElCQAuHEftd0QcAezJiPz3Z2Lrr2wYTtIGNXzp/hlHBLi3m3lqmHydPy6
-      GCwWJBKsWITDe1B6uwFALVf8sx+131nl3iMq8tXMieNfvnjOlLDZ7AE/DVvx1wYtLe3gAP8/FslH
-      indt3bxr6+awhORKRoApdfxbV6+QXta9T1+iRBK0tXUWLFsRHRlpbmmp9sFhTuasOVwRhLb2Dmw2
-      G4CVjS0pZ2yHcbExAJycnT/YVF5urv+tmyjzzhAIiv/8/TcAA4cO/2+figfR86dPyEda6/Yd2nbo
-      SAovnjnFjK1TFLlwFgAMjVC3AVq3x8WzuHkZAgEUgy2fhGDyKGSkyVetbaGhodxOlXvWzi3YsOrd
-      jlw1TP8VM+bLV6u9Z8ml3bP7l3FjmBdEizZtd/13TE9f/+zxo1v/WgdgzOQpy9asJ1uXL5x38ewZ
-      ABdu+/fq0JYUKr4dBILi+dOnnT95gmnfyNh4w7ad3l1UqDv/bFx/7sRxADsPH+3SsxcpXDDjlzs3
-      rgM4cfmaiWkrf79bsyaNz87KYvaq7eZ+5PzFstYQADs3byKDv1cDgpkvrg1/rjx97AiAoBcvbe0d
-      PkrCbxbyfchisTp0+rDBvLxLDOD8qROMfySA+dOnkTrkWUr+sc90Cl+Yz54/klHm9PQrev38t2/P
-      od27nGo6t2rXnnwPnTtxnGhFSkil0rFDBgbevcNmsyfPmLX+3+0Ojo4CQfHS+b/eunYFwIOgwCmj
-      hmemp5tZWCxf+9df23a4uLryeLyVvy08vPe998GLZ0+XLZirrq7RrqMPeTtGR0YeO7i/koL5nj61
-      asniEoGgz6DBZ6/7DR87XiwSbVz955njR8m+a5cv3b9ju0Qi6dyj16ade9p08JbJZKeO/rd2+VIA
-      YydPJdXsaziOnTzVpbayabBLz97keyXI/y5TyGjPvQYMUqrfrXdf4uavpq4+dvJUEuUweORIAGKx
-      +PL5c6Taw/tBZKHjd9W3vwxkUNvUHK510E6uG8D31Ht1po6WK5FtvfHzbNjXwLNH71UI8sfiOSgR
-      wMgYE6ZhwE948ezdC0yRxw+QkgSvlrCxg6094mMxYSgy01GnLo76YtXfYLNx9QKWzQMAsRgThyEh
-      Dq7uuB6Mp9FYtgZiEQ7twc2rAHDsIA7shESC31fhaTSuBqBuA8TGYNEsFYcGkJOd/VOv7i9fPOeq
-      qf08+9d/9x/y7tJVKpWePHL416mTATg4OjEvgGYtWo6dPFVdo7If0Eod/1HpXdeitbKVacBPwxYu
-      /2PclJ+dXFwq2XiLtm0BPH/6JCsjA8CFM/Ir1LJtO7IQGx0FwMTMbPe/W3+fO3vnlk052dkqm7p8
-      /qxYLAbQsWt3xfIdm/5OSXrbun2Heo0aqdzx4pnTZKFNe++atWqRcYbzp09W8hR+KPJyEXAbAFq1
-      A5uNth0BgM/HzSvv6mRnYewQZKSBw8HgERg7GUIh4mLea6fKPcv3NFYtQYkAfQbh7HUMHwuxCBtX
-      48xx4DP0LIaAO7dru7n/PPvXps1bAAi+5z9n6mQAoyZMIs/2i2fPMFaGh8HBAMwsLOo2aKjy7bB8
-      wXyioi1YtuLMtVuNvbxyc3KmjB5Bhs6U6N1/YOmfJn9liEWikMBAAJZW1k2bt8jNyZkyanh2Vpa1
-      rd3hs75EnX39KmLDqpUfOKvy+SgJv02kUinxV6nfqLFKfVqJ8i6xEpbWNl179SbL5FmqW17g2HfI
-      59UjU1OSV/4mN84xj3iV6Orp7Th05OaDR0fOX2Rc3VXqkXduXA998hjA8HHjFy7/Y9CwEf/uP6Sj
-      o2NlbePvdwvA36tWErPE3mMnR0+aPHDo8GO+l8mg9pb1a5S8nWYuWBQcFnHw9Ll/9x9SedAKBNu2
-      8S8AhkZG67dua9Ss2fJ1f1nb2AIgrve5OTn7d24H4FbHY/vBw30HD9l15JiNnb2ZhcXD+8FSqZSJ
-      PHV1r7N0zbr6jRornamBoSGxc0RHRmakpQEQCYXkWeNRr35ZW8uoiZNqODkB0NTUXLpmXe+BgwCM
-      m/IzsdmcPXmcVHsQFEgWvq9vxC9AbDTCnwNAO2+wWLC1R81aAHD1AhhH84f38fA+ALTvhENnMG8J
-      rgSgz/sq/T8b5AsHT2PxSmzYjgu3oaZKAeOqYf8JnLgM/yfQ0cH+nSBxz2s2o2VbDBuDnv0A4NRR
-      pCQhPRVpqQBgXwOu7jAxw5jJiE5HWAI6dQOA0FITaYvWMDGDuyfOXENMJs6UE8d6cPdOoofN+33p
-      vCXLevTtt/vIcTIuc+nc2TevX7u61xk8YiSp3Llnr6Vr1jHjWRVTtuNnZmSQVcav44Nc8T3fwtOd
-      +ZGwA8L6f7Z7d+laVFjY3NOtiavzXytX6Ojo/DJ3fo++/QCIRaKkxEQAh3bvWvnbwkO7d61astin
-      eZO4mJiyR7lw+hQAbW0dRQU3Jent9k1/A5g+b4HKECLmZWNjZ088RtqX+mW+ehleyRP8cbh8Xt6D
-      2vkAQLtSrzPG/A/gyD7k5QLA/KVYtxVL1+D2Q2Wnjir3rG0bAcDQCOu3olEzLF8HaxsA2LwWQPX3
-      LIYJ06ZfuO0/b8my45eu1mvYCMD1SxfevH5tZmHRd+BgAFkZGcQ0EB8bS1IieHfuymKxyr4dsjMz
-      Txw+CKBD5y5TZs5u7OW1fut2ACUCwY4tm8oeunX7DmQonDE9PHvymM/nAejZrz+bzU5PSx08fGSf
-      QYNXrP+rTQfvMZOnkL4ZEhz4gbMqh4+V8NvkYXCQ/EJU7v1Y3iVWqlbDyWn0RLl+SZ6ljKPC/wHV
-      r0cWFRaS535DF0cv99ohwUEAajg5TZk5u4K9Bg0bwWjrHvXkcQ3F7ycTIQTcvU0WuvSQ2+o96zeI
-      SE5/EPH6j/UbSwSCRw/uA6jl6kYuKgAzCwvvzl0AZKSlvQoPY5py8/CctWARV03tvYPy3ztoeYLl
-      5uRERrwEUK9hI3UNDQBcLrd1B28ACXFxCXFxD4MDSVxqx27diSFTS0s7OCzi8euYC7f92ZXxrAGI
-      LohSk+SThyECQTGAPgOVjZHlYedQgwxqPHv0kAzDMZqoFXmUUkph3mrepaMZ7TsCQHYWAu/KS4L9
-      5Qv9h8gXOBzUbfCuEZFQ7mFZsxbqNZQXutWBymSp7TvK8wSRd+H9ewCgqQmPUifs9j4AIJMh4A4s
-      LGFiCgA3rqBvJxzYiYQ4qCsM/LmXevcN6Iol83D3ZkVRrgACS7vSwGEjSs+FM3DoMLJ81++m6t3K
-      oeKOLygd96l8+kk+n5f8NpH5FZSm1wFQWFCQn5cLQFhSQj6xxBJJMY9HvhLfJiYSE6OLq+u6rf8S
-      5TIrI2PpvDlKh0hLTSFytvH2VlcYQ121ZLFAUOzdpSuxMZTl0YP7pS8b+b3SzseHLJBBMYoipGex
-      WOjgAwBmFqhTFwBu35CHYwMIuidfYHqWgSGcFHxNq9yzcnMQGQEA9RrK+wuXi9YdACAhDglx1d+z
-      GJo0b04SWnE4nH6DfyKF9wMDAIyfJneyIjcMM0zk0011VM3D+8HEcsk46Du5uDg4OgK453erbH2u
-      mlr3Pv0AxL55k5qSDAWFkrxWiIa6edder5at79y4vmPz38V8HoCs0k++j+VjJfw28T0tH9zw6da9
-      4pqECi7xj0P1+0fKZLLkt4ny1rlcJ2eXzj17TfplhlI8VAVwuBW9achrA4DKVG3Z2VnkVq7h9J63
-      O5MZR9FpUpHKpAlVFIw4RAMIuufvYS+XpKSkhCwkxMWmp6WXymmFqtKxa1dtbR0+n3c/MKDv4CHk
-      7mSxWD37D6h8IxOnTSfpBs4ePzZoxEjiwd2xK40BVOa8fKASjx/g9SsAYHKKXTgtH+ZOL3XeKnXJ
-      UyY3ByJhRRUUKc2ZKCczAwBKSlC3hrxEUmoHTYgDVw3bD+HnMchMx9OHePoQS+ejliuGj8XICWCx
-      MHIcwkNx5jh4RTi4Cwd3QVsb3l0w5zc4qor9yEhLB6Cnr89EcUGh45TXU8qj4o7PZAvKz8+rZIO9
-      BwxcueGdGUOjVM+TSqVjBvWLffNGQ1Nz8669rnU89m7benjvnj3b/jEyMZk2Z65jzZphCclJiQkk
-      mKD/T8OehISkpiQH3LnNKypSjLe7eOY0iUBX7A4hwUEXz55hs9mKrvdKMMpiekrq32tWAeDzeKTk
-      wpnT85cuZyld2h+Y9DQ8CAQAPX0c2isvJF8TIiGuXsSgYQDkbpFq6jAtJyNclXtWZqleFHQPHqXW
-      8NJHNRLi4OBYzT1LJTb28qRRJFVhbTf3tt4d/f1uXb3gu3Lj34/u3wegoanZql17lbsz/XHz2jXb
-      /pYbZsldl5qSLBIKywZt9Bow8Mj+vQAeBAT0HTzkQcA9AE7Ozp715R++L18837Bqpf+tm+S7i1g3
-      KsjJUDFVkPBbQywSXT5/FoCNnb2r+zu39+YeboUF8u/YJs1b7D9xWuXuSpf4x6H69UhdPb374ZFk
-      WUdXt9pnv2AsecSOqATz+FYav5aVrrIqZwj8IFyO/K9zrFmTfPYpYmNrR4x/ANRUyVlJtLV1Onbt
-      euHM6YfBgQAe3Q8G0LR5i49Kd9ygSdNGzZo9CQm5dP6sk4s8xIE6RyoREYbYUh+evduVt16/DGEJ
-      1DXevZ/Ke9h+sEIFkHtKUxPjpipvatAYAJq1QPALBAfg1lUE3kVcDKIisWQesrIwZxG4ati4A7MX
-      4dol3PNDSBD4fFw8i8C78AtRDj5lRFXqKcxqJU3mDBV3fMb9NzI8XCkKOzLiZXxMjK29fQ2nmrp6
-      eky5mpq6ypieiLAXsW/eAOjWuw8ZK/j9zzXHDh4Qi8WXzp6ZNmcuAH0DAyYUgMvletZvkJqSLJVK
-      M9LTHRX0yPOnTpIzVXSov3bBl/wPnZo3VTgsJg77iUQHikWiqxfOk8Lrly9ev3xRsVry28TQx48U
-      wzZ/cC6dk/eFgnxsWlNm61m5HgkWUGGvqXLPYj7/HWuiex/lrUQrrd6epRKJuDTasrRnTZg23d/v
-      Fp/Pu3PjxuOQ+wBatWtfnusIY8Vo3qYNM9TGoDI7VdPmLSwsrdLTUkOCg3r07Rf65AmAnqV+k4F3
-      74wa2E8sEtk51Ji7eEnrDt5De/dQHK/7WKog4bfGXb+b+Xl5KGMVLizIZ/xb+OWnKi17iX8Qql+P
-      ZLFYlYzorBqMf1V8bAyxmUul0qsXfI1NTMwtLB0cHUmejjdRkYp7Rb58SRbsqilCytzSksViyWQy
-      XT19lRPzkOw8AOJjY5nCIP+7EonEyNjYzcOTsYDyeBWl0O09cNCFM6fjYmJSkt4+CQkB0GvAwIpl
-      Y0wjDBN+nv4kZFh0ZOTpo/8BsLC0YsboKYQLpZHr/YegjkJur2sX8PA+igrhdx1de8Gq1BcgLhaN
-      mqlox8gEGpooESiHCFQGSytkpkMgwJSZqkfrAKhroF1HuXH0+iVMHgmpFCcOYU7pPWhrj/FTMX4q
-      crIxfTwC7iA3Bzeu4KdRyk3Z2jskxMXxiorSUlOYLxPirQHA1r6yjoyEijt+e59O61YsA+B75tTP
-      c+Yqmv83rvrz+qULAFas2zBq4qQPHojkGQHAJEzR0NRUU1MXi8XkHeDvd+vJw5CC/Lxf5swjOQqY
-      XMGaWu/+1tjo6PDnoQAaNGlCcqAQDI2MFJ04iwoLSLMmpqbkBAP975KonUbNmil+Q0aGh588chjA
-      uVMnqB7JcLG0Z81ZBJ13nwnYsRkZaQi4g+xMmJjB2gax0RCLkPwWNsrTBgGf0LPMLcFiQSaDrh5m
-      lR9MX409SyWMZcHWTn56rdq1d3WvExnx8vihAyQSpeznPfN2YHqoWx2PSk4Fx2aze/UfsPvfrSHB
-      gaFPnxCfKCb+5u81f4pFIg6Hc+rq9cr4OHFK+6yih4lE+i6CvQoSfmsw4wxKOTvnL11BkigBqOC/
-      KnuJVVKBJvqd8v1pze1L84kQlQiA3/WrU0ePGNKz27o/lnHV1Nq09wYQHxt79+YNUuHN69fE2atm
-      rVqVjwmtGF09PRIZExb6jBlqXzDjl8Hdu4wdMjApMaFJ8xZkzutL586STM4ZaWnjhgwa0a/3qAF9
-      id2UvE3fJiRUMJTQtkNH8r7c8+8/AkExl8vt0bd/eZWJjVYikTDpxwide/S0c6gBgIQidezajY67
-      KSKTvdMjf12McVPe/UZOkJcTH69W8nQc+G+ffJSNV4Qbl981xeXCqyUAJCXiVqkb/o0rqPBjQQ5J
-      RSmT4Y78zsWR/RjQBaMGwO8axCK8TcCzR0gtzX7YuQeMTADI5wXJzUFUpNyHDICxCTqXTumiMqMO
-      M53X/h1yA2xxMf/o/r0AuFxu9c7n5u5Zt11HHwAxUVFrlv7OxKiePX6MKJHWNrYDhw+vqIlSyJ0M
-      4N5tP15REYAbVy6RLkZ03zdRrzevXb1/x3aSo4DP54U+fgTAxNRU0ZDvWxrl7fN+pPaM+QuDwyKY
-      H5PGa/XmreOm/IzS0BwAw8aMGzflZ+Y3b8kyUn7F97xEMUPMD0xivDy5gZ0Dps97r2eREBapFJd9
-      AaBlac/aXzqbVFwMnj1511SVe5aunjzNZFjou6RCC2ZgcHeMHYKkxOrvWQznThwnd2ZRYeHRA/sA
-      sFgsJrs1i8UiXpL3bvuREkX1Rent0NirOUkDefv6NVLC5/MG9+g6uEfX2ZMnlne/EaNDbHT0Vd/z
-      ADzq1WeybqUmpwBQU1M3M7cAIJVKS1SGvpfCuKYE3fMHIBAU79yyiclaUGUJvx14PN6tq1cB6Orp
-      ebVspbhpxLjxTDfv1vs9m3bFl1gRbum9khgf/3nO4Kvx/emRXq1at/XuCODCmdOTRgxduXjRzInj
-      AWhoas6cvxDA/KXLydDApBHDlsybs2rJ4oHdOolFIjabzWTqqhZmLfyNxWKJRaLRg/qf/O/QvF9+
-      PnZw/4OgQC0tLVt7Bx1d3Wm/zgOQGB83sGvn9X8sH9yjC7nhfl28hIz6kZQiifFxI/v3mTRiqMqj
-      qKmrd+3VB8CR/fsAtO7gXUGcFxP0PX7okO5tW5HoPABsNpvJnQk6qF2G0MdIfgsAtVxh/b73VVtv
-      uS/XrWvg8dCgCdp0AIBnj+DTHGOHoIWn3P2L4Ze58gTFk4Zj1ED09saEoajMqM6YyTA2AYBFs3Bg
-      J7asw/KFePQA8bFo1hL5eejjgz4+GNAF504g8C5+/xXZmQDkFpFDu+HjhQFd8NtsBN6F72ls3wQA
-      JmbwUXXBh40ZS2KNd2z+e+roERtX/9mrfVsyZDxl1pxqD8NavWkLmVdw979b2zeuP33C2L6dvGdN
-      ngDA0Mho15FjlcxX7ODoSJJTxkZHt21Ub0AXn8kj5LFBoyZOBjBo2AiiL/6xeOGkEUO7t21FUleO
-      //kXxc+nC6dV2x4qRlhSQgayWSxWO28fxU1mFhbE8ywzPf3BD+ZoXx6X5NnG0L6T8qYOpSUXTgPA
-      sDFyz8jd/6JvJwzvi45e7yVSxSf0rFkLwWJBLMLoQTj5H+b9gmMH8SAIWlqwta/+nsVw9YJvq3oe
-      44YM8vGSpwsYOGyE4uyafQYMMre0JMt1GzRkllHm7WBgaEie4ZERL6eNHXXyv0OjB/R7EBjwIDCg
-      QZOm5fmP1W3QkCTxIK+PXgqO9XU86wIQCIrHDx28eunvPdu3ITbR8gagG5dGz2xZt6apq0t9R4dV
-      SxZrKESnVU3Cb4dbV6+QN2Zb746Vd+X84CVmcPPwIMF8506dmDjsJ8UpVb93vj89EsDO/46OGDee
-      q6Z27eKF3f9sKSosrOXqdvT8JTKXpYur65nrNxs1ayYQFB/ctZOkjqvt5n7ozPlPnOZIibbeHbcd
-      OGxta/fyxfO506aeOHxQS0t78oxZTJbyqbPmLFuz3sjYOCz02T8b1se+eWNiarpm89aho8eSCov/
-      WEU+8u7d9nsYHCQuZxpT0vmVRiVUMm7qNLc6HgBevnge+TJcMfvAgGHDibVSU1OLpN+jMJwrzRBZ
-      9m2nb4AmXgBQIsCNSwCw7YDclBIXA79rMDRCt97v7dLEC//uh4kpxGLcvYnw5xgyEpVJFmZhieOX
-      UL8RcrKxdD42rIKwBF164tQV6OrBxAwnLsKrFZISMXMShvXBoT0wMcPC5Zg2BwCmz8O8JTA0wn/7
-      MKwPpo9HShJat8epyzBU9emhpaV98vL1Xv0HcNXULp8/t3nt6qjIVyZmZsvWrJ+zaPFH/H2Vw9rW
-      7lrg/ZETJmpr6yTExfmeOvn0YQiXy+3Rt99l/0DG978y/LP3wKBhI9TU1TPT0x89uC+RSMwtLZnQ
-      bD19/SPnLzZo3ERYUnLt4oXY6GhNTa1f5s5XnDs7LPQZ0Zjtazh+1KxOftevFRUWAqjboCEZNFeE
-      yRXCRH3+4JwvDV7v4KO8qWU7+TQzj0OQkgQDQxz1has7ADx9iIA7aOIldwtmqHLPauuNbQdgbYuX
-      LzB3Gk4chpYWJs/App0Aqr9nMQwaPlJdTf3WtSspyUkcDmfQsBF/bvhbsYKaujozC5T3+yMAZd8O
-      sxctnrVgkY6OzqVzZ+dOmxoSHGRhabVh+86KZ8ElDpECQTGLxerZ791Y1uI/V5OXBQnWLizIJ85O
-      vKIilSHbzVq0HDlhIvkSS09L1dXX+2P9xu7vD45VTcJvBN8qfVh+8BIz6Ojq/r5yNVdNTSQUXr98
-      8eWLF9Ug9LcBqwrBWYn5yu53VUYikZCRKXUNdca/WCwS8fl8AJqamuplJzQopbiYHx0ZyefzrW1s
-      7Gs4lq2QmZ6elJggkUitbW2Uvg8KCwpkMhmHw2GCN2UyGXGk5apxtbV1Ki+YVCqNj43NSEvV1dNz
-      qe2qUcavTSKRxERH5WRlGRobO9eqrRQYLhAUR7x4oa6h4Vy7diWT81WMVCqNfBkuKC52cqmlaLlM
-      SXrb3MMNgE/X7nuOnSi/gXc4LPs3YdnPny7S94Duh6u8T3oa3sZDzwC1XCESgqS10dZ+N84lFiEq
-      EnwenGvD0AiFBZDJwOFApxKHSk1BUiI4bNSsBQND5a15uUiMB58Hcws4OEHpO18iQUIssrPB5cDR
-      WfE9V+74H4/Hi4l6zefzzczMHZ2dPzbC5mMRi0SvXoZnZ2Xp6Oq61fFQjK35KORi83jmFpYOTk5l
-      DR4pSW/fJiZqaWnVcnOrls5FqRhVT4yP7lmxb5CZATt7WNuCzwdxbdXTfxdnU+WeJZUiPhYZadDV
-      g0ttuRarSHX1LJFQSJLWaWtrs9jsqFcRfB7f0dlZMTECw9yfpxC32iv3gpSmXVb5dhCWlES/jiws
-      KDAzt/jE3iqTyeLevMlITzMxNXOuXVtYUkJSjmjr6JSXwCQ9LTU+NtbI2LimSy0Oh1NczBcJRQB0
-      9fQYST5Wwu/xRfNRl1iRnOzs6NeRJiamTi4un/tJW3nsDT5p7sqvrEdSvhhH9u9dNGsGgK17D/Sq
-      XNqg77F7V5WPftt9h/y/OXdTvjWqRY/8Dql6z5JIJC083NJSU5xcXO48UjHvxo/Aj/Si+Ub5RD3y
-      W1GHKZ+JhLg4AEWFhbu2bgZgbWOr5CZMoVAolC9JWmoKmZH56IH9aakpABT91ymU74vqz/tD+XaI
-      j41t37g+SZ6XkZbGYrH+2LCxMhnXKRQKhfKZWLNsScCd23b2DmSO3wZNmg4aPvJrC0WhVBFqj/x/
-      piA/r3Ezr5dhL7IzM+s2aLjv+KmP8iCmUCgUSrVjbmHJZrOfPX5kaGQ0Ytz4Q6fP0c97yvcLvXf/
-      n6nboOGpqzc+XI9CoVAoX4pFK1YuWrHya0tBoVQPVI+kUEBjUCiUzwPtWRTK/zl0XJtCoVAoFAqF
-      UhWoHkmhUCgUCoVCqQp0XJtCoVAoFArli8Ln88QiMQB9A4OvLcsnUZU85KxZ6z6HKBQKhUKhUH40
-      lPKQH967Z+3yJQC27N7X4f3pIr8ikREvB3TxATBi3IT5S5d/eoMThg65ceUSgIS8z+VG3NzDrbAg
-      v0nzFvtPnK6g2ifmIa+KPfLbTz3/XeTH//aF/BYk/OoyfHUBqAzfiAD/fzI4GFZlspkK3nnfwv/z
-      zUL/nPJwWPavUolQWEKmKRaRaTG/DaQSCZFKUFxcLQ3aOTi4eXhWS1PlUViQX1hQwC/6vOFudFyb
-      QqFQKBQK5YuyZPXary1C9UD1SAqFQqFQKN8oMVFRz548kkokjb1aODk7K27Ky80NCQrIzMgwMDTy
-      atnKzMKClKckvc3LzQVgYGhoY2cPICsjIyM9DYCmppaTiwupViIQ3A8MSH6byOFwHJ1dGjfz4nA4
-      iu1HR0Y+fRTC4XKbtWipUjaZTBb+PPTVy3CxSORc27VxMy82+73wZT6fFxIYmJKcpKGp6VbHo07d
-      wIEJjwAAIABJREFUesymtwnxxMDp7lkXQHxsLJ9XRFYLCwqC793Nyc528/Cs36gxAB6PF3j3dlZG
-      hnNtVyVhsrOyHgYHZaan6+nru3l6urrX+ei/+NOgeiSFQqH8iHw+rywKpVqIe/Nm1IC+d2/dJKss
-      Fmv1pi0/jRpDVndu2bRh1UoyUzkArpra9F/nzZi/EMCjBw+mjx8DwNbeISA0jM1mz5g4LvDuHQBz
-      Fi2ePm8BAH+/W7Mmjc/OymIOV9vN/cj5i0QZFYtEi2bPPHH4IHPo5q3bKIn3NiF+6uiRL549ZUpc
-      3etsP3SEUXZPHjm8YuF8oiwSGjRpuv3gYStrGwArFi5Q9I+c/8vUB0GBbDZ75Ya/Vy1ZXFRYSHaZ
-      vfA3KxubP35bWJCfT0pGTZy0Yt0Gsrx908a//vxDLHrnANCzX//Nu/cpKcSfFZr3h0KhUCgUyjfH
-      6qW/37vt18Sred0GDQHIZLJVSxaLxWIAvqdPrVqyuEQg6DNo8NnrfsPHjheLRBtX/3nm+FEAvQcM
-      bOfTCUBSYoL/rZvxsbFEiazl6jZ11hwAuTk5U0YNz87Ksra1O3zWd9ma9QBev4rYsEo+z9Dm9WuJ
-      Euni6jptzty2HX2C7/kryiYWi8cMHvDi2VMDQ8N/9h08eOqsmYVFZMTL8UMHCUtKAPhduzr35ymF
-      BQVudTz+2rZj9KTJAJ49ejhh6JAK4pulUumiWTN0dfU86zcgJRtX/zl32lQ2m82YIQ/t3pWZng4g
-      4M7tNcuWiEWiVu3an752c9CwEQAunj1z6eyZ6rsIH4bqkRQKhUKhUL45ataqdTXw/ulrNy/eudfE
-      qzmAgvz8xPh4ANs2/gXA0Mho/dZtjZo1W77uL2sbWwCb164m+67+e7O2tg6Aw/v2/Ld3NwAWi7Xu
-      n21cNTUA6Wmpg4eP7DNo8Ir1f7Xp4D1m8hQy/B0SHAiguJi/99+tAEzNzX1v3Z37+9KDp86u+nuz
-      omy3rl6JjowEMG3O3J79+rfz6TR74W8AYqKiLp8/B+DvNasAqKmrHzh9duDQ4cvX/tW5Ry9jE5Oi
-      woI3r19XcNY/jRoT9OLlpbsBHvXqk5IOnbsEvYg4eeX6wKHDAchksqjIVwD4fN7I8RN69uu/etOW
-      Jl7NZ8xfQOqHBAd9+p9feei4NoVCofxYpCS9lUqlZuYWGpqaX1uWz4iwpEQgEADQ1tHhcunL7vtj
-      /tLljLefm6fnowf3AQiK+bk5OZERLwHUa9hIXUMDAJfLbd3B+8ThgwlxcQlxcQ6Ojta2dvOWLFu2
-      YO6dG9cf6gYBGDVxUoPGTUhrru51lq5ZB6CwoODOjeuvX0UU83kAsjIyADx/+pTH4wHo0qOXjq48
-      rQGzLyE4QG6eJAougPadOpMF/9u32nfqHBb6DED9ho0sraxJ+a7/jlbmrFdv2sJisQC4e3iGPw8F
-      sGLdX7p6egBq1qpF6hQVFQLo3L1n5+49AaSmJF88eyYi7AXZSs7ii/HlutbZ48fI3wqgc89eXi1b
-      la2TlZFx++b19JQUPX2Dxl5ejDL+ZXj6MORiqTXYtU6dwSNGlVdTJBReu3RRICju1ruvjs4nJV76
-      WDau/rOw1Eli0oyZzA3KIBaLQ4ICX754LpVKa7m6tW7fQU1d/euKBCArI8Pv+tWMtDRzS8v2Pp3N
-      LS2rUYDKXLhHD+5LxGLFEh1dXWbg4NOpzO1NSE9LvXfbD4ChkZFP1+7VJQAqdyEePbgf+uSxoLjY
-      zt6hbUcfI2PjahQgOyvrn7/kyWU1tbRUpliTyWQhQYFhoc+EQqGdQ40OnTqT52N1UfkLkZ2ZeefW
-      DW1tnW69+1SjAKjchXgVHvYwOLiwsMDG1q5D5y4GhoafcsTrly48CAxULOFwuRZWVnUbNCwbOpCd
-      ldXcww3AnEWLc3NyAMxa+BuTCfmfDeuzMzMB6Ojp/frb76RQWFKyeunvAEzMzKbNmfspolbMrWtX
-      gu7eBdB38BAylAng0rmzT0IekOWfZ/9qam5Olnf/syUlKQnAnN9+V3kXHd63Z8XC+QBOXLrq1ar1
-      5xP7ixEZ8fLEoYNKhabm5rXd3Zu3asNoPJ8JkozQ1b3O6Ws3P+uBVMLlvFNXMjPSyULQPX8Pe3n/
-      KikpIQsJcbEOjo4ARk2cdOrofy9fPC8sKDA1N5+35L0n0ssXzzesWul/6yYZKCfxMWTEOT01ldSx
-      trUtTx4ysgxgWN9eSrE1CXFxzFZLaxXdv2KIEgmAuauZEqI0K3LF9/z2TRuJjybT06uQF/xT+EJ6
-      pEQi+XPJb4yOnBAfV/b5fvzQgSXzfmV8ZgF06tbj3/0Hy/5xn4nd/2694nueLBsYGvYfMpQYwBUR
-      i8Vnjh3ZtGZ1SnISgOatWn9JPTIq8hVjtAdgbWs7Ydp0xQpZGRmjB/Vn3qMAnFxc9h0/7Viz5tcS
-      CcDJ/w4tmj1TJBSSVU1NrfX/bu/Vf0B1yfDBCycSCgd16yyVShULvbt03Xf8VLUIUJnbm2HpvF+v
-      XvAF4ObhWY165AcvRIlAMHHE0Ls3bzAlOjo6m3bv7dStR3XJcPnc2X07tjGr3Xr3UdLUs7Oyxg8d
-      /PRhCFOib2Cwde+Bdh19qkWASl6Igvz/sXfmcTVmfxz/3KV916qiRJsSEaUFKdnG2I2xM/axjiFj
-      GIOx88NgMIMxRhJCCEXWKNmivShZWqVUt/Uuvz9OPa5KWu69xZz3qz+e55zTfT7POc/yfc75nu95
-      t+/37Qf3/FFUxDNq1VqyduQnG0IgECyZM/ukrw+Toqauvv3P/Z79BjT4oOGhoeI1L45xa5P123/v
-      0duDSbkXdoekZ6Sn+/x9AEDvvv3c3HsD4PP52zeuZ27VmfMWkDdZXEw0+f1Bw4Y3WGRdKOIVkQMp
-      q6gwdqTP3wcY1zSXXr1IRQmFwm3r1/J4PB09PdKxVB1tbR0Sn0+58il9YM9uACZt2jSmtpuQ1JTk
-      jzW0iqrqwqXLqj9+JQgJRlgo5WCEdYGxKdu0bTtwyLAquUbGrchGVmbGi+cpZDs3J+dZYgJzUYVe
-      vzZx5DB+eXkrE9PFy39x6+0xZvBXcdFRJJex22oxyJge7uGjv22hoyuepaunx1iW1a0ICbJj4/r/
-      rV8LoLtbjzmLFptbWXWzMpfe4T6GjPwjw0NvkYc7eXHeuHKZzMlniHxw/6cF80pLSlqZmC5YuszB
-      yQlA8IXzOzZtkI1CHo8XEnSJUfguL+96yAefXEKh8Kz/SU/HLkvmfk+MSNlz1v8kAGVlFecePQGc
-      OXG8SoE5300iRuSgYcPJpLbkpKTpY0fzP+yKk6WkuJjonxbOLy8rs7axnbvYW1tHp6SkeNHsGWmv
-      XkpEwCcbDkBK8jNiRLa1sLC27UD+unV3logA1OHyFi9JjEiJ88mG2PW/LcSI9OjXf8a8BUpKyjwe
-      b8H0qWT4RkIaTgBwcnUj/SIB1TQsnjOLGJHDRn87fe58RUWl/HfvZk8c97Hqqi+fbAgej/fHtq3O
-      Hax3bd1cVCSxExfn0w2xZRMxIu0dus5a8IOqmlpBfv7sSRNepj5v/NEnzZj5p4/vroP/rN60lQx4
-      vXqROmX0yLiYaKbM3duhABydXRi3/Zgnj8nGs6REYkSStyDzX8x4WTfnj34gSQRHlwpJ0ZWSAJC3
-      e4WkqIo3fWpKCrl0PxaQBcCQUd9cCg27FBrGWA+rf/Je/ZO33+HD0pEvO7q79fjTx3fvYZ8NO3aO
-      /26qgqIir7Dwt+XLyIfBF4+egQEx9VTV1BcuXVbljxn8XbHoh4L8fHUNDTNzc4FAsGTu98y85m0b
-      1vLLyzkczomLQYNHjmqhrS3++8TVEsDzZ88+pkG/cpzBs//AKgLGTZlqYGRErtjnycnMv8RFR10L
-      Dnp0/x4z87oxFBXxdm7dDMDcysrnzDnXXu5KSsqN/9kGICM7kjxMVdXUFiz9CQCfz7949ox4AZ+/
-      D5I3/a6DhxYuXfa3nz+x4oMCz8lGYdC5s6QrdM6PizW1tFD5PmDIysxYOHNayrNnAEgB2UNezE5u
-      bn0GDAQQ/TgyRewqj3xwP+zWTQDuXn13Hfxnw46doydMApAYHxcSdLFJJAE4sHsXv7ycKyf376mA
-      H39esXLD5hba2satWt0LC5OIgE82HIDnyRWSzly+Rt4rl0LDZs5fKBEBqMPlTeDz+SuX/IiaxiYa
-      zycbgkjSMzD484jvstW/jZ08BQCvsDAxLlYiAtJevSTeSx59+7n2dAdw/vQp8T7gtFcvQy5dBNCr
-      j9e2vX/9vGbtxOkzAPB4vNs3rktEwycb4vrl4I2rVhbk5ysoKkrpmVt7Q/DLy//c9TsAbV1dn4Dz
-      S39dvXbrdgClJSUH99Tcz1QvbDt26jtw0KBhwydOn/Gnjy+5yMvLynwO7mfKRITdAdDN2bkbY7Q9
-      jiQb8dHRADS1tIxbmwCIi66wIxlDk7HzpIS+QUsyIslIysxIJ4PvpG+bMW3fS3J2FQgEsVFPYqOe
-      vEx9zissPO137ELAmdKSkpw3b0g6sTgZazg//11s1BPxb4yXqc8DThw/cnB/yKWLUvrAkCxGxq36
-      DhzU/+vB306c/NvW7X/+W+F4V6W3svbzEolEj+5FHD9y+MjB/VcuXaj+SZmdmRlw8sTRQwcjH9yX
-      3rk0AFU1NRJVMSryUVZGBklcOn/uNwP7TRk98tWLVADnT58iUXVGjhk3efosAHHRUXt2bCOF01+n
-      AZCTk9fV0wcgFApLS9+PhdrZ25Oe+Evnz5JuI5FIdPq4n7gG117uZIN5vUZFPhrSp/fYIYP+2LZV
-      RUWFdFU8fnCfTMcRCoWL58yeNGr4EE93iXRFvX3zhnz1GbQ0JCPaxcVFjf/ZBiALO7KstDTo/FkA
-      Lj162dh1JMGZqrzsZ81f6Bd4ye/8xY6duwBQUVUlHdelJaUyUAjg7KmTADS1tOzsO5MhnsuBgSUl
-      75c/Mmhp+O2EiQOHDL1w8/awb76VjSpxHj98QLro3dx79+ztSRLP+b8fmb0ZcoVsDB89hmyMGDOW
-      bFy/LBV3lk9KQuU91qFjJ9Lug0eMfPQs9dr9yMEjR0lEwycbDpXflNo6OowTmASpy+VNOHro7/jY
-      mF6efciTS4LUpSGuhN9/nltw/cFjMhzDPDRbaOtIRAPjourm3ruHhweA9LTX9yvd2gCoqWucuXLN
-      7/zF37b8j6QwToHi3iwNpi4N0f/rwR07d5k2Z15oZLSpFJw9PtkQD+/fI2Hh+g8aTFxiBg4Zqqio
-      BOD6leAafrFxuPfxIhtkiiuAwoICYk51c3ZtaWjU2rQNxGyy2OgoACZtzIgnDDPMF/34MQBNLS0L
-      K2uJi6yCo4sbSNTojAyIdUD29OzzoaQKQ7ObiwuvsLC/m3N/N+cFM6Z6OnVdMGPqrInjnqcknznh
-      R9KjHj0E0N+tYggiPPRWfzfnyxcDAZSUFM+f/p1rR9t506b8/MOCKaNHOttakw+ez4ielZ4hTEN/
-      8rxePE8Z0MNlSJ/ei+fM/vmHBd+NHuVsayU+z/ffA/tdOtrMmzr5pwXzBnv0Gt7Ps6zS4aE5sPCn
-      n1ksFr+8fNKo4cePHF4y93vff/4Ovx2qpKRk3Nok9+3bX5YsIiXHT50+/NsxZJDk980bnyUmArDp
-      YAegpKR46phv1q9cMci9R3JSEgDy6SuvoEDCAxXk5/d37T5tzOge9nZ/7vxgvnZPD08ycPrv/r+2
-      /Lb68P6/po8b8+hexP3wcPImWrziVzabLRQKxwz5auOqlWOHDCKjhYNHjJRIqHADQyPi4B56/drP
-      PyxY6f3j1+49SVYVJy5pIws78ua1kHd5eQDcenuwWCzyeA0PvZWZkc6UMTM3d3JxdXJ1I53V/seO
-      ElOgfQfprj5JyMvNvXU1BIBrL3c2m03uyaIi3uULF8SLrdmy7Y9D/4rHo5cl5yrfiD3cPdpaWJAg
-      BWdOvh81e5pYEUrA2saWbFhatycbSfFxTSIpJzv7bU4OAENj41cvUg/v/+uv3TvDbt2UlBdwHRvu
-      WVISABOztqf9jq1Y/MOWtWvIB6JEqMvlTaRuXbsawLzFSyXuBP3JhiCwWCwVFZWiIl7AyRMnfHwA
-      2Nh1bG1qKhENxGLT0dOzsrFl/B3Fh7bV1NXtHbo6ubq1MjEFUFJSzPgItreza7yAujQEm80OCLm+
-      /Ld1kp3pxfDpmzSh4sKzqrxJ5eTl27RrB+B5cnK5pN/TjHNYC52Kr4X7d8OFQqGOnh4JlUy6TFKe
-      PeMVFgKIj4kGYNq2LTGySeefQCCIj4kB0K27C+M3Jj26OVdYe8RSJBr0DVq2t+0A4HlyMul0Idaw
-      hqYm85QDcD88PO3VSycXV6NWrUmXqjhTZs4mG61N20yZOdvc0grAqqXeZ477AVj662r/S1ccnJxy
-      376dNWk8sSo+FxinCO3Kz8JPnteCGVNjo55wudwtf+z92++kuoZGXm6u99yKKrp94/ryRQtKS0q0
-      WrSYNmfeiG/HPnn0SCLfe5Kip4fnH4f+NTRuFfPk8eI5s/3+/UdJSXnm/IXb9+0H8NvPP5HpYj16
-      e7Rp21ZFVZX0qpSVli6ZNxvA8rXryYvyWnDQ3h3bCvLfkXm9vMJC4hsze+GiuT8ukZOXz8vNDb5w
-      Pi/37bgpU8UFsFisg8dOEkf/nVs2rfhxYdqrl7YdOx07f4H0nTs4Of17KqCdpWVWRsYf27beuXlD
-      XkFh8sxZW//YJ5Ea4HK52/b+pa2jIxKJjhzcf2jfXjNzc2JZpiQ/lcgh6qpEBsdg3iXuffoA6NXH
-      66Svj1AovHDmzOSZs6qXv3PzxopFPwBgs9nTvpei1zBD4JlTxIOQRC7t5VHxFjx3yl/cr1wGz9CP
-      QbwzARi1at3O0hKAex+vIwf3P0tMjIuJJvcDGf0BwKwNpa6hQb6HcnPfNokk5hWeGB/n3rVzWeV8
-      OicX179P+JPgXo2hjg33/NlTAA8j7jIzPPZs/9+uA4f6fz24kQJQ58t767o1ebm5zj16dnF0LMiX
-      gHMMQ10aQhwb45ZCoZDD4Xw1dNgv6zdK5KpOTkoib/1eHn1YLJZxa5O2FhbPEhMvnj2zatOW6iFX
-      ysvKvp80kbzSenp4SuTrvI4NIb27uF43qZ6+HvOP5NEvFArz373T1tWt4afrz9ucnLBbN8kkawBf
-      Da2Yi0CcIxnnYCc3t5O+PiKRKDY6qqtTd9If2aZtO01NLQDx0dFCoTDl6VNiunWT8qA2oXvlxOqY
-      J4979+0XVyGpwrQVCoXxMTH2Dl2JA2VXJ2fxqbJcObm/jvj27tuvvKysepyKlRs2kWFfJuZLTnY2
-      iTXdu2+/WQt+ALB55x73rvalJSV7f9++aeduGZxvI+HxeLFRT1YtXUJ2SUN/8rx4hYVdujm1Nbc0
-      adOGhCT0GvDVSV+flGfPsjMzdfX1d23dTH7wn5OnySDh1DlzB7n3kPinTo18N+v772Z9XyVx5YZN
-      VSZUDRg8pN+gr58nJ2dlpKuqqZlbWjFxrLbu2bd1zwfm2upNW5k1YACYtGlzMTQs5enTrMwMbR3d
-      dpaWZaWlZMY3mZXFYrF+XP7LzPkLkxLiWSxWe9sOHC6XxKCQV6i4tDQ0NXceOLT2fzueJSaU8/nG
-      rVszjpUE117uIXcfvEx9np6WJi8vb2FtLf7W++voMfHCfoGXPnnKVWrG3avv3djEhLhYHo/XysTE
-      0MiYx+OJRyaJfpEG6SP1/sji4qIrFy8CsLCyJh+IPXp7kDs/oFp/CYDLFwMnjxpBOiPXbPkf6TeW
-      NmRIjsVi9e7TF4Cuvj7pdLwafEl8RaMm5F54GLHJPPr1Iym9+lTt8mGsNPE3JenMLy76YJxXZpKY
-      79ek+Pi25hbf//AjGUcLvx26fcP6qr9Yf+rYcMRBTVVNbeWGTXN/XMJms/nl5Uvnz2m8I1QdL++E
-      uFifgwcA/LRqTSOPWJ26NIQ4ZMhDIBBEPnjw6N49iWg4d6qiH86jX3+y4e7pBSDnzRuyjIQ4xcVF
-      k78ZceXSBQAWVtY7/jrYeAH1fc5IgzrdpMxrWOwmVVWtiO7RePemH2fPNNFUNdFUtW9rMnvS+Lc5
-      ORwO54effmamJ0eE3Qbg5FJhq3XrXmEaxkVHv83JIUPJFlbWVjY2RM/z5GTGJbGWGS0SxLi1CVk1
-      jhyX+GhaWFu3M7cgHyRx0VFvsrJIb1MVf013T6/effsBqGOws4iwOwKBAGIhAM3MzYmDJuMm1Dw5
-      6etDGrq9kf6Ifn3IgGmf/gN/XPEL6nBeKqqqP69Zu3nXHzPmzr8fHn5o396ESj/pN9lZ5WVlxNe5
-      rYUFMSIBWNvYKja/aKNsNtusXTsnVzfbjp3qGwyVxWKZmZs7ubqZW1mxWCwFRUV1DQ11DQ3x715V
-      NTV7h66dujjIKyhwOBxSgDiiMKhraNh37datu3MVI5KhlYlpt+7Onbo4NL7rpDpy8vK2HTs5OruQ
-      o6uoqBCREj9QLUi9P/LyhQvkbc2VkyPh3QFoamm9zcl5dP/ei+cpxLAghFy6OHPCOH55ubKyytY9
-      +yQe161GMjPSw0NvAVBTVz984C+SSLxWy8vKLp4LIGsNNS3MeygzLZ1UY1GlT/RZ/5PeK1exWCyl
-      ytgWPF4hcxkRc0pNoiH66i6JubFNzcwCrlxTUFQcNW5Cry4dRSLRhYAzy1b/1hgBdW+4W5FRr168
-      YHM4xOsrNSX5rP/JvNzcu6GhTOTYhlHHy/tX78UCgeCrocOYeaMSpC4NIV7+0u3whxF3t/y2+tWL
-      1FkTxx2/EMS8bBoMM3R7PzyMvJAYR/KzJ0+Ih/UpLSmZPGoEmRDW08Nz18F/JPLIq9dzRkrUpSGU
-      lSsm9xQVvv+Gya/sn1ZVU2+kBq0WLZRVVDMz0sm81AlTp02ZNYcJ+1VaUhL54AGArt0rWtykTRuD
-      loYZ6Wlx0VHtKme5mltZaVfGMYmPiU6IjQGgoqIiM5ceR1fXM8f94qKjysvKniUlAjC3tCYOAEnx
-      8XEx0UxrdvvQtK1vZzMT5G/Hxg1/bKvorCKtlp72usZOzWaCsrKKlrZ2Xu5b4pDQ3a3Hop9XMDdy
-      Xc7rTVbWtg3rzpzwIw674qEHc9++Jf2OTAAdCqUWpG5HMg5DZN5cldzzp08Rb1YAyUlJc7+bxC8v
-      N2rV+tAJfxk4dDMaiL9a/rt32yvfQO9zT/k3uR3JLy9npp0GBZ6rMof99csXkffv2XftpqtbMVKW
-      l5tLPuiZ4AKMd5SMJWlWhrm279qN2JSmZmatTU1TU1IaH/en7g2noKjIRIIA0MmhKxl/zEhvbJ9/
-      XS7v/HfvSPS786dPnT99ismNi44y0VRNzWtUMLY6NoR4orWNrbWNrUFLwymjRwqFwuNH/m2kHRkb
-      9YRxuiLx+cQJCjxXVlrKTFFf6b2YGJEz5y/0XrmqSvzeBlP354yUqGNDMDG0xScLE7dOrpycmnpj
-      7ciff1s3csw4n78PLFs4H8Dd27eX/vq+C/zR/Xv88nI1dXUrMW8HRxeXgJMn4mKiiaOhnLy8Wdt2
-      XDk5bV3dnOzshLhYMtjt4NS9Sjxz6eHo7HLmuN/z5OToJ49Jv5qljQ0AS+v2SfHxibGxrU1MASgr
-      qzRyrQoOt+KMuvfowXS8Mch4skK9GDB4yNY9++Kio7726FVWWvrk4QPxi+eT55WZkf61e8+M9DRl
-      ZZWfVq0ZMHjI33v3MHO96xI9kUJhkK4dWZCff+1KMABtXd3vf/iRSS8uKtq8ZhWAM8f9yPNdJBIt
-      mDGVx+O10Nb2O3+BeOLLBuYNtGjZchWxfru9O7ZlZWTcunY1JztbUk5LDSP0xnUyW6WLo6N4zNX4
-      6OjjPv8COH3Cz75rN+vKOUkJMTHEGYusHAWAuKjLXlJLQyMVVVVeYWHay/dWI5mD3/hVTOrYcInx
-      cUHnzr7Ly+s3aDBxk2BCiFUZnqgvdby82Ww2mW/BkPbqpUgk4srJ6Ru0bIwA1LkhSkqKjx76m1dQ
-      oKOnRwKLMldLbk5OIzUwc6KHjx5j0/F9l9WlswERYXcKCwpCgi4RV9SrQZd8//kbwLQ58yQ4xF/3
-      54z0qGNDMHcic2+WlZamPH0KwNK6vaQMtbGTv7sREhJ0/mxCXOzcqZP/8jlGfplEIO/a/QOfwm7O
-      LgEnTyTExDzrmADA3NKKxFxrb9vh1rWrzxITyMiy48dD60scR2dXAEKh8NK5sySF1Ju1bYfzp089
-      TUokN5SDk1PDVjvk8So+3pilhqxtbBcuXdZ45TLG2rbDslW//bp0MY/Hm/LNyHNXb5BX1SfP69/9
-      f5Gv6I07d1dfEkJLW1tBUbG0pCTl49ETKRQG6dqRF88FkO5xD69+VdxmT/n5PktMTIiLTYqPN7ey
-      uhp06fHDBwC+nTiZxWKR+E8A2Gy2oTS71l88T3l0/x6AViam85YsFc9KTko6cnC/UCgMDDgzYeo0
-      6Wn4JGdPVsQNGTv5OyamD4DszEzyiroQcGbl+k2e/fqv/slbJBIdPXRw0PARHA7nSOVob5+BEluz
-      pF6SOByOex+v86dP3QsPe5qQ0M7S8vaN6+T51cWxUZ6vdW84fnn5lrVrALx+9ZLYkczaGOJGTwOo
-      ++V9J+qDGI22rQ0L8vPNLa0uhTY2iGYdG0JeXmH7hnXv8vKUlVU8+w3Q1dcnnYIAWhrVe9kucUQi
-      EWNH/rh8hfjdqqdvQEIVnjt1ktiRZOkFNXX1MZOmMPc4AE2tFo35rqh7QzT4EJ+kjg1hZWNr3Nrk
-      1YvUi2fPLFmxUltX96SvD3EH9xogyUUyN+3c/eThg/S01yGXLm5ctZL4kIR/OMmG0N21B4CiIt7V
-      4GBUxkMBYGVje+va1Uf375Ohg24ycY4ktLWw0NHTe5OVRfrvjVubkM428nn8JiuLhKdpwFICXC6X
-      z+e/TE0ViUQsFsvBqTsxmK4GXVryy68sFquoiDd51AgARsatNu/eI7Mu2AYzacbMm9dCrgZ9LYpf
-      AAAgAElEQVRdev3yxfTx3x47e0FOXv6T55X++jX5d2bkurj4vQ89l8t1cnG9EXLl1YvUK5cuEOfa
-      4Avnec1gJRtKM0S682zOV4aUq+6F1turwhU9wP8EgNPHKyYu7f7fFhc7G+bPy9lRugorxxndvbyq
-      KazQfFZWfvo1UlZaSsbIWCwWMx+ZoKuvT+ILZGdmhofeam3ahgQev3vn9gA350HuPQJOngDQ08Oz
-      lmX6pCoJwJxFi7lcrlAoHOzZ69uvB07+ZgQANpvdyP6hujdc+w52ZPLHhYAzY4cMGtnf6/qVywB6
-      eng20nei7pe3lKh7Q7DZ7EkzZgEoKuL1dXUa2d9ryZzZANhs9qhxExqjIfL+vdcvXwCwsLKu8snX
-      08OTvIavXLrI4/GeJSaS2QAF+fnuDp3Eb3O/I41aX+QzaggWi7VkxUoA7/Ly+rl1Hztk0PJFC0mx
-      yZVRaSSCppbWjv0HSb/jvt+3+/37D5/PfxgRAaDK08DM3Jws5kEse6ajmhiUJFFBUbFTteFRqUJ8
-      LcjRmU5cJj4USXes/5LZHbt0AfDiecqE4UNmjB+joak57fu5AOJjY+ZMmXj8yOFJI4aFh94KD71l
-      37Vb8zciAbBYrC2795I4VvfDwxfPnQ3gk+fF1OTS+XO2/LZ68jcjyEABKkfz5y72JhfPjHFjJo4c
-      Ntij17Qxo5vzQD+lCZGiHZmTnX3r2lUAXC6XhOUUx7NyXid52UtqdZP6cqYyQj2Z8CuOS69exKXv
-      /t1wSS3i1wBCgi4RP2g7+87Vh9eZ6bHEZFyzeeu4KVO5XG58bMyTRw9ZLNbAIUN3/y3hRcDqJcna
-      tsOfR3wNjYwLCwru3LxRWlJiaGS878jRRvrk1avhdvx5YMiob1gsVuj1axFhd1gsVv+vB+88cKgx
-      Aup1eUuJejXE/CVLZy34QUFRMSc7OyLsDp/PNzQy3vuvT5UlsOvL6RMVDVHdhlPX0CCtXFpSEnz+
-      3L3wO4050Mf47Bpi8MhRa/+3XU1dPSsjI/T6NYFA0KGT/dGA80xUdknh6Owy58eKcDDLfljwIOJu
-      URFPUVGpik8hi8USH7NmjDZrsdi99l0cZDzjhPSSVlHS0tCIWUtMXkGhY/1nrS1fs45EWbp5NSTi
-      zm0+n//DsuULly5TUVE5f/rU4jmz7965rW/QcuuefeO/m/rJX2smaOvobNv7F3FqPO13jEysqf28
-      xk6eQoYIEuPjdm7ZdC/sDrMCOxnL7urUffffh7V1dPh8/vXLwdGPI0dPmNR4/12ZoPpf+msWsBrg
-      SPviXXNfNsrk192pv1aNPtXckJ7Id3l5TxMShCKhaRszJpZkA5CgQoFAkJyUlPMmW0dXz8zcvO6z
-      KySoIS83l6xkwARrlbGABiNBDcXFRYlxccVFRXr6BqZt2zZJQzSMJhcgWQ1lpaXxsTFFPJ6BoZGp
-      mZkMNLzJynqamKCkrFx94oWkaA5t9ElKSopjnzyRV1BoZ2nJeEiXlZYmJcQX5Ofr6um3addOUtO/
-      xGmSyqn9vDIz0p8nJyspKVm1t2FzOGRCt4KCAhNng19enhgfV8QramdpqamlVZCfLxKJOBwOCScn
-      KSRdM83FupIJkvE0aK3RqIBEsohDTpExGpqaXRyl6w9QXzgcjrmVlTmk6KD2STS1tJpbtcgeJSUp
-      mhGUuiOvoCCNIFC1oKOnx8wW/y+jqKjUuVvV54C8gkJTLVQmVWo/L32DluJT/apH4OLKybXv8H6t
-      qc+kP7Ih/HsAG1cBwO9/ofdHYsHNm4arQQAQFo1GR+j6oqB2JIVCoVAolP8uZWUoyAeAcv5HyxTz
-      KsrQaEhVkMX62hQKhUKhUCiULw/aH0mhUCgUCuWLIucNIu4gOxNq6rDuAKv2H+QKhYgIQ3ISNDTh
-      2qvmXygqwu0byM6EoTFcelTNTU5CSQnYHJhb4mYIsrPRuw909ACgrBQRYXjxHHLysO+CdpYf/KNA
-      gMcPkJIMXgF09dGtO7Q/nJtXVIR7YUh/DYEARq3g5IrmtyDlB1A7kkKhUCgUypfDnu3Yshb88vcp
-      g4Zhx18goZyyMzFtLB7dr8hSVoalTdVfeHAXMyciK6Ni19AYlWtyVTB7MuKioa0Da1uEXgeA1Zsw
-      cTpuXcPCmcjOfF+y/9fYugdk3eLHDzH3O6SmvM/lymHmPPy4HGQVoeM+WP1TxQA6QasF1m3DgMEN
-      qwlZQMe1KRQKhUKhfCHcuoYNv4JfDtdeOHkJo8YCwLlTOF+5Ku3sSRVGZE8PfP8DWpvi0b0PfiHn
-      DaaMRlYGOBx8Mx5TZqKsDCk1Le6T8wah12FpjQ6dYNwaz5MxbQyyM2Fjh6MBWLcNbDYunsWvSwCA
-      z8f0sUhNgVV7BN3BwyT8ugH8chzej8sXASAxHt5zUZCPIaNwJwq3n2DkGOTlYtVSNHoRXylC7UgK
-      hUKhUChfCEVFmDAVg4Zh/XZ0dcJ874r0u3cAICIMEWEA4O6Fw/5Y8gsu3MKQUR/8gs9B5OUCgPdK
-      bNqJlRtwNaLq8DTD3B8RdAfnr6NHb/y9D2RhoA074NITYydj0DAAOHEUaa+QmY6MdABobQqr9tDW
-      xeSZSMpEVCq8BgDAk0cgsd7t7GHUCsatsXEnnmbjbhxaNmrdMelC7UgKhUKhUChfCH0HYs0W7DoI
-      OXmcOwWfipV68CYLAO5ULIuL4aMrNjgc2H24GsPtm1XLaGjCrG0Nx1JVez8kLSePsJsAoKgI28po
-      S+59AEAkwq1r0DeAtg4ABF/AUC8c2ofUFMiLDZe3t63Y+O1nzJqIM8eR/w4NWkNepjR7gRQKhUKh
-      UCh15kIA9mzHk0cAwCxvSeL1ZFa6PBoZf/TfiVuknHzFvJlaIBYkQ3YWAJSWws60IkVQGUgoNQVc
-      Oew5jO8nIzsTDyPwMAIrvWFhhXFTMGEaWCy074BfN2D9rygtwYUAXAgAm41uzpizCG7udTvzpoDa
-      kRQKhUKhUL4QdmzE/9YDQHc3zFkEcyt0E1sBg7H8agsDyfpUgY/A4QKAoiK+m101y94BABydcecJ
-      7tzClYsIvY6UZ0iMxy9L8OYNFi0DgMkzMWw0Qi7h2mXcvoGcNwgPxd3bOHL6o/PKmxxqR1IoFAqF
-      QvkSKCrCzq0AYG4FnzPgcJD/7oMCLY0qNlKS0eUjC5wZGiE5CfxyvH4Jo1b1OLpBS2RnoqQEsxZ8
-      NFiPvAJ6eaKXJwAEncfMCRAK4Xe4wo4EoKGJYaMxbDTKy7B1HfZsh0iE4z7N146k/pEUCoVCoVC+
-      BN6+QXkZABi0rBjRJhNfGFx7VmwcOVhRkleI4MAPyrhUlvl7b8VGyjM8evDpoxNTTyTCteCKFJ+/
-      MaIfJo5AyCXwy/EyFY/uvZ983fcraGkDAFcOAIqKkJyEiDAUFQGAnDxGfFtRUq4Zd/o1Y2kUCoVC
-      oVAodcbAEFotkPsWodfx8w/gyuHS2YosMhXavit69MbNq3h0D326w8wcD+5WzM5mGDsZB/bgTRb+
-      2o0H96CigrDQD6JRfozJM+H3L97mYNlCZKYj/x12/Q+lJTA1g6ML3uVhSB+8yYJxa/z4M3T1EXQe
-      OdkA8O1EAHj8AGMGQyhEdzdM/R4cNvb+DgBsNkaNl1wdSRraH0mhUCgUCuVLgMvFtr3Q1oFIhCMH
-      cWgfzMyh1QIAUpIryvxxqCLOTsozhFyCplbVKN8amjgaULEEzsMI3LqGrk4VDo61o2+AY+fRqQve
-      5mClN7auQ1kp+g3CiQtQVYO2LvzOwckVr15gwQyMHYLD+6Gti59WYc4iAOjuhr+Ook1bhN3Cd6Mx
-      aRTCQ2FuhQO+cHSWXB1JGtofSaFQKBQK5QvB3Qt3Y5EQBx4PrUxgaAQe7/28aQBq6vjrKDIz8PI5
-      1DRgYYXyMmz8HQCUlSvKWFoj6A6SnyI7C61aw9AYRUUVXZJq6gBwKbTmo1taIyAE6Wl49QIcNtpa
-      QEPzfW47S/idR14uXjxHEQ96+jAxez+jHIBnP3j2qwg2yRfAyBiGH59X3kygdiSFQqFQKJQvBzn5
-      9xEcgYo1CaugbwB9g4pteYUP4jgymLWDWbuKbcbErAstDWuLHK6pBU2t2v7d8HMwHxmoHUmhUCgU
-      CoXSrDHRrJ6mWpd/TM0rlLSWD6D+kRQKhUKhUCiUhkDtSAqFQqFQKBRKQ6Dj2hQKhUKhUCjNmtS8
-      6mnSHbCuI9SOpFAoFAqF8mXQLEyr/xR0XJtCoVAoFAqF0hBofySFQqFQKJTPGIFAwCssBKCgoKDw
-      sZWtP1vKy8oyM9IBGLc2aWotNUDtSAqFQqFQKJ8xCbEx/d2cASxYumzh0mU1lpk3bcrVoEsAwqLj
-      1dTVZaqvGvt+356RliaeoqCo2MrExMGpu6V1+yqFL1+8MGviuNambTz79QfQQlt77mJvklVYULB1
-      7RqybdOx44hvx5LtxPg430N/A+ji6PTV0GFSPRdqR1IoFAqFQvmMUVRUsrbtAEBXT4+kHNizG4BJ
-      mzae/QaQlGJeUUF+PgCRSCRVMRcCzqSnvZaXVxj/3dSPlTl93C8uOqrGrG7dnbf8sc+kTRsm5e6d
-      UACOzi7XQy4nJyVxOJxpc+cpKioBiI2OOrj3D1LMtmMnxo68FhxE0ttaWEjotD4KtSMpFAqFQqF8
-      xpiZm18KDRNPWf2TNwCvAV8xdqTM+OfPveG3Q9XU1WuxIxnWb/9dW1e3mFeUkZ52/vSpqMhHEWF3
-      xg4ZdOXuPWIpArh7+zaAbi4uXDm55KQkgUAQHxPTqYsDgLioKABsNlsoFCbGx/H5fC6XCyAm6gn5
-      X0dnVymdJgO1IykUCoVCoTQjysvKkhLiAejq6evq6wPIyc4mPoKKikpm5uZVyqhpqCcnJTHlYyut
-      qPz8d7FRTwyNW2lqfbAQoVAofHTvXnxstJq6hmsv9xba2uK5aa9ePoiIyMvNVVVVte3YydzKisnK
-      SE97++YNADNzc8bOS3v1Mi83F4C5pdXrV694PB4AoUAQG/VEU0vL0LhVLWfao7cH4/U4bc68Ef29
-      HkbcfZn6/MrFi2Q8uiA/Pz4mGkC37i5yXDnff/4GEP04ssKOjIkG0KGT/eOHD8pKS1OePiVqY548
-      BtBCW7udpWX9q79+UDuSQqFQKBRK82JoH4+SkuLREyZt/H0XgO0b1x3e/xcAVTW1mJfpAB7evzdq
-      QF8AOw8camdhIe4fSbYBhIfe6u/mvOWPvSPHjGN++UbIle0b1z1NSCC7aurqvmcDO3SyB5D/7t3S
-      +XMCz5wWV+Lg5LR93/5WJqYA9u3YTsaLL966076DHSmwde1vJ319ANx+EuM9d3ZU5CMAPB6vv5vz
-      iG/Hbt2zr46nzOFwevT2eBhxF8CL5ykk8V7YHZFIpGdgYGpmJq8gTxJjnlQYymRw3NHFNT42prSk
-      JDY6ytzKqqiIR6zqrt1dWCxWHY/eYGjcHwqFQqFQKM0IOXn5Lo6OAIhNBrGB2sKCAmJjPXn0kKR0
-      d3Wr8u9TZs4mG61N20yZOdvc0ko8d86UiWkvX/X08CQdgQX5+ds2rCNZMyeMJUbkoGHD/zj077Tv
-      5wK4Hx4+ZvAg0sv4SQYMHmrQ0pCcwpSZs3v09qjXiTPmo7aODtmICLsDwNHZBYChkbFRq9YAoh9H
-      AhAKhQmxsQDM2rUzbWMGgPRcJsTECIVCAI4uLvU6esOgdiSFQqFQKJTmBbEOE2JjykpLhUJh7JMo
-      APZduwGIjYoC8PjBfQBm5uZk4FuclRs2kQ2r9jYrN2wiQ8AMXgO+uh0Ve9j/TNDtcCUlZVRaq+Gh
-      t27fuA7A3avvroP/DBwydPna9TPmLQDw4nnKaT/fusieOH2GqZkZAEVFxZUbNg0eOaou/yUUCtNe
-      v/pj29Yzx/0AKCkp9/bqR7LCb4cC6NbdRbxa4mNj+Hz+8+Tk4uIiAG3atjNt2w4AGdCPfsI4R1I7
-      kkKhUCgUyn8P117uAPh8flxMdMrTp8XFRTp6el2dugOIfvIYlcafS4+e9f3lrXv2EYdIVTW1ViYm
-      AIqLigCEXr9GCowaO54pPHr8RLJx/fLlxp1QzbjY2ZhoqrZpod7dxmrjqpVCoVBNXX3PP/8S47i4
-      uIicpqNrxXSZbs7OAIgrJOl9BGBuZW1lYwMgNjoKlb2SqmpqZA67tKH+kRQKhUKhUJoXHew7Kyur
-      FBXx4mOiVVTVAJhbWhFrKSEmhsfjPU9OBuDco1djjsLhvreCMjMyyAbpUCSYVG5nZ2U25kAfw6Cl
-      IZvNTnv9CgCHw/l1w+ZBw0dotWhBch/du8cvL9fQ1GSG5h1dKgbxY6OjniYmAGihra2to0OiTmZl
-      ZLzNyYmPjQbg4NSdw+FIQ3MVaH8khUKhUCiU5gWXy+3avTuAuJjohLhYABbW1sRaiouJToyNIcUc
-      XSQW14aZkkKcCwmiym0WWyr2kn/Q5bCY+K+HjwAgEAgeP3zAGJEA7t65DaCrkzO78uimZmZ6BgYA
-      4mOiE+NiAVi2twHARC9PiI2Ji46GrAa1Qe1ICoVCoVAozRAnVzcAcdHRZDaJtY1tO0tLDofz6kXq
-      owf3AVhYWTPzUWqExyus++FatW5NNpip3ADiKw1Wksv0X+a/e8eUEQgF1X+tqG7zcgjrtv1OJv2c
-      9PXZu2Mbk36PTLL5cLoMMRBjo6NSnj4F0N62A4A27dqRBSGvX7lMloh0kpyFXTvUjqRQKBQKhdLs
-      6O7WA0BCbExCbDSA9h3sSPBIkUh07pQ/ACe3qjO1GUg47pepqXVfvaZ334qpLf/s/1MgqDAN9/+x
-      i2x4DRwEgOksvH3zBoCSkuJ9v28/53/yg0PLyQEQCARpr17W8dBq6uo79x8kw9AbV628cukCAH55
-      +YO7dwF07e4sXpiY17FRT5KfPQXQ3s4OAIfDsbCyBnD+9CkAiopKJJKRDKB2JIVCoVAolGaHnX1n
-      VTW13Ldvnycnc7lcaxtbADZ2HQGQIIvObh+dZNOxSxcAL56nTBg+ZMb4MXU5nI1dxfrUDyPuDu/r
-      uW3Duokjh532OwbAycV1wOAhABycupPCv2/a0M3KvFMbk3W/LFdQUBD/HWZ6+NQxowf2dC0qqlPH
-      ZOdujgt/+hmAUCicO2VyXHRUVOSjkpJiZWWVKhYhMSuzMjLKy8pQ2R8JgMSzfPUiFUDnbt3k5OXr
-      ctzGQ+1ICoVCoVAozQ4Oh9Ot0snP3MpaXkEBgK1dR5LCYrFIh2WNLF+zjvQd3rwaEnHnNp/Pr8sR
-      N+36Y+5ibzV19Uf3723fsO765WAFRcXx3039+4Q/6Sx0dHaZMG068aTMzEhXVVdbs/l/A4cOF/+R
-      72bPISZvzJPH8THR4qPktTN74SLS11hUxJsyehSJ+GPftSuX+8GUaAsra2YBHi6Xy0zBaS82O7ub
-      rJwjQedrUygUCoVCaZ787XeySsq0OfOmzZlXJbF9B7vUvA9cITt3cwyPTYh98kReQaGdpSWXy/3r
-      6LHqv19lVW4Oh/PjzysWeP/0LCkxNydHTV29nYUl8TtkWLP5f3MWLX6enKzVokVbcwsOh1NcXLRi
-      7XoAqmpqAFpoa1+4dSc+JrqkuNjM3KLKkow1Hpc5ut/5i8xuclKSvUNX/ZaGVYqxWKxHz1Kr//uk
-      GTMnzZhZPV3aUDuSQqFQKBTKl4aiolLnbo4N+Ecul8tMf64RfYOW+gYtmV0lJWUlpQ8KsNlsZtXE
-      BmNmbk5WEm/m0HFtCoVCoVAoFEpDoHYkhUKhUCgUCqUhUDuSQqFQKBQKhdIQqB1JoVAoFAqFQmkI
-      1I6kUCgUCoVCoTQEakdSKBQKhUKhUBoCtSMpFAqFQqFQKA2B2pEUCoVCoVAolIZA7UgKhUKhUCgU
-      SkNgiUSi+v7Pi3d1WnSc8rlz61WGm7FBU6ugUCifB/SJQWkAt15ljLVp29QqKA2nIesittZQkbgO
-      SnPkFW1rCoVSZ+gTg9IAXjW1AErjoOPaFAqFQqFQKJSGQO1ICoVCoVAoFEpDoHYkhUKhUCgUCqUh
-      UDuSQqFQKBQKhdIQqB1JoVAoFAqFQmkIDZmvXQtCodDb21skEm3atInNrmqkvn79evPmza1bt/7h
-      hx8ke9x6cfny5cDAwAEDBnh5eVXPPXDgQFRU1PTp09u3by97bYTPoho/RkJCQkhISF5enpmZ2cCB
-      A9XU1JpEhlAoDAoKUlBQ6N27d5MIAPDq1auQkJBBgwa1aNHiP6hBJBKFhoZGREQIBIJOnTp5eHhw
-      OBwZaygpKbl48WJCQoKysrKbm5u9vb2MBQDIzs4ODAxMS0vT1dXt37+/sbGx7DV8AURGRubl5VVP
-      d3BwUFVVJdu1NPeGDRs2bNhw69atDh06yEixrMjLy4uMjKyerqOjY2trWyWxxgeCpqbmwIEDfXx8
-      pCv080EgEAQHBz9+/JjNZtvb23t4eFR5Eaempl6+fDktLU1fX9/d3d3CwoLJ+uqrr6KiolJTU2Wu
-      uukQSZoBAwYAuHnzZvWsLVu2AFixYoXED1ovIiIiAPTu3bt6VllZmZaWlpKSUkFBgeyFidMcqvFI
-      9NP6/ssvv/zCYrG0tLQ6d+7MYrFatmwZEREhDW21UF5efvjwYWtrawCDBw+W8dEJSUlJ06dPl5OT
-      A/Do0aP/oAYej0euYRMTE/KQdXR0fPPmjSw1JCUltWvXDoCdnZ2+vj6AadOmCYVCWWo4e/asmpqa
-      nJycg4ODioqKgoLC/v37ZSlAljTgiVF3evbsWeMrLDU1lRSovblXrlzZhDejVLl27VqNNTN58mTx
-      YrU8EJrwUSmS8mXTAHJycrp06QLA0tKSdCe5urqKmwRbtmzhcDhqamoODg66uroAFi1axOT27NlT
-      Q0OjKYQ3GZK3I48ePQpgzpw51bNcXFwAxMfHS/yg9cXCwoLNZmdmZlZJv3z5MoDRo0c3iSpxmkM1
-      1vf29vf3B9CrV6/CwkKRSHT79m0lJSVDQ0OyKxt8fX3NzMwAkPtf9g/H7OzsMWPGcDgcJSUlU1PT
-      Jnl1NQcNc+fOBbBkyRLyIt+2bZuMm0MgEHTs2JHNZp89e1YkEpWWlo4cORLAtm3bZKbhxYsXysrK
-      LVu2TEpKEolE6enplpaWbDb7/v37MtMgS6RqEKSnp6eIkZycrKenZ29vT3I/2dxfsB1ZXFyc8iFr
-      164FEBAQQAp88oFA7Uhx5s+fD2Dfvn1kd8OGDQDWrVtHdh88eADAzc2NWJalpaXDhg0DQC48EbUj
-      JQKPx1NRUTEyMqry3f/69WsWi+Xg4CDxIzaAVatWAfjzzz+rpM+YMQPA+fPnm0SVOM2hGut7ezs6
-      OrLZ7GfPnjEpy5cvF78hZcCePXs8PT2Dg4Nzc3Ob5OFYWlpqb2+/cuXK7Oxs8jyS/auryTXk5eXJ
-      y8u3bduWz+czia6urgASEhJko+HixYsAJk2axKTk5uaqqqoaGhrKrEvS29sbwKFDh5iUK1euAPj2
-      229lI0DGyNIguHPnDoDVq1eT3U82t7gdGR0dfeDAgaNHj2ZnZ8tMsCzx8vJSUVEpKioiu598IDCP
-      Sh6PFxAQsG/fvlu3bslMbXOzIw8cOODt7c08uzIyMgCMHDmS7G7evBmAr68vU55cikynD2NHCgSC
-      Gzdu7Nu3LyAgoLS0VLYnIVMkb0eKRKLx48cDCAsLE0/8/fffZdwZUAtPnz4F0LdvX/FEPp+vq6ur
-      o6NTVlbWVMLEafJqrNftnZOTA8DZ2Vk8MSYmBsDQoUMlLe3TNJUdKU5T2ZFNruHUqVMAli1bJp64
-      e/duADt27JCNhnnz5gEIDg4WTyR9VI8fP5aNBjs7Ozk5OfH+eKFQqKenp6WlJRsBMkaWBsGcOXMA
-      xMTEkN1PNjexI8+cOdOvXz8AioqKAFq0aEG6ir8kMjMz2Ww2Y/dU4WN25Ndff713714tLS1SMwDm
-      zZsnE73Nzo6swuPHj8XNROJXxvQ+iipfc3PnziW7xI68fv26lZUVl8vlcrkAHBwcvmBTUirztceO
-      HQvgxIkT4oknT55ks9mjR4+WxhHrS9u2bZ2cnEJCQt6+fcsk3rx5Mzs7e9SoUcSDpMlp/tUoTnx8
-      PIDOnTuLJ1pbWysrK8fFxTWRKErTQFq8ysXg4ODAZP13NFhaWqqovF8qkMVidenSJTc3NzMzUzYa
-      vkgEAoGfnx/jvoY6N/c333xjY2OTnZ3N4/HWrFnz9u3bPXv2yFC4LPDz8xMKhWSwte5cuHBh27Zt
-      x48fLyoqevXqlbGx8e7du8nX+H+ZgoKCJUuWiL9z+/Tpw2Kxzp07x5QhTmju7u5MSn5+/rBhwxYu
-      XFhYWJifnz9gwID79+8HBQXJWLzMkIod6enpqa+vT/okCFlZWaGhoZ6engYGBtI4YgMYN24cn88X
-      vxqI4HHjxjWdqA/4LKqRISsrC0AVYSwWS09PLzs7u4lEUZqGGi8GMvVBZhdDVlYWl8vV1tZuKg15
-      eXnl5eXVb1UZ18MXSUhISHZ2tripVMfm3rVr15YtW3R0dNhs9rRp0wAkJSXJSrWM8PX1lZeXHzhw
-      YL3+y8LC4u7du56eniwWy8jI6KuvvhIIBCkpKVIS+VkwcOBAY2PjtLQ0f39/Mi0BgJ2d3aFDh0JC
-      Qrp37z516tRevXr9+eefq1atGjp0KPOPcnJyN2/enD59uoKCgpKS0oQJE/AlXmkMUrEjORzO6NGj
-      nz9/TjxSAZw6dUooFJIONnHi4uICAgICAwMTExOrZBUUFISEhJw5c+bGjRtFRUUSFzlq1Cgul3vy
-      5EmyKxQK/f39zczMnJyc6i6jFv2N57OoxiqId70Q1NXV+Xy+tI9LaYZUuRjU1dUByPJiqPFq/A9q
-      +PI4duwYgOHDh4sn1qWqSQ8lgQS+yc/Pl55O2ZOamhoWFubl5VXfgGvm5uYaGhrM7hdZOfWlrKxM
-      Tk4uKSkpICBAvCoyMjIKCgqysrLevHmTm5tbWlpaUFAgEAiYAkpKSjY2NszuF1+ZEkx8lDkAACAA
-      SURBVI4fyTB27NgdO3b4+/uT+fOnT59WUlIS/3x8/fr18OHDk5OTe/XqJRKJQkJC7O3t/f39NTU1
-      AezcuXPp0qX29vZmZmaJiYlxcXG7d++WbE+hrq6ul5dXcHBwQUGBmpra3bt309PTV6xYwWKxmDK1
-      yKhdv6Ro/tXIQLxACgoKqqS/e/dOQUFBGkekNFtqvBjevXsHQGYXA5fLrfFqlJmGWu4ImWmokWPH
-      jhEvFABOTk7EX/AzorS01N/fv1WrVuSpSGhAczcT/yXJ4uvrC0C8b6xhfJGVU18uX75cVla2cePG
-      X375pbCwkPiY+fr6ent7T5w48eDBgySo5Pr165ctW6anp7d48eIaf+eLr0xprWfTtWtXCwsLMiab
-      m5t79erVwYMHM9FiAXh7excUFKSkpBw/fvzEiRPx8fGKiook7E5SUtK8efN2794dGhp6+PDh8PDw
-      devW+fv7l5WVSVbkuHHjysrKAgMDAZCYNeJdfbXLqEW/BPksqpFgaGgIgExtEyczM7MZjsJTpEqN
-      FwPxCJTZxUAm6lYZPpalBlVVVTU1tRrvCJlpqJFz585tr+TGjRtNJaPBBAYG5ufnjxgxQjyxyZu7
-      mXD06FEOhzNkyJCmFvKFIC8vv2LFis6dO/v7+5Mw+MRSX7duHROZ/Mcff1RRUTly5EhTCm1SpLgu
-      4tixYxMSEmJiYs6fP8/n86t0g2VnZ+vr6zMjEXp6eoGBgWR63Zs3bwCQKICE77///vTp0/Ly8pJV
-      OHjwYBUVFWJBnj592sHBwdLSksmtXUYt+iVL869GgqWlJZfLffTokXhiXFxcSUlJ9TUVKF82pMWr
-      XAwPHz5ksv47GpKSkgoLC5kUkUj06NEjQ0NDLS0t2Wiojo+PT14l69evbyoZDYYMalfpcmsOzd3k
-      xMbGRkVF9ezZswkX0PoisbKyElXGJCFfhuRTmSAnJ9eiRYv/8sw56dqRAE6dOuXv76+trV1lEcIJ
-      EyZcu3Zt/Pjx1Rd06tKli42NzdixY/fv3y/+CJY4ysrKw4YNu3jxYlhYWHJy8pgxY+ouoxb9kqX5
-      VyNBRUWlT58+4eHh4t7E5BNt8ODB0j46pVnRs2dPTU3NY8eOlZeXM4lHjhzhcDj1df9vMKRL5t9/
-      /2VScnNzAwMDra2tzc3NZaahvLzcz8+PSbly5UpmZia9IxpMYWHhuXPn9PX1mXkPhObQ3E0O6Sqr
-      4jZKqRdFRUW6urpt2rQR93eMi4tjs9lk6ZpWrVoBIKviEV6+fElmuMtebXNBqlGFnJycLCwsFBUV
-      Z82aVT03ODiYLHVlaWm5du3a9PR0Jis3N3fJkiU6OjqKioojR468cOGClBReunQJAFkIIS0trUpu
-      7TJq0S9Zmqoa6xvW686dO2Q10oSEhPLy8qNHj8rLy9vZ2ZWXl9frdyQCjR/ZtBo2btwIYMKECW/e
-      vMnPz1+yZAmA2bNny1JD//79AezYsaOkpOTFixfkG+z48eMyE5CXl2dgYKClpRUcHCwUCsPDw01N
-      TVVUVJKTk2WmQZbIIBDg4cOHAcyYMaN6Vu3NXeN6NgB69uwpbc0yw8zMjMVivX79upYytcchZyDV
-      de3aNWnorEJzix85ceJEAHPmzHn79m1ubu6KFSsADB8+nOQSm8HKyur27ds8Hu/evXtk8tbevXtJ
-      gerr2ZCFK1euXCnjE5EZ0rUjd+3aRazV27dvf6xMSkrKmjVrWrVqRYaYxbPKysrOnj07dOhQFovl
-      7u5eXFwscYV8Pp/EhujTp8/HytQuoxb9kqKpqrEBt/fJkyfJRxuhR48eL1++rO+PSARqRzatBqFQ
-      uHz5csaJgoRZkXEk3ry8PHFHMVVV1d27d8tSgEgkioqKsrOzYzSYmpreuHFDxhpkhgwMAjIrKCgo
-      qHpW7c39xduR4eHhALp37157MWpHfhIejzdu3DjxGbfDhg3Lzc1lChw+fJiYDQQNDY3169czuf9B
-      O5IlEonq2nUpTcrLywcPHvzgwYManQxCQ0Pd3Nz++OOPWbNmyV5bXWTUrl9mSLYafWKejbVp2wAN
-      kZGRhYWFpqambdq0qe+/U74k3r17Fx0dLRQKraysxD8wZMnr16+TkpIUFRU7duyopKTUJBpiY2Mz
-      MzNbtGjRoUMHxj3/y6NhTwzJ0hyam1IvmsNlU52cnJz4+HiRSGRhYaGnp1clVyAQJCYmZmZmamlp
-      WVtbS2nWweeCtOL+1Bc5ObnevXsHBQUJhcLqz1kXFxdVVVUS3LgJqUVG7fplRnOoRjk5ua5du0r1
-      EJTPBQ0NjSp+bLLHyMjIyMioaTW0b9+eWXmFIlWaQ3NTvgC0tbVreXZxOBxra2tra2tZSmq2NI3F
-      IxKJevfu3atXLzIBCsDz58/3798/evRoNpsdFBSkoqJy/PhxkiUUCjdv3lxaWlol0IO0qUVG7fpl
-      pvCzqEYKhUKhUChfLE01oP706VM3NzclJSVnZ2dHR0d1dfXvv/+ex+OR3E2bNmloaLRt27ZXr16t
-      WrWytbUNCQmRvchaZNSuX2ZItRqbm9sKhUJpztAnBqUB0Mvmc6eJ/SNzcnJSU1PZbLalpWUVXxY+
-      n5+SkpKbm6uvr29iYtJUCmuXUYt+WSKlamyebisUCqV5Qp8YlAZAL5vPnSb2j9TW1tbW1q4xi8vl
-      Noe4X7XLqEW/LGn+1UihUCgUCuXL44udOUihUCgUCoVCkSrUjqRQKBQKhUKhNARqR1IoFAqFQqFQ
-      GgK1IykUCoVCoVAoDaEh87V9Yp5JQwqFQqFQKBQKRZY0cr58c1kXkdIMoeEYKBRK3aFPDEoDoJfN
-      5w4d16ZQKBQKhUKhNARqR1IoFAqFQqFQGgK1IykUCoVCoVAoDYHakRQKhUKhUCiUhkDtSAqFQqFQ
-      KBRKQ6B2JIVCoVAoFAqlIXAl+3NCodDb21skEm3atInNrmqkvn79evPmza1bt/7hhx8ke9x6cfny
-      5cDAwAEDBnh5eVXPPXDgQFRU1PTp09u3by97bfhM6rAWEhISQkJC8vLyzMzMBg4cqKam1iQyhEJh
-      UFCQgoJC7969m0QAgFevXoWEhAwaNKhFixb/QQ0ikSg0NDQiIkIgEHTq1MnDw4PD4chYQ0lJycWL
-      FxMSEpSVld3c3Ozt7WUsgKE5XAyfNZGRkXl5edXTHRwcVFVVyXZxcfGFCxcSExMVFBS6du3q6urK
-      YrFI1oYNGzZs2HDr1q0OHTrITrRMyMvLi4yMrJ6uo6Nja2vL7L548eLSpUvp6enGxsb9+vUzMjJi
-      sjQ1NQcOHOjj4yMLuZ8DAoEgODj48ePHbDbb3t7ew8Ojyrs4Pj7+6tWrubm5RkZG/fr1MzAwYLK+
-      +uqrqKio1NRUmatuOkSSZsCAAQBu3rxZPWvLli0AVqxYIfGD1ouIiAgAvXv3rp5VVlampaWlpKRU
-      UFAge2EMzaQOj0Q/re+//PLLLywWS0tLq3PnziwWq2XLlhEREdLQVgvl5eWHDx+2trYGMHjwYBkf
-      nZCUlDR9+nQ5OTkAjx49+g9q4PF45DI2MTGxsLAA4Ojo+ObNG1lqSEpKateuHQA7Ozt9fX0A06ZN
-      EwqFstQgauqGkCUNeGLUnZ49e9b4CktNTSUFYmJiTExMOBxOp06dTE1NAbi7uzNP8pUrV36p9X/t
-      2rUaa2by5MlMmf3793O5XDU1ta5du6qrqysoKBw7dozJbcJHpUjKl00DyMnJ6dKlCwBLS0vSneTq
-      6ipuEixatAiAlpYWqUxlZeWjR48yuT179tTQ0GgK4U2G5O3Io0ePApgzZ071LBcXFwDx8fESP2h9
-      sbCwYLPZmZmZVdIvX74MYPTo0U2iiqGZ1GF9b29/f38AvXr1KiwsFIlEt2/fVlJSMjQ0JLuywdfX
-      18zMDAC5/2X/cMzOzh4zZgyHw1FSUiIvM9m/upqDhrlz5wJYsmQJsdu2bdsm4+YQCAQdO3Zks9ln
-      z54ViUSlpaUjR44EsG3bNplpaA4NIUukahCkp6eniJGcnKynp2dvb88U6Nixo4KCwr1798juhg0b
-      ACxatIjsfsF2ZHFxccqHrF27FkBAQAApkJ6erqCgYGVllZeXJxKJ3rx5Y2RkpK6uXlxcTApQO1Kc
-      +fPnA9i3bx/ZJRfSunXryO7p06cB9O3bl8fjiUSid+/eOTs7y8vLP3v2jBSgdqQE4PF4KioqRkZG
-      Vb77X79+zWKxHBwcJH7EBrBq1SoAf/75Z5X0GTNmADh//nyTqGJoJnVY39vb0dGRzWYzt5NIJFq+
-      fLn4DSkD9uzZ4+npGRwcnJub2yQPx9LSUnt7+5UrV2ZnZ5PnkexfXU2uIS8vT15evm3btnw+n0l0
-      dXUFkJCQIBsNFy9eBDBp0iQmJTc3V1VV1dDQUGZdkk3eEDJGlgbBnTt3AKxevZrsvn79esSIEczL
-      XiQSlZWVycnJ2drakl1xOzI6OvrAgQNHjx7Nzs6WmWBZ4uXlpaKiUlRURHafPXu2YsWKCxcuMAVm
-      zpwJICYmhuwyj0oejxcQELBv375bt27JTG1zsyMPHDjg7e3NPLsyMjIAjBw5kuwOGzYMQGxsLFM+
-      LCwMAPFGE4nZkQKB4MaNG/v27QsICCgtLZXtScgUyduRIpFo/PjxAMLCwsQTf//9dxl3BtTC06dP
-      ySeFeCKfz9fV1dXR0SkrK2sqYQzNoQ7rdXvn5OQAcHZ2Fk+MiYkBMHToUElL+zRNZUeK0xxMhybR
-      cOrUKQDLli0TT9y9ezeAHTt2yEbDvHnzAAQHB4snki7Jx48fy0aDOM3hYpA2sjQI5syZI24JVaes
-      rExRUdHGxobsEjvyzJkz/fr1A6CoqAigRYsWSUlJspIsIzIzM9lsNmP31MjQoUMBMH4mAL7++uu9
-      e/dqaWmRmgEwb948mehtdnZkFR4/fiw+PGhnZycnJycQCJgCAoGAw+Ew7z5iR16/ft3KyorL5XK5
-      XAAODg5fsCkplfnaY8eOBXDixAnxxJMnT7LZ7NGjR0vjiPWlbdu2Tk5OISEhb9++ZRJv3ryZnZ09
-      atQo4snUtDT/OqxCfHw8gM6dO4snWltbKysrx8XFNZEoStNAWrzKxeDg4MBk/Uc0UKSEQCDw8/Nj
-      3NdqxMfHp6SkhDgCMXzzzTc2NjbZ2dk8Hm/NmjVv377ds2eP9PXKFD8/P6FQSLrNauTChQvnzp3r
-      27evtra2eOK2bduOHz9eVFT06tUrY2Pj3bt3k6/x/zIFBQVLliwRf+3KycmVl5eXlpYyZdhstrq6
-      ekpKCpOSn58/bNiwhQsXFhYW5ufnDxgw4P79+0FBQbJWLyukYkd6enrq6+uTPglCVlZWaGiop6en
-      +LSmpmXcuHF8Pv/cuXNMChE8bty4phP1ns+iDsXJysoCUEUbi8XS09PLzs5uIlGUpqHGi4HMdJHZ
-      xZCVlcXlcsXflLLXQJESISEh2dnZtZhKV69enT17trq6+tKlS8XTd+3atWXLFh0dHTabPW3aNABJ
-      SUlSlytbfH195eXlBw4cWD3rxIkTHTt2HDly5MSJE319fcWzLCws7t696+npyWKxjIyMvvrqK4FA
-      IG4b/QcZOHCgsbFxWlqav78/80FCvkUvXbrEFIuNjc3NzS0qKmJS5OTkbt68OX36dAUFBSUlpQkT
-      JuBLvNIYpGJHcjic0aNHP3/+/MGDByTl1KlTQqGQ9LGJExcXFxAQEBgYmJiYWCWroKAgJCTkzJkz
-      N27cEG8hSTFq1Cgul3vy5EmyKxQK/f39zczMnJyc6i6jFv2NpC51mJ+f/7yStLQ0gUAg/gtlZWVM
-      7osXL8S/n6SHiopKlRR1dXU+ny+DQ1OaG1UuBnV1dQCyvBhqvBplrIEiDY4dOwZg+PDhNeaeOHFi
-      4MCB8vLyZ86cadOmjXgWMQIIJABTfn6+NJXKmtTU1LCwMC8vrxoDrvH5fBaLVVxcHBoaevv2bfEs
-      c3NzDQ0NZveLrJz6Qlxsk5KSAgICmKqYO3eunJzc7NmzL1++nJ+ff+3atcGDBzORpwhKSko2NjbM
-      7hdfmdKKQ07MHTKBF8Dp06eVlJTEPx9fv37t5OTUs2dPHx+fQ4cOOTk5eXh4MOHBdu7caWBgsHLl
-      ylOnTnl7e7ds2fLIkSOSVairq+vl5RUcHFxQUADg7t276enpY8eOZeKN1S6jdv0S4ZN1ePDgwbZt
-      2w4ZMmTIkCGOjo4aGhrjx49PT08nubGxsW3atOnbt++QIUM8PT3V1dU9PDzu3r0rQYXiEC8QUpni
-      vHv3TkFBQUoHpTRParwY3r17B0BmFwOXy63xapSlhubJsWPHfq1EvFvlc6G0tNTf379Vq1YkOEsV
-      du3aNWrUKBMTk/DwcHd391p+pzn4L0kc0stI3B+r8+2330ZGRsbExAiFwqFDh9YYdZLwRVZOfbl8
-      +XJaWtqyZcsOHTr03XffkUQbG5uzZ89yuVwvLy8NDY1BgwbNnz+/RYsWmpqaH/udL74ypWVHdu3a
-      1cLCggzL5ubmXr16tYrN7u3tXVBQkJKScvz48RMnTsTHxysqKpKwO0lJSfPmzdu9e3doaOjhw4fD
-      w8PXrVvn7+9fVlYmWZHjxo0rKysLDAxEpbkm3ttXu4xa9EuKT9YhADU1tcjIyMjIyJcvXz548CAh
-      IcHZ2Zm8LAl+fn6RkZGJiYnp6emtW7d2c3O7f/++BEUyGBoaAiBT28TJzMxsngPxFOlR48WQmZmJ
-      aoPdUtUgFAqrDGHLWEPz5Ny5c9sruXHjRlPLqTeBgYH5+fkjRoyonrV///65c+d6eHjcu3fPyspK
-      9tqanKNHj3I4nCFDhvyfvTsNaOpoG4d/ZYGwr7IvIiqLCIhipVpEBXFBZLEiBbR635Vqa61dKVbU
-      p7bqrbR2w61orZVFEBARZCmiiAtWhVbZKwgKCAET9i3L+2Fez/80wVRpchJhfp/IzCTnYjJJ5szM
-      mSOhjL29/ddff83j8U6ePElZYC8pZWXlqKio6dOnp6SkEONEixcvrq+vLy8vv379enNz87vvvvv4
-      8WNLS0v5hipHMrwvYmhoaFVVVVlZ2fnz53k8nsi6QzabbWRkREw8GRoaZmZmoqsp29raAADtAoi8
-      ++67aWlpysrK0o3Qz89PXV0d9SDT0tJcXV1tbW2JXMlhSIhfiiTXoQhbW9vU1NSmpqYjR46I5+rp
-      6cXGxtrZ2W3fvl26QRJHZzKZJSUl5MSKior+/n7yPRWwsQC94yKN4c6dO0TWGIlBMcXFxXGf2rNn
-      j7zDeWFoUlt8yO3u3bvvvPPO3Llzs7Ky5HUbLfkqLy+/e/euh4fHP94zCXWy8ULh52RnZyd8uicJ
-      QqfT7e3t3dzcNDU1y8vLBwcHyUsmxhrZ9iMBIDU1NSUlRV9fX+QmhGvWrCkoKFi9erX40PqMGTMc
-      HBxCQ0NjY2O7u7tlF6GamlpgYOCFCxeuX79eW1sbEhLy/GFIiF+KJNehOHNz87lz5168eHHYXAaD
-      sWrVqkuXLgkEAqmHqq6uvnDhwhs3bpBXE6NlAH5+flI/HKbIPDw8dHR0EhMTh4aGiMRTp04xGIxh
-      l//LAhqS+fXXX4kUDoeTmZlpb28/efJkamLApK67uzsjI8PIyEjkQmwA+OSTTwDgl19+kfqIw8sC
-      TWqLLxv98ssvWSzW8ePHiRS0ZcEYH5gfVm9vr4GBwYQJE8jXG1RUVNDpdAMDAwCIj4+3sLD46aef
-      iFxU7RKu+hr1ZNiPRHvrnDp1KicnR3wzndDQ0Nzc3IcPH7q4uNjZ2e3evZuYBVNWVi4qKgoJCYmM
-      jDQwMAgKCkJbCstCaGhoT0/Pxo0bxffTkRyGhPilSHIdDsvKyqqpqUlCbl9fn3TXcRKioqJoNNqq
-      Vauqq6t5PF5CQkJ0dLSTk9NY/oCNTSwWKzIysq6u7q233mpvb+/q6oqIiLh27drbb7+Nprwp8Mor
-      ryxZsuTUqVPff//9wMDAw4cPg4ODe3p60D0IsJdUWlpaf3+/v7+/yP2OGxoacnJyrKysLl26dIIE
-      3RtsjIiPj6fRaOKT2mii7PPPP7969SqPx/v9998/+ugjBoMhfuUrpqam5uPj8+DBgy1btnA4HC6X
-      u3379pKSkoCAAHSVnre3d19f39atW4uKivr7+5OTk6Ojo729vdF9FsYome5O+eOPP6KjXL169Vll
-      6urqdu3aZWFhgaaYyVmDg4Pnzp0LCAig0Wjz588nbuIkRTweD20FsnDhwmeVkRyGhPilQkIdHjhw
-      QPz+S//5z3+cnZ2FQiGa0RPZ9xgtiOFwOM9z6BFsD3vmzBl00obMnTv34cOHL/oiUoH3IZdvDAKB
-      YNu2bcTIENpmheKdeLlcLvk3VUNDIyYmhsoAyBShMcgaBRtKo13Ec3JyRNKftdSP+IYc9r6IAODh
-      4SHrmKlx48YNAHj11VeHzb1w4YK5uTlRLUZGRsnJyUSu+Fclqq6CggKZxowo2j7kPT09YWFh5Ctu
-      AwMDyT+axcXF5H0Ali5d2traSuSK3xcR3QB9x44dlP0LFKMJhcIX73xK39DQkJ+f3+3bt9FCeBFF
-      RUXu7u4HDx7cuHEj9bE9TxiS45eRb7/9dufOnSKDi+7u7rq6uufOnSstLXVxcSkpKZk2bRqRGxUV
-      9f3333O5XPKH5Fniyu6HOkx80aiGhoZKS0u7u7utrKxENt3AxpqOjo579+4JBAI7OzvyCQaVGhsb
-      a2pqVFRUnJ2dVVVV5RLDGDGybwyMGnw+v7Kyks1m6+npTZkyBW2qoAgUs9m0t7dXVlYKhUIbGxtD
-      Q0ORXIFAUFZW1tnZaWVlZWZmJpcIFYeitCQlJaUFCxbk5OQIBAKRCQsAmDNnjoaGBtrcWI4khCE5
-      fspUVlZeu3aNGMIU0d/fHx8fv3jx4ufpRI6YkpLSzJkzZff62EtEW1tbfB0bxczMzPAXPYYxGAzy
-      poaYZPr6+hK+u+h0uqOjI5XxKDL59HiEQuGCBQvmzZtHXAD14MGD2NjY4OBgOp2ek5Ojrq6elJSE
-      sgQCwf79+wcGBobd6EF2JIQhOX4qgyTweLy8vDwfHx9nZ+d169aJF7h7966fn197e/uuXbuoDw/D
-      MAzDsNFHPp0eGo32008/CQQCCwuLOXPmuLm5OTs7e3l5oWugFi1atHPnzvDw8EmTJs2fP9/KyurX
-      X3/Nzs6m+FxKQhiS46dSR0eHjo6Ojo6OhobGO++8ExQUdOnSJRUVFaKAu7u7jo6Oqqqqt7e3kZHR
-      rVu3bGxsKA4SwzAMw7BRSc7rI9vb2+vr6+l0uq2trcjSJR6PV1dXx+FwjIyMxo8fL68IJYchIf5R
-      QDGXrWAYppjwNwY2ArjZvOzkvD5SX19fX19/2Cwmk6kI27xJDkNC/BiGYRiGYaOb3K4IwTAMwzAM
-      w15quB+JYRiGYRiGjQTuR2IYhmEYhmEjgfuRGIZhGIZh2EiM5HrtuLL7sggFwzAMwzAMo9K/vF5e
-      Ue6LiCkgvB0DhmHPD39jYCOAm83LDs9rYxiGYRiGYSOB+5EYhmEYhmHYSOB+JIZhGIZhGDYSuB+J
-      YRiGYRiGjQTuR2IYhmEYhmEjgfuRGIZhGIZh2EgwpftyAoEgIiJCKBTu27ePThftpDY2Nu7fv9/S
-      0vLDDz+U7nGfX11d3XfffWdjY/POO++I516+fDktLW3BggXLly+nPjaC4lejBFVVVfn5+Vwu19ra
-      2sfHR1NTUy5hCASCnJwcFou1YMECuQQAAI8ePcrPz/f19dXT0xuDMQiFwqKiops3b/L5/GnTpnl6
-      ejIYDIpjQLq7uzMzMx0dHadMmUL90dlsdmZmZlNTk4GBwZIlS8zNzamPYRQoLS3lcrni6a6urhoa
-      GiKJFRUVxcXF06ZNmzZtGkrZu3fv3r17r1y54ujoKPNYqcXlcktLS8XTx40bN3XqVPR3X19fcXGx
-      SIF58+ahP3R0dHx8fOLi4mQZ5kuDz+fn5ub+8ccfdDrdxcXF09NT/FcYAAoLC1NTUwEgMjLSyMiI
-      nLVs2bK7d+/W19dTFLHcCaVt6dKlAFBYWCieFR0dDQBRUVFSP+jz6+/v19XVVVdX7+3tFc9dtmwZ
-      AOTn51MfmAhFqMZT9/560ads376dRqPp6upOnz6dRqOZmJjcvHlTFrFJMDQ0dPLkSXt7ewDw8/Oj
-      +OhITU1NeHi4kpISAJSUlIzBGHp6elAbHj9+vI2NDQDMmjWrra2N4jA4HM6XX36pr68PAAcOHKD4
-      6EKh8Ny5c5qamkpKSq6ururq6iwWKzY2lvowqDGCb4zn5+HhMexPWH19vUjJoaEhBwcHANixYweR
-      uGPHDjl+GGWqoKBg2JpZt24dUeby5csiuXp6ekSuHL8qhTJuNi+qvb19xowZAGBra4tOO1977bWu
-      ri7xkkuWLNHR0QGAb775RiTLw8NDW1ubkngVgvT7kfHx8QCwadMm8aw5c+YAQGVlpdQP+kLCw8MB
-      4MyZMyLpXV1dLBbL1NSUz+fLJTAyRajGF/14p6SkAMC8efO6u7uFQuHVq1dVVVVNTU3RQ2okJCRY
-      W1sDAPoKoP7Lkc1mh4SEMBgMVVVVKysrufx0KUIM7733HgB8+umnAoFAKBQeOHCA+rdj69at2tra
-      NBrNzs5OLv3IhoYGNTU1ExOTmpoaoVDY3Nxsa2tLp9Nv3bpFcSTUkGmHoLm5uY6ktrbW0NDQxcVF
-      vOS3335Lo9HGTj+yr6+v7u+++uorAEhPTyfKxMbGAsCNGzeIMo8ePSJycT+S8P777wPAkSNH0MO9
-      e/cCwO7du0WKtbS0MBiMLVu22NraTp8+XSR3rPUjpb8+0s/PT11dPS0tTfj3O+U0NTVdu3bN1dXV
-      1tZW6gd9IaGhoQCARqTJzp8/PzAwEBISMuwgNsUUvxrFoVn4Y8eOqaurA8Ds2bM/+uijpqYmKqdL
-      0Hx6bm7u1atXKTsomZaWVkVFxbZt2xoaGvz8/MZmDB0dHUeOHJk4ceLu3bvRF77WYAAAIABJREFU
-      L/qWLVtee+219PT06upqysJ4+PDhihUrysrK9uzZQ9lByWJiYnp7e/fs2TNp0iQAMDY2jomJEQgE
-      X3/9tVzieakZGxtbkTx+/Li1tTUgIECkWGtr6/bt24OCgiS8VFlZ2fHjxxMSEtra2mQZMkVUVFSs
-      /u7y5cvq6uoLFy4kylRVVampqc2aNYsoY2ZmJv5Svb29586dO3r0aFFREYX/gQJxcnKKiIj473//
-      ix6uXbsWAEpKSkSKJSYm8vn85cuX+/v737lzp6KiYthXEwgEhYWFR48ePXfu3ODgoCwDlytZdE5X
-      r14NANevXycnfv/99yCnqSURAoHA0tJSS0urv7+fnB4YGAiKdMIq92p8odPE9vZ2AJg9ezY5says
-      DAACAgKkHdo/43A4INeTbOHTU1v5tii5xIBO0rZu3UpOjImJAYDvvvuOykiQtLQ0uXz5ODk5KSkp
-      kcfjBQKBoaGhrq4uxZFQg8qBpU2bNgFAWVmZSPq6desmTpyYm5sLw41Hnj17dvHixQCgoqICAHp6
-      emioeDRpaWmh0+krV64kJ/r5+Tk5OT3rKQCwfPnyw4cP6+rqopoBgM2bN8s+WKFQwcYjRfzxxx8w
-      3MTgzJkzdXR0BgcHr127BgCRkZHkXDQeeenSJTs7OyaTyWQyAcDV1XVgYIDC2Kkjk4E3NOCXnJxM
-      Tjxz5gydTg8ODpbFEV8IjUYLCQnp7OxE3zVIb29vVlbWlClTiHXZcqfg1SiisrISAKZPn05OtLe3
-      V1NTe9a5GjZaoXdcpDG4uroSWWNERUWFra0tGp5HaDTajBkzOBxOS0uLHAN72fH5/NOnTxMr2AjF
-      xcUnTpzYtm0bWhYsbtWqVQ4ODmw2u6enZ9euXU+ePDl06BAlIVPn9OnTAoEADYsQampqbGxsLl68
-      +OWXX+7fvx99XZNlZWUdOHAgKSmpt7f30aNH5ubmMTEx6Gx8zOrq6vr000/Ff3Crq6t///13Hx8f
-      JSWlWbNmmZiYxMfHC/8+c9jZ2RkYGPjBBx90d3d3dnYuXbr01q1bOTk51P4HFJFJP9LLy8vIyIg8
-      cdza2lpUVOTl5WVsbEwuWVFRkZ6enpmZKT7b1dXVlZ+ff/bs2cuXL/f29ko3wrCwMPj71PaFCxf6
-      +/tROhHzg6fYbLbIK3R2dhK5TU1NfD5fuhHCy1CNZK2trQAgEhiNRjM0NBSvPWx0G7YxoEsax05j
-      4HK5Q0NDIpUAY68eZCE/P5/NZot0lQQCwaZNm5ycnNasWfOsJ/7444/R0dHjxo2j0+nr168HgJqa
-      GpmHS62EhARlZWUfHx8ihc/n19TUXLhwYdWqVXl5ebt27XJwcDh48CD5WTY2NsXFxV5eXjQazczM
-      bNmyZXw+v66ujvLwFYWPj4+5uXlTU1NKSgq6JoFw6tQpAEBrKuh0up+fX319/ZUrV8hllJSUCgsL
-      w8PDWSyWqqoqapOjr7EhMulHMhiM4ODgBw8e3L59G6WkpqYKBAI0wIY0Nja6ubl5eHjExcWdOHHC
-      zc3N09OT2Nbhhx9+MDY23rFjR2pqakREhImJCXrnpMXBwcHZ2Tk9PX1oaAiloGG/kJAQokx4eLiz
-      s7O/v//y5cvt7OxMTEyioqKIJQ7Hjx+fOHGiv7+/v7//rFmztLW1V69e3dzcLMUgFb8axZGHXhAt
-      LS0ejyfTg2KKSaQxaGlpAcBYawzDfiJg7NWDdCUmJgLAihUryInHjh27devWt99+K2GBOxoUR9BO
-      WJ2dnTILUw7q6+uvX7/u7e1N3nCNw+E4ODh4eno2NDRcvny5pqZm4sSJ7733XlVVFVFm8uTJ2tra
-      xMNRWTkvZHBwUElJqaamJj09nVwPQqEwLi5OVVUV7UcBAOh8RuS3VVVVFW0agIzu+pTVBSWor4Mu
-      4AWAtLQ0VVVV8uljREREV1dXXV1dUlJScnJyZWWliopKXl4eANTU1GzevDkmJqaoqOjkyZM3btzY
-      vXt3SkqKdJephoaGcjgctGPCwMBAVlaWu7v7+PHjyWXmz59fWlr6559/trW1nTx58vDhw+TxbU1N
-      zdLS0tLS0ocPH96+fbuqqmr27NkdHR3SDRIUuxoJaAlIV1eXSHpHRweLxZLFETGFNWxjQB+NsdMY
-      JHwiQK71kJiYuPOp7OxseYUxYgMDAykpKRYWFmh/FoTD4Xz++eeBgYHEnoj/6Flz3y+1hIQEeDpU
-      Rhg3blxJSUl6erqqqioAGBkZbdu2TSAQnD59+lmvMyor54Xk5eU1NTVt3br1xIkTxGU3AHD9+vXa
-      2lobG5ucnJyzZ8+ePXuWy+Uymczk5OSBgYFnvdrork9Z9SNnzpxpY2OD5mQ5HM7Fixf9/PzIu8Wy
-      2WwjIyPiZN3Q0DAzM3PlypUAgK6hQ7u3IO+++25aWpqysrIUIwwJCaHRaCjCvLy8rq4u8jifCBqN
-      tnDhwoMHD6alpd28eVO8gK2tbWpqalNT05EjR6QYpOJXI8HU1BQAHj9+LJLe0tIiPrWHjW7DNga0
-      InDsNAYNDQ1NTc1hPxEg13rIyMj49inxbQUVX2ZmZmdn5+uvv05O/P7779lsdmdn59q1a9euXYu2
-      azl79iy63nbsiI+PZzAY/v7+kou98sorAFBbW0tJUC8rZWXlqKio6dOnp6SkELN8aNyxtrZ27VPr
-      169nMplcLjcrK0uu8cqNDDe4CQ0NraqqKisrO3/+PI/HIy89BIA1a9YUFBSsXr1afCP+GTNmODg4
-      hIaGxsbGdnd3yyg8MzOzefPmpaWlCQQC1LtC3S8JAgICVFRULl68OGyuubn53Llzn5U7YgpejQRb
-      W1smkymyP0JFRUV/fz9xTwVsjEDvuEhjuHPnDpE1RkydOrWmpob86RMKhSUlJaamprq6uvKKKi4u
-      jvuUvHZE+jfQpLbIkNvkyZPffPPNYfeyGTvKy8vv3r3r4eEhcvMqoVDY0tJCXsSPFnShIXNMMjs7
-      O+HTDUmGhoaSkpK0tLTYbDaX5Pz58wDw66+/yjtY+ZBtPxIAUlNTU1JS9PX1vb29RXJzc3MfPnzo
-      4uJiZ2e3e/du4sRdWVm5qKgoJCQkMjLSwMAgKCjowoULsogwLCystbW1sLAQbQbxjzeOYzKZaOHt
-      swpYWVlJyB0Zxa9GBG1XduPGDfJSYnTqJq9tFDF58fDw0NHRSUxMJNYfA8CpU6cYDAZ5+f+o5+/v
-      PzQ0RJ49/O2331paWvAnYsS6u7szMjKMjIxELn0ICQk5QfLZZ58BgL+//4kTJ+QTqDygSW2RZaMA
-      8MEHHxgbG5PXMKDtdZ2dnakMT/H19vYaGBhMmDCB3OeuqKig0+kGBgYAcOHChfb2dh8fH5F1KfPm
-      zTMwMMjMzBybV7jLsB85ceJENze3U6dO5eTkBAUFia8PWLhw4aVLl+rq6sLCwg4fPjxp0iTi2mQd
-      HZ3//e9/TU1NSUlJPB7Px8dnwYIF/f390o1wxYoVLBZry5YtT548kTCpTSYQCCQs4pacOzKKX42E
-      qKgoGo22atWq6upqHo+XkJAQHR3t5OQkclklNuqxWKzIyMi6urq33nqrvb29q6srIiLi2rVrb7/9
-      NpryHiPefvttY2PjTz75JC8vTygUFhcXh4eHq6urf/LJJ/IO7WWVlpbW39/v7++vCHeLUDTx8fE0
-      Gk18Unvz5s1qamoffPAB2u6nsLBwx44d+vr65OtKMQBQU1Pz8fF58ODBli1bOBwOl8vdvn17SUlJ
-      QEAAujwO3VNDvKfOYDACAwMHBwdF9ukbI2T7UQwLC6uurhbZT0eElZXVtm3b7t+/P3fu3I0bN5Kz
-      lJSUfH19U1NTCwsLCwoKfv75Z+mGp62t7evr+8cff2hpafn6+v5j+f7+/oaGBktLy2cVqK6ulpA7
-      YgpejYRXX301KSnp0aNHtra2SkpKISEhbm5umZmZePZkDPrkk0+2bduWmJg4btw4LS2t6Ojo9evX
-      o7sjjh3a2tp5eXkWFhbe3t50Ot3NzQ0AsrKyJkyYIO/QXlbohrH41FRccXFxbW2tm5ub+KmatbX1
-      hQsXeDyevb09k8n08PDQ19fPyclB953HyA4ePBgWFhYTE6Onp6erq7tr167AwEB0V8mOjo5z586p
-      q6sTV2qToXVxst4RRUHJcxP0v9u/fz+dTh/23tYCgUBDQ2Pnzp1UxuPn5ydyN5SjR48CQHl5uVAo
-      PHDggMgNNNHo98GDB6kMUpwUq3FktxkYHBy8efPmxYsXa2trR/B0bDThcrlFRUWFhYWtra3yjkWe
-      ysrKLl68WFpaOuwHc9RQ5BuTYHw+/969ewUFBdXV1fKO5W8UsNm0tbUVFRVduXKlpaVF3rG8BOQz
-      UCQUCj09PQUCAVrzBwAPHjyIjY0NDg6m0+k5OTmBgYE///wzukeqQCCIjo4eGBgQuUCPSt3d3YmJ
-      ie+///7GjRvt7e1Fcnk8XkFBwYYNG5ydndetW0dZVIpZjUpKSjNnzpTpIbCXhba2tsg6trFpypQp
-      IndewTCK0el08o6GmAT6+vr4i+v5yacfSaPRfvrpp3Xr1llYWLi4uPD5/IqKitWrV+/btw8AFi1a
-      tHPnzvDw8K1bt1pYWNy/f19bWzs7O5v6z0BmZqaOjg4AoIuODxw4EB4eTuR2dHQQuRYWFkFBQZGR
-      kcTNSSnwslQjhmEYhmGjEk3495tCUqy9vb2+vp5Op9va2qItUgk8Hq+uro7D4RgZGYlsD46JkFE1
-      xpXdD3WYKNVIMQwbtfA3BjYCuNm87OR8AYS+vv6zlvoymczJkydTHM9LClcjhmEYhmHUw1snYBiG
-      YRiGYSOB+5EYhmEYhmHYSOB+JIZhGIZhGDYSuB+JYRiGYRiGjQTuR2IYhmEYhmEjMZJ9f+LK7ssi
-      FAzDMAzDMIxK/3LfJTnvH4kpMrytF4Zhzw9/Y2AjgJvNyw7Pa2MYhmEYhmEjgfuRGIZhGIZh2Ejg
-      fiSGYRiGYRg2ErgfiWEYhmEYho0E7kdiGIZhGIZhI4H7kRiGYRiGYdhIMKX7cgKBICIiQigU7tu3
-      j04X7aQ2Njbu37/f0tLyww8/lO5xn19dXd13331nY2PzzjvviOdevnw5LS1twYIFy5cvpz42RPHr
-      ULKqqqr8/Hwul2ttbe3j46OpqSmXMAQCQU5ODovFWrBggVwCAIBHjx7l5+f7+vrq6emNwRiEQmFR
-      UdHNmzf5fP60adM8PT0ZDAbFMSDd3d2ZmZmOjo5TpkyRSwCgGI3hpVZaWsrlcsXTXV1dNTQ0iIdX
-      r169ceMGg8FwcnKaP38+jUZD6Xv37t27d++VK1ccHR0pipgqXC63tLRUPH3cuHFTp04FgAcPHjx4
-      8EC8wKRJk8zNzQFAR0fHx8cnLi5OxpG+HPh8fm5u7h9//EGn011cXDw9Pck/xPv3729sbCQeqqmp
-      WVtbz50718bGhkhctmzZ3bt36+vrKY1bjoTStnTpUgAoLCwUz4qOjgaAqKgoqR/0+fX39+vq6qqr
-      q/f29ornLlu2DADy8/OpD4xMQerw1L2/XvQp27dvp9Fourq606dPp9FoJiYmN2/elEVsEgwNDZ08
-      edLe3h4A/Pz8KD46UlNTEx4erqSkBAAlJSVjMIaenh7UjMePH4++YWfNmtXW1kZxGBwO58svv9TX
-      1weAAwcOUHx0RBEaAzVG8I3x/Dw8PIb9Cauvr0cFhoaGXn/9dQCws7ObNGkSAHh5eRHf8zt27Bit
-      9V9QUDBszaxbtw4VQP+7uF9++QUVkONXpVDGzeZFtbe3z5gxAwBsbW3Raedrr73W1dVFFHB2dkbV
-      5efnt3jx4mnTpjGZTAAICgoaHBxEZTw8PLS1teX0H8iB9PuR8fHxALBp0ybxrDlz5gBAZWWl1A/6
-      QsLDwwHgzJkzIuldXV0sFsvU1JTP58slMIKC1OGLfrxTUlIAYN68ed3d3UKh8OrVq6qqqqampugh
-      NRISEqytrQEAfQVQ/+XIZrNDQkIYDIaqqqqVlZVcfroUIYb33nsPAD799FOBQCAUCg8cOED927F1
-      61ZtbW0ajWZnZyeXfqQivBFUkmmHoLm5uY6ktrbW0NDQxcWFKLB7924AOHbsGHr45Zdfkk+5R3E/
-      sq+vr+7vvvrqKwBIT09HBTgcjkgBX19fBoPR3t6OCuB+JOH9998HgCNHjqCHe/fuBYDdu3cTBVA/
-      kvyUx48fo9/lmJgYlIL7kf9WT0+Purq6mZkZ+v0gNDY20mg0V1dXqR/xRV2+fBkAQkJCRNITEhIA
-      4OOPP5ZLVGQKUocv+vGeNWsWnU6/f/8+kbJt2zbyZ5IChw4d8vLyys3N5XA4cvlyHBgYcHFx2bFj
-      B5vNRl9J1P90yT0GLperrKw8ceJEHo9HJL722msAUFVVRVkYq1ev/s9//lNeXp6WliaXfqTc3wiK
-      UdkhuHbtGgB88cUX6CGfzzc0NJw5cyZRYHBw8OTJkzdu3EAPyf3Ie/fuHTt2LD4+ns1mUxYwlby9
-      vZ815yYUCvv6+rS0tBYsWECkEF+VPT096enpR44cuXLlCkWxKlg/8tixYxEREcQX1+PHjwFg5cqV
-      RAHxfqRQKMzNzSUPABP9SD6ff/ny5SNHjqSnpw8MDFDyH8iBlNdHAoCamlpgYOCvv/5aXFzs5uZG
-      pKekpAiFwtDQUKkf8UW5u7tbWlqeP39+YGCAxWIR6cnJyQCgCBEqfh2Ke/LkSXFx8ezZs9FwIPLG
-      G298+eWX2dnZaAyYAhs2bNiwYQMADLuUigLKysp37tyRy6EVJ4aLFy8ODg6uWrWKvCDyjTfeKCoq
-      ys7OJi8kkqmTJ0+iP6qqqqg5ogi5vxGjGJq0WbFiBXpYUlLS2tr69ttvEwWUlJRWr14t8qz6+vrI
-      yMjs7GwVFZX+/n49Pb3i4mI0CT5qtLa2/vbbbytWrFBVVR22QGZmZmdnJ1F1iFAoPHLkSGRkZF9f
-      X39/PwBs3rz5u+++oyJiRfKf//yH/LClpQUAjIyMJD+Lx+MBgJqaGjnx8uXLGzZs+Ouvv1ABV1fX
-      q1evKisrSzliBSCT67VRRwd1ywhnzpyh0+nBwcGyOOILodFoISEhnZ2d6BwC6e3tzcrKmjJlyrRp
-      0+QYG0HB61BcZWUlAEyfPp2caG9vr6amVlFRIaegMPlA77hIY3B1dSWyMOzf4PP5p0+fJlawAUB5
-      eTkA2NjYNDc3x8bGfv311xkZGYODgyJPXLVqlYODA5vN7unp2bVr15MnTw4dOkR19DJ2+vRpgUAQ
-      GBj4rALx8fE0Gs3f35+cmJWVdeDAgaSkpN7e3kePHpmbm8fExKBZnTGrq6vr008//cff3Obm5l27
-      dikpKa1du5ZI7OzsDAwM/OCDD7q7uzs7O5cuXXrr1q2cnByZBy0P0h+PBAAvLy8jI6PU1NSvv/4a
-      pbS2thYVFXl5eRkbG5NLVlRUVFdXM5nMyZMni4xSdHV13bx5s6urS1dXd+bMmSI9/X8pLCxs7969
-      qampvr6+KOXChQv9/f1hYWFEmdbW1t7eXvS3urq6gYEB+RU6OzufPHmC/lZWVjYyMpLutajPU4eS
-      YxgcHGxqakJ/0+l0IyMj8uCr1LW2tgKAyPtLo9EMDQ3ZbLbsjospoGEbAzqnx40B+/fy8/PZbPZb
-      b71FpKBLaG/fvh0eHm5hYdHf39/Q0GBtbZ2dnT158mSi2I8//kg8a/369VFRUTU1NRQHL2sJCQnK
-      yso+Pj7D5nZ0dGRlZbm5uZmampLTbWxsrl27pq2tDQBmZmbLli07fPhwXV2drq4uFUErHh8fn6Ki
-      ovHjx6ekpKDlj2SoF97X18dms2tqary8vAoLC9GpMqKkpFRYWOjg4IAerlmzJisra/Q1NkQm45EM
-      BiM4OPjBgwe3b99GKampqQKBgDwh29jY6Obm5uHhERcXd+LECTc3N09PT2Iu8ocffjA2Nt6xY0dq
-      ampERISJicmpU6ekGKGDg4Ozs3N6evrQ0BBKQSN/ISEhRJnw8HBnZ2d/f//ly5fb2dmZmJhERUUR
-      J7jHjx+fOHGiv7+/v7//rFmztLW1V69e3dzcLK0In6cOJcdQXl4+YcKERYsW+fv7e3l5aWlpeXp6
-      FhcXSyvCYamrq4ukaGlpoTF/bKwRaQxaWlrwdAIIw/6NxMREIE1qAwCaiv35558zMzOrqqrq6+tj
-      YmJqa2tFprbJv/RoA6bOzk6KgqZEfX399evXvb29n7XhWnp6en9/v8ikNgBMnjwZdSKRUVk5L2Rw
-      cFBJSammpiY9PV28HqysrKysrOzt7R0dHcePH5+RkbFr1y40hY2oqqoSnUgY7fUpq33IUXcHXcAL
-      AGlpaaqqquSR9oiIiK6urrq6uqSkpOTk5MrKShUVlby8PACoqanZvHlzTExMUVERWii9e/fulJQU
-      8UmKfxkhh8NBOyYMDAxkZWW5u7uPHz+eXGb+/PmlpaV//vlnW1vbyZMnDx8+TB7f1tTULC0tLS0t
-      ffjw4e3bt6uqqmbPnt3R0SHFCEFiHT5PDKdPny4tLa2urm5ubra0tHR3d79165a0IiRDex90dXWJ
-      pHd0dMh0HBRTQMM2BtQscWOQu8TExJ1PZWdnyzucFzYwMJCSkmJhYYH2ZyH78MMP58+fj/5+5513
-      5syZU1xcfP/+/WFfB+3ENMqgq0UDAgKeVQCtK5VQABmVlfNC8vLympqatm7deuLEif/+978iud8+
-      9csvv9y7d+/MmTN5eXmenp59fX3Dvtrork9Z9SNnzpxpY2OTmpoKABwO5+LFi35+fuTdYtlstpGR
-      ETFiYWhomJmZuXLlSgBoa2sDAPLlGu+++25aWpp0F6iGhITQaDQUYV5eXldXl4TrV2g02sKFCw8e
-      PJiWlnbz5k3xAra2tqmpqU1NTUeOHJFWhP9Yhy8Ug56eXmxsrJ2d3fbt26UVIRmaJUFXt5G1tLSI
-      zG9io96wjQGtWMeNQe4yMjKIX0G0ecXLBV0mgraKJKCxNFtbW3LizJkzAWDYLbhHq/j4eAaDIbL2
-      kYAuwXFxcSH/vGLPoqysHBUVNX369JSUFMkXbvr7+wcHBzc0NFy8eJGy8BSHDO+LGBoaWlVVVVZW
-      dv78eR6PR156CABr1qwpKChYvXq1+Eb8M2bMcHBwCA0NjY2N7e7ullF4ZmZm8+bNS0tLEwgEqJOK
-      erESBAQEqKioPKuhmJubz507V7rNSHIdvmgMDAZj1apVly5dEggEUgwSsbW1ZTKZJSUl5MSKior+
-      /n50TwVs7EDvuEhjQFcu48Ygd3Fxcdyn9uzZI+9wXhia1BYZUZs4cSIAPHz4kJyIli2NnSHw8vLy
-      u3fvenh4POueSWfOnOHz+f84GImR2dnZCYXC9vZ2ycXQ+m8pTki+RGTbjwSA1NTUlJQUfX19b29v
-      kdzc3NyHDx+6uLjY2dnt3r2bGL1QVlYuKioKCQmJjIw0MDAICgq6cOGCLCIMCwtrbW0tLCw8e/bs
-      4sWL//F+ZUwm09zcnLh4RZyVlZWE3BGQXIcjiMHKyqqvr08We+Koq6svXLjwxo0b5KXEaFWrn5+f
-      1A+HKTIPDw8dHZ3ExERi/TEAnDp1isFgPGv5P4Y9j+7u7oyMDCMjI5FLHzw8PJSVlc+dO0ek8Pn8
-      vLw8JSUlJycnysOUDzSpLb728fkLjHG9vb0GBgYTJkzg8/lEYkVFBZ1OF7nQVkRHR8eZM2cAYPTd
-      dfN5yLAfOXHiRDc3t1OnTuXk5AQFBYmvD1i4cOGlS5fq6urCwsIOHz48adIkNIcLADo6Ov/73/+a
-      mpqSkpJ4PJ6Pj8+CBQvQSmopWrFiBYvF2rJly5MnT55zU0aBQCB+z+vnzB2Bf6zDEUQIANINkhAV
-      FUWj0VatWlVdXc3j8RISEqKjo52cnCTsQIGNSiwWKzIysq6u7q233mpvb+/q6oqIiLh27drbb78t
-      cpUohr2QtLS0/v5+f39/kS8xbW3t9evXX7lyJSIigsPhoL0kq6ur169fjy7wGguG3dCH0NDQUFRU
-      RN4sCROhpqbm4+Pz4MGDLVu2cDgcLpe7ffv2kpKSgIAAkVZ06dKlS5cuFRQUpKamfvHFF05OTg8e
-      PHjrrbfGZj9SJvv+EMLCwjZt2oT+eFYZKyurbdu2RURE+Pn5bdy4kdznUFJS8vX19fX1LSoqcnd3
-      //nnnzdu3CjF8LS1tX19fc+cOaOlpUVsACQB2kvC0tLyWQWqq6sl5I7M89Th88dQXV2tpaVFvi5P
-      il599dWkpKSNGzcSq5Tmzp0bFxeHrrrAxpRPPvmkq6tr3759aDNwOp2+fv16dHdEDBsxdJnIsKem
-      33zzzcDAQHR09L59+wCAwWCEh4ePnSZXXFxcW1v76quvPutUDQ1G4rN6yQ4ePMjn82NiYn788UeU
-      EhgYGBsbK1KMuJwLAIyNjWfMmLF///5/XBo3asn3djpk+/fvp9Ppw97bWiAQaGho7Ny5k8p40I3Y
-      ySlHjx4FgPLycqFQeODAAZEbaKLR74MHD1IWoeQY0Oo08n3Y+vr6rK2tg4KCnvP1R3a7qsHBwZs3
-      b168eLG2tnYET8dGEy6XW1RUVFhY2NraKu9YMJlThBvcPXny5Nq1a9evX3/y5Im8Y8GeiyI0GxFt
-      bW1FRUVXrlxpaWmRdywvAfkMFAmFQk9PT4FAgJb9AcCDBw9iY2ODg4PpdHpOTk5gYODPP/8cFBQE
-      AAKBIDo6emBgQOQCPSp1d3cnJia+//77GzdutLe3F8nl8XgFBQUbNmxwdnZet26dXCL8xxju3r37
-      8ccft7e379q1S6aRKCkpocskMUxbW1t8C18Mkx1dXd1XX31V3lFgLzd9fX38xfX85NOPpNFoP/30
-      07p16ywsLFxcXPh8fkVFxerVq9F8xKJFi3bu3BkeHr5161YLC4v79+9ra2tnZ2eTd/WkRmZmpo6O
-      DgCgi44PHDhAvk90R0cHkWthYREUFBQZGamiokJlhP8Yg7u7O4PBGBjLC5jEAAAgAElEQVQY0NHR
-      Wbhw4a1bt0bZzWQxDMMwDJMXmlAolOPh29vb6+vr6XS6ra2tyE3leTxeXV0dh8MxMjIS2R4co0Zc
-      2f1Qh4nyjgLDsJcD/sbARgA3m5ednC+A0NfXR/Pa4tBNtymOB8MwDMMwDHtOMtz3B8MwDMMwDBvF
-      cD8SwzAMwzAMGwncj8QwDMMwDMNGAvcjMQzDMAzDsJHA/UgMwzAMwzBsJEay709c2X1ZhIJhGIZh
-      GIZR6V/uuyTn/SMxRYa39cIw7PnhbwxsBHCzednheW0MwzAMwzBsJHA/EsMwDMMwDBsJ3I/EMAzD
-      MAzDRgL3IzEMwzAMw7CRwP1IDMMwDMMwbCRwPxLDMAzDMAwbCaZ0X+7QoUNVVVWbN2+2trYWz42M
-      jOzv79+7dy+LxZLucV9IXl5eZmbm0qVLvb29xXOPHTt29+7d8PDwKVOmUB8bIhAIIiIihELhvn37
-      6HTRvn5jY+P+/fstLS0//PBDuYQnWVVVVX5+PpfLtba29vHx0dTUlEsYAoEgJyeHxWItWLBALgEA
-      wKNHj/Lz8319ffX09MZsDPJ9I/r7+y9cuFBVVaWmpubu7u7i4kJ9DGw2OzMzs6mpycDAYMmSJebm
-      5tTHMAqUlpZyuVzxdFdXVw0NDfR3Z2dnZmZmXV2dqqrqK6+8Mnv2bBqNhrL27t27d+/eK1euODo6
-      Uhc0JbhcbmlpqXj6uHHjpk6dSjysrKy8ePEih8MxMzNbvHixsbExkaWjo+Pj4xMXF0dFuAqvoaEh
-      Ozu7ubnZ3Nx88eLFZmZmIgUEAkFqaurZs2erq6sHBwctLCyWLVv25ptvqqioEGXGVpUKpWrfvn0A
-      8MUXX4hn3bp1CwDc3d2le8QRuHnzJgAsWLBAPGtwcFBXV1dVVbWrq4v6wMiWLl0KAIWFheJZ0dHR
-      ABAVFSXrGE7d++tFn7J9+3Yajaarqzt9+nQajWZiYnLz5k1ZxCbB0NDQyZMn7e3tAcDPz4/ioyM1
-      NTXh4eFKSkoAUFJSMjZjkPsbUVNTM2nSJABwcnIyMjICgPXr1wsEAipjOHfunKamppKSkqurq7q6
-      OovFio2NpTIAKo3gG+P5eXh4DPsTVl9fjwrk5+fr6ekpKSk5OzujgYwFCxZ0dHSg3B07dsjxwyhT
-      BQUFw9bMunXriDIfffQRAOjq6s6cOVNLS0tNTS0+Pp7IleNXpVDGzeZFxcbGMplMTU1NVFEsFisx
-      MZFcoLGxcdasWQCwcOHC3bt3R0dH+/n5AYCdnV1dXR1RTL5VSjEp9yMfPXpEo9GmTp0qnvX5558D
-      wOHDh6V7xJGxsbGh0+ktLS0i6Xl5eQAQHBwsl6jI4uPjAWDTpk3iWXPmzAGAyspKWcfwoh/vlJQU
-      AJg3b153d7dQKLx69aqqqqqpqSl6SI2EhAT0E4KGk6n/JLPZ7JCQEAaDoaqqamVlJZefLkWIQe5v
-      BJ/Pd3Z2ptPp586dEwqFAwMDK1euBIADBw5QFkNDQ4OampqJiUlNTY1QKGxubra1taXT6bdu3aIs
-      BirJtEPQ3NxcR1JbW2toaOji4oJy+/v7DQwMxo0b99df/38M6Hz7ww8/RA9HcT+yr6+v7u+++uor
-      AEhPT0cF0tLSAGDRokU9PT1CobCjo2P27NnKysr3799HBXA/EmlubmaxWHZ2dlwuVygUtrW1mZmZ
-      aWlp9fX1oQI9PT2Ojo7KyspE3SK//PILOl8dGhpCKbgf+a/Mnz8fAKqrq0XSbW1tlZWV29vbpX7E
-      Efi///s/ADh69KhI+ttvvw0A58+fl0tUZD09Perq6mZmZiLDJ42NjTQazdXVlYIYXvTjPWvWLDqd
-      Tnw3CYXCbdu2AcCRI0ekHdozHTp0yMvLKzc3l8PhyOWTPDAw4OLismPHDjab/f7778vlp0sRYpD7
-      G3HhwgUAWLt2LZHC4XA0NDRMTU0pG5KMiIgAgBMnThApv/32GwC88cYb1ARAMSo7BNeuXSPPff3+
-      ++8A8PbbbxMF+Hy+iooKMahB7kfeu3fv2LFj8fHxbDabsoCp5O3tra6u3tvbix4GBgYCQHl5OVHg
-      +vXrAIBWTwlJnZ6enp709PQjR45cuXKFsmgVpx95//79qKiorKwsImXDhg0AUFZWhh7u2bMHAHbt
-      2iX+3GXLlk2aNKm4uBg9lG+VUkz6/chjx44BwJ49e8iJf/75p0J1z//66y90fkZO5PF46Ix2cHBQ
-      XoGRrV69GgCuX79OTvz+++8pG1N5oY93e3s7AMyePZucWFZWBgABAQHSDu2fyav7QiavPpxCxSCv
-      N2Lz5s0AkJubS05EQ5J//PEHNTE4OTkpKSmRx+MFAoGhoaGuri41AVCMyg7Bpk2byD/waN0UMfqI
-      GBgYODo6or9RP/Ls2bOLFy8GALSUTU9PDw0VjyYtLS10On3lypVECmqHfD6fSOHz+QwGg/i6BoDl
-      y5cfPnxYV1eXWOS3efNmagJWnH6kuICAAABoa2tDD8ePH6+srEwslpBAvlVKMelfr71ixQoWi5Wc
-      nExOPHPmDACEhoZK/XAjM3HiRDc3t/z8/CdPnhCJhYWFbDY7KCgILSmTO1Rd4jVJp9ODg4PlFNQz
-      VVZWAsD06dPJifb29mpqahUVFXIKChu7UKsTaZCurq5EFjUx2NraqqurEyk0Gm3GjBkcDqelpYWa
-      GEYlPp9/+vRpW1tb4mpIR0dHExOT3NzcgYEBlPLbb7+x2Ww0P0ZYtWqVg4MDm83u6enZtWvXkydP
-      Dh06RHX0Mnb69GmBQIDGIBElJaWhoSGiZgCATqdraWnV1dURKVlZWQcOHEhKSurt7X306JG5uXlM
-      TAw6CRyzsrKyMjIyFi1apK+vDwANDQ319fUzZszQ0tJ6zqePkSqVfj9SW1vb19f3zp079fX1RGJq
-      aqqWlpavry96ODg4+OCphoYGcvtGGhoaiAJdXV1SDxIAwsLCeDxeRkYGOUiUTi7W1dWVn59/9uzZ
-      y5cv9/b2irxIRUVFenp6ZmZmdXW11CP08vIyMjJCUSGtra1FRUVeXl7kS+0khyE5filqbW0FAJHA
-      aDSaoaEhm82W3XExbFitra1MJhP9ABDQ1TbUNEgulzs0NCTyiaA4htEqPz+fzWaTu0poyZqGhoaj
-      o+PatWv9/f2DgoJCQ0N37dpFfuKPP/4YHR09btw4Op2+fv16AKipqaE6ehlLSEhQVlb28fEhUtDp
-      U3Z2NpFSXl7O4XDIvwg2NjbFxcVeXl40Gs3MzGzZsmV8Pp/c0RxTkpOTnZ2dV65c+eabbyYkJKDE
-      xsZGALCwsHjOFxk7VSqT/SPRQBoagwSAysrKe/furVixghjdLS8vnzBhwqJFi/z9/b28vLS0tDw9
-      PYuLi4lXcHJymjNnjr+//9KlS42NjR0dHX/99VfpBhkUFMRkMokgBQJBSkqKtbW1m5sbUeaHH34w
-      NjbesWNHampqRESEiYnJqVOnUFZjY6Obm5uHh0dcXNyJEyfc3Nw8PT2H3ZZixBgMRnBw8IMHD27f
-      vo1SUlNTBQIBeVhXchgS4pcR8tALoqWlxePxZHpQDBvWsK0RAKhskIoQw+iTmJgIACtWrCAntre3
-      czictra29vZ2Lpfb29vb09MjMkiBelQI2gmrs7OTkpApUl9ff/36dW9vb/KGa++9956SktI777yT
-      l5fX2dlZUFDg5+dHbJaETJ48WVtbm3g4Kivn+fF4PBqN1tfXV1RUdPXqVZSI2hJ5cx/Jxk6VyqQf
-      uWTJEl1dXXT1LgCgi8VExvkA4PTp06WlpdXV1c3NzZaWlu7u7miNC/LJJ5+Ulpai06b169evXbsW
-      LQ2UFgMDA29v79zcXDTeWVxc3NzcHBoaSuw3VlNTs3nz5piYmKKiopMnT964cWP37t0pKSmDg4MA
-      EBER0dXVVVdXl5SUlJycXFlZqaKigi73liLUZSTXpKqqKvksXEIYkuOXOiaTCQDig8cdHR3y3S4U
-      G5uYTOawrREAqGmQEj4RlMUwrMTExJ1PkceoXhYDAwMpKSkWFhYzZswgEuvq6vz9/ZWVlWtrazMy
-      Mi5dupSXl5eRkbF27dpnvY6CrF+SLjR4hlb1ERwcHM6dO8dkMr29vdGE4fvvv6+np6ejo/Os1xmV
-      lfP83njjjdLS0rKyMoFAEBAQgLbnRJMb6EqAERjFVSqTfiSLxVq5cuWNGzeampoAICUlxdTUdN68
-      ec8qr6enFxsba2dnt337dvFcZWXlzZs3b9iwYefOnf39/VKMMywsbHBwMDMzE5721chDfW1tbQBA
-      3lD93XffTUtLU1ZWBgA2m21kZEQMNhgaGmZmZqJV/FI0c+ZMGxsbNLXN4XAuXrwoch4pIQzJ8Uud
-      qakpADx+/FgkvaWlRXxqD8NkDV2XLTJ9jFYlUtMgNTQ0NDU1h/1EUBbDsDIyMr596vLly/IKY8Qy
-      MzM7Oztff/11cmJaWtrAwMBnn31G9I3c3d09PT2zsrLIi+BHvfj4eAaD4e/vL5K+ePHi+vr68vLy
-      69evNzc3v/vuu48fP7a0tJRLkC8Le3v7r7/+msfjnTx5EgAmTZrEYrGG3fJ9jJPVfRFDQ0OFQmFa
-      WlpDQ8Pt27dDQkLE78tCxmAwVq1adenSJYFAMGyBkJAQDocj3bfQz89PXV0d9SDT0tJcXV1tbW2J
-      3BkzZjg4OISGhsbGxnZ3d4s8d82aNQUFBatXr5Z1qwoNDa2qqiorKzt//jyPxxMZ1pUQhuT4pc7W
-      1pbJZJaUlJATKyoq+vv7yfdUwDBqoFYn0iDv3LlDZFETQ01NDfnTJxQKS0pKTE1NdXV1qYlBXFxc
-      HPcptI/JywVNaosMuaH+OjqbJaClqGjp9lhQXl5+9+5dDw+PYW9eRafT7e3t3dzcNDU1y8vLBwcH
-      ybP82LDs7Ozg6WpmVVVVLy+vxsZGtOeUiLi4uGXLlp09e5bqEBWArPqR7u7ulpaWqampaCwtJCTk
-      H59iZWXV19f3rCWGaDtlNMApLWpqaoGBgRcuXLh+/Xptba1IkMrKykVFRSEhIZGRkQYGBkFBQWhH
-      OiQ0NDQ3N/fhw4cuLi52dna7d+8WH3iQCjREmpqampKSoq+vL3IvRwlhSI5f6tTV1RcuXHjjxg3y
-      unW0HBNt949hVEJDMuR11RwOJzMz097efvLkyZTFMDQ0dPr0aSLlt99+a2lpwZ+IEevu7s7IyDAy
-      MkK3YyCgqx/QvcoQgUBQXFxMp9NNTEyojlJO0KS2yLJRAIiPj7ewsPjpp59ESpKXSGEA8OWXX7JY
-      rOPHjxMpaG8HYvYgMjISADZv3tzX10d+Ymtra0RERF5eHrqB1pgjuy2FPvvsMzqdPnXqVHt7e5Es
-      NEggsqcdGjrmcDhCoVBbW1tki8SGhgYASEtLk26QaHkQuu9FU1PTsGUGBwfPnTsXEBBAo9Hmz59P
-      bG2P1NXV7dq1y8LCAg1tSjc8xM3NzcbGRkVFZePGjc8qIyEMyfFL8KLbel27do1Op7u4uFRVVQ0N
-      DcXHxysrK5O3+KcS3j9SQWKQ4xuxZMkSAPjuu+/6+/sbGhrQOVhSUhJlAXC5XGNjY11d3dzcXIFA
-      cOPGDSsrK3V19draWspioBIFGwGinwnyfuNIS0uLtra2hobG6dOnOzo67t+/v2bNGiDdnGzY+9kA
-      gIeHh6xjpoy1tTWNRmtsbBRJZ7PZ+vr648aNu3LlSl9fX1JSEovF8vb2JgqIf0JRdRUUFFAQtuLs
-      H1lZWamsrGxsbFxUVDQ0NHTz5s1JkyYxGAxys/nf//4HADNnzrx48SKPx+PxeNnZ2ZMnT2YwGKdO
-      nSKKybdKKSbDfuS9e/dQV/Wrr74SyRq2H7lt2zYtLS10qwnxfiS6D8Tt27elGySPx0NzHwsXLvzH
-      wleuXAGAgwcPimcNDg4uWbLE0NBQuuEhP/74I6rJq1evSi4pOQwJ8Q9rBB/vM2fOGBgYEGcpc+fO
-      ffjw4Yu+iFTgfqSCxCDHN4LL5ZIXimloaMTExFAcw927d52cnIgYrKysLl++THEMlKGgQ4B2Ec/J
-      yRHP+v3338lVzWQy33zzzc7OTpQ76vuRN27cAIBXX3112Nzi4uIJEyYQlbN06dLW1lYiF/cjCRcu
-      XDA3NycqysjIKDk5WaTMuXPnnJ2dAYBOpzMYDACYNWtWUVERucyY6kfShELh8w9eSktpaamLi0tJ
-      Scm0adNQSn9/v4ODg6urK5oD0tHR2blz55YtW4inhIaGFhQUPHz4EL1tciEUCrW0tD7++GPUIERE
-      R0dHREQMDQ1JXgkqaxLCkBy/uLiy+6EOE180gKGhodLS0u7ubisrK/I3F4bJRWNjY01NjYqKirOz
-      s6qqqlxiKC8vb2lp0dPTc3R0lO/3g0yN7BtDuurr6xsaGpSVle3t7Z9zv+gxQiAQlJWVdXZ2WllZ
-      mZmZyTuc/0cRmg0Zn8+vrKxks9l6enpTpkxBGy+Ie/To0V9//TU0NDR58mS07m7MGr6CKHb37t2P
-      P/64vb1dZM9YpLm5OTo6OiEhAV2JRllUOTk5gYGBP//8c1BQEAAIBILo6OiBgYHXX39dKBR6enqi
-      LSfRXgAPHjyIjY0NDg6m8kdCchgS4pdpVEpKSjNnzpTpITDs+ZmZmcn9V3PKlCnEnVcwmRo/fvz4
-      8ePlHYUiotPpjo6O8o7iJcBgMBwcHP6xmLm5OXnkciyT55mxu7u7jo6Oqqqqt7e3kZHRrVu3bGxs
-      iNzIyEgdHR1NTU1bW9t79+799ttvFN8McNGiRTt37gwPD580adL8+fOtrKx+/fXX7OxsBwcHGo32
-      008/CQQCCwuLOXPmuLm5OTs7e3l5kRcyU0ByGBLipzJIDMMwDMNGK/nMa79EeDxeXV0dh8MxMjIS
-      P81tb2+vr6+n0+m2trbymjKTHIbk+CVTtOkGDMMUGf7GwEYAN5uXnULMaysyJpMpYZcQfX19kRv4
-      yoWEMCTHj2EYhmEYNmKjdsU3hmEYhmEYJlO4H4lhGIZhGIaNBO5HYhiGYRiGYSOB+5EYhmEYhmHY
-      SIzkeu24svuyCAXDMAzDMAyj0r+8Xh7v+4M9E96OAcOw54e/MbARwM3mZYfntTEMwzAMw7CRwP1I
-      DMMwDMMwbCRwPxLDMAzDMAwbCdyPxDAMwzAMw0YC9yMxDMMwDMOwkcD9SAzDMAzDMGwkmNJ9uUOH
-      DlVVVW3evNna2lo8NzIysr+/f+/evSwWS7rHfSF5eXmZmZlLly719vYWzz127Njdu3fDw8OnTJlC
-      fWwAIBAIIiIihELhvn376HTRjn5jY+P+/fstLS0//PBDuYT3j6qqqvLz87lcrrW1tY+Pj6amplzC
-      EAgEOTk5LBZrwYIFcgkAAB49epSfn+/r66unpzdmY5DvG9Hf33/hwoWqqio1NTV3d3cXFxfqY0Dk
-      /ka81EpLS7lcrni6q6urhoYGOaWwsDA1NRUAIiMjjYyMyFl79+7du3fvlStXHB0dZRotlbhcbmlp
-      qXj6uHHjpk6dCgB9fX2RkZHkLD09vcmTJ3t5eRkYGBCJy5Ytu3v3bn19vawDVnwNDQ3Z2dnNzc3m
-      5uaLFy82MzMjsrKzs7Ozs4mHLBZr3Lhxs2bNmjNnDoPBIL+Ijo6Oj49PXFwcdXHLkVCq9u3bBwBf
-      fPGFeNatW7cAwN3dXbpHHIGbN28CwIIFC8SzBgcHdXV1VVVVu7q6qA+MsHTpUgAoLCwUz4qOjgaA
-      qKgoCsI4de+vF33K9u3baTSarq7u9OnTaTSaiYnJzZs3ZRGbBENDQydPnrS3twcAPz8/io+O1NTU
-      hIeHKykpAUBJScnYjEHub0RNTc2kSZMAwMnJCXUp1q9fLxAIqA9D7o2BGiP4xnhOHh4ew/5+1dfX
-      i5RcsmSJjo4OAHzzzTciWTt27Bh9b0FBQcGwNbNu3TpUgMPhAIC+vr6fn5+fn5+np6eNjQ0AKCkp
-      7d+/n3gdDw8PbW1tufwLsms2IxAbG8tkMjU1NWfOnKmlpcVisRITE4lc1IReeeUVVJkLFixAffEJ
-      EyacO3eO/Dpy/PWhnpT7kY8ePaLRaFOnThXP+vzzzwHg8OHD0j3iyNjY2NDp9JaWFpH0vLw8AAgO
-      DpZLVIT4+HgA2LRpk3jWnDlzAKCyspKCMF70452SkgIA8+bN6+7uFgqFV69eVVVVNTU1RQ+pkZCQ
-      gMbC0XAy9Z9kNpsdEhLCYDBUVVWtrKzk8rulCDHI/Y3g8/nOzs50Oh19vw8MDKxcuRIADhw4QFkM
-      ivBGUEl2HYLm5uY6ktraWkNDQxcXF5FiLS0tDAZjy5Yttra206dPF8kdlf3Ivr6+ur/76quvACA9
-      PR0VQP1IDw8P8rNu375taGgIAPfu3UMpuB8pFAqbm5tZLJadnR2XyxUKhW1tbWZmZlpaWn19fagA
-      akJpaWnEUwQCQVpa2rhx4+h0+oULF4j0MdWPlPL6SDMzs3nz5t27d6+mpkYk68yZM8rKyuirXO5C
-      Q0MFAkF6erpI+pkzZwAgLCxMHkH9P35+furq6qixktObmpquXbvm6upqa2srr9gkQBPxx44dU1dX
-      B4DZs2d/9NFHTU1NVI7to/n03Nzcq1evUnZQMi0trYqKim3btjU0NPj5+Y3ZGOT+RuTm5v7xxx9r
-      1qzx9fUFAGVl5aNHj2poaKAxGGpiUIQ3YnQwNja2Inn8+HFra2tAQIBIscTERD6fv3z5cn9//zt3
-      7lRUVDzrBcvKyo4fP56QkNDW1ibj2GVLRUXF6u8uX76srq6+cOFCCc+aPn36W2+9BQC3b98WyRII
-      BIWFhUePHj137tzg4KAMQ1c8vb29n3766TfffKOtrQ0A+vr6vr6+nZ2dtbW1z3oKjUbz9/dHJ6sb
-      Nmzg8/nir3nu3LmjR48WFRXJNno5knrP9NixYwCwZ88ecuKff/4JitQ9/+uvvwBg0aJF5EQej2dg
-      YDBu3LjBwUF5BUZYvXo1AFy/fp2c+P333wOFAyovdJrY3t4OALNnzyYnlpWVAUBAQIC0Q/tn6Cxc
-      vk3u/fffB3mPf8g9Bnm9EZs3bwaA3NxcciI6j/3jjz8oDkaoAG8EBSgbWNq0aRMAlJWViaTPnDlT
-      R0dncHDw2rVrABAZGUnORYNJZ8+eXbx4MQCoqKgAgJ6eXk1NDTVhU6ClpYVOp69cuZJIGXY8UigU
-      fvrppwCQnJyMHqLxyEuXLtnZ2TGZTCaTCQCurq4DAwOyjllxxiPFoXOVtrY29FB8PJKwZMkSALh4
-      8SJ6CADLly8/fPiwrq4uamkAsHnzZupCp5D0r9desWIFi8VKTk4mJ6JxvtDQUKkfbmQmTpzo5uaW
-      n5//5MkTIrGwsJDNZgcFBaGVTPKF6kq8Gul0enBwsJyCkqSyshIApk+fTk60t7dXU1OTMCqAYTKC
-      Wp1Ig3R1dSWysJcUn88/ffq0ra2tyKWQ1dXVv//+u4+Pj5KS0qxZs0xMTOLj44ViY8+rVq1ycHBg
-      s9k9PT27du168uTJoUOHKAxftk6fPi0QCAIDAyUXu3Xr1vHjxy0sLFCXGuns7AwMDPzggw+6u7s7
-      OzuXLl1669atnJwcGYesuLKysjIyMhYtWqSvr/+PhdF1hOg6EOLpBw4cSEpK6u3tffTokbm5eUxM
-      DOrWjzLS70dqa2v7+vreuXOHfOVXamqqlpYWmmBSEGFhYTweLyMjg0hBV/nJfVIb8fLyMjIyQiEh
-      ra2tRUVFXl5exsbGcgzsWVpbWwFAJDYajWZoaMhms+UUFDZ2tba2MplMkR8AdLUNbpAvtfz8fDab
-      Ld5VOnXqFACgASQ6ne7n51dfX3/lyhWRYj/++GN0dDRa0LZ+/XoAEF+F9fJKSEhQVlb28fERSb93
-      756/v7+/v7+np6etra23t3dQUNC1a9fIV7srKSkVFhaGh4ezWCxVVdU1a9bA6Kqc55ecnOzs7Lxy
-      5co333wzISHheZ5iaWkJAI8fPyZSbGxsiouLvby8aDSamZnZsmXL+Hx+XV2drIKWH5nsH4nG0tAY
-      JABUVlbeu3dvxYoVxOju4ODgg6caGhoGBgZEXqGhoYEo0NXVJYsgg4KCmEwmEaRAIEhJSbG2tnZz
-      cyMX6+rqys/PP3v27OXLl3t7e0VepKKiIj09PTMzs7q6WrrhMRiM4ODgBw8eEOtXUlNTBQIBeUy3
-      s7OTqKWmpiaRlRn/WMmygFZGkmlpafF4PAoOjWEihm2NAIAb5EstMTERAFasWEFOFAqFcXFxqqqq
-      aLMLAEAdTdS5JENj0gjag6mzs1OmAVOmvr7++vXr3t7e4rutEcsoHR0dnZycVFRUTp48uXv37u7u
-      bqKMqqqqg4MD8XCUVc4L4fF4NBqtr6+vqKjoOVd4KysrAwD5V3jy5MlonSUyiutTyvtHIkuWLNHV
-      1U1JSfnoo48AIC0tDf4+zldeXu7i4mJjY6Oqqtrb21tfX//aa6/t3r171qxZqICTk5O6urqBgcHg
-      4GB9fb21tfWnn36KlgxKi4GBgbe3d25ubldXl6amZnFxcXNzc1RUFI1GI8r88MMPn332mYuLi7W1
-      dXV1dUVFRUxMDPpHGhsbV6xYUVtbO2/ePKFQmJ+f7+LikpKSgrackIrQ0NDvvvsuJSVlxowZAJCW
-      lqaqqko+Cz9+/PhHH32E9kJrb2/ncDgBAQH79u0zMTGB56hk6ULracQ7/R0dHfLdLhQbm5hM5rCt
-      EQDGeINMTExEq1AAwM3NjTyzqfgGBgZSUlIsLCzQtyLh+vXrtbW1zs7OxDzs0NAQk8lMTk7+4Ycf
-      nvWOK8ISJilCI2filx8BwKRJk7799lviIY/H2759+549e9ra2pKSkoZ9tVFWOS/kjTfeeOONNyoq
-      Kvz8/AICAn7//fdp06ZJfgqa5ZCwX/Iork+ZjEeyWKyVK1feuHGjqakJAFJSUkxNTefNmydS7PTp
-      06WlpdXV1c3NzZaWlu7u7uS1BZ988klpaWl5eTmHw1m/fv3atf2jEsIAACAASURBVGvRVSZSFBYW
-      Njg4mJmZiYKEv6/grKmp2bx5c0xMTFFR0cmTJ2/cuLF79+6UlBR0CVtERERXV1ddXV1SUlJycnJl
-      ZaWKigraNkhaZs6caWNjg6a2ORzOxYsX/fz8RDbd1dTULC0tLS0tffjw4e3bt6uqqmbPno1+LBHJ
-      lSxFpqam8PdRfaSlpUUxJ+Kx0c3U1FQgEIhMYbe0tIDY6ouxJiMj49unLl++LO9wXkxmZmZnZ+fr
-      r78uko7GHWtra9c+tX79eiaTyeVys7Ky5BGpHMTHxzMYDH9//38syWQyv/rqK0tLyzNnzshoxm8U
-      sLe3//rrr3k83smTJ/+xMNoNHm2XO9bI6r6IoaGhQqEwLS2toaHh9u3bISEh4rdm+f/au/Owpo61
-      AeATAoSAshZRRIqUEhCV4lZcUoEKRZFGpCoN2OpTpNr6oFcetaiot1oXQPnwitUW7L0ugGiICyCI
-      LFq0YEWggGwtCCIoiGEzBAjJ98c8zZMmGDAmOQHf318yc07yOjlJJjNz3hExNjaOjY21s7PbvXu3
-      dK22tnZwcPD69ev37t3L4/EUGCROr4N7kGw2WyKfDs4HIb4xz7fffstms/HwdWtrq5mZmWjibNy4
-      campqQrPauTv719VVVVeXp6SksLn82Wv3aTRaMnJyU1NTadOnZKuld3Ib45Go2lqahYVFYkXVlRU
-      8Hg8vK0CAKqErzqJC/LBgweiqrfW+fPn2/928OBBosN5PXhSW2LIrb+/PykpSV9fv7W1tV1MSkoK
-      Qujs2bPExKpaDx8+LC0tXbhw4TA3TMKL14VCIfQjZbCzs0PDWFH98uXLixcvamlpEbh9GoGU1Y+k
-      0+mWlpbJycl4OI3JZMo+nkwmr1q1Kjc3VyAQDHoAk8nkcDiDbgAlN11d3eXLl1+/fh3PiUgEOXPm
-      TAcHB39//9jYWPFFJNgXX3yRk5OzevVqxYYkAY+PJicns1gsExOTQTdyFGdhYfHRRx9lZ2cPWjtk
-      I78JnLEsPz9ffF02HiSAzHlA9fCojHgfgsPhpKam2tvbv//++8TFBeTX3d197do1MzMzvB2DyPXr
-      19va2ry8vCTmr11cXExNTVNTU0flTbIS8KS2xLJRGYqKih48eGBqaiqxe+TbbP/+/RQK5fTp06IS
-      nNtB9gxGf39/YGBga2trYGDg2znXoax+JIlEYjKZubm5cXFx9vb2w9nW1srKqqenZ9BNVHEtQghP
-      lCuQv7//y5cvN2zYIJ1PR1tbOy8vj8lkhoaGmpqarly58vr16+In3rhx4/Hjx05OTnZ2dgcOHJCe
-      0n1zOD/RuXPnMjIyhpmQyMrKSkYryW7kN4RXl65ataq6uprP5yckJERGRk6fPn3IJBQAKNycOXMW
-      L1587ty5Y8eO9fb2Pn782M/P7+XLl//+97+JDg3Iic1m83i8ZcuWScxu4Z0OpLtQZDJ5+fLlfX19
-      EgnURqX4+HicE3vQ2vb29tzc3Nzc3MzMzAsXLgQHB9PpdIRQZGSkxMbQbzM8o7hz5847d+7w+fzf
-      f/89JCSETCZLpCwsKyvDjZmenh4ZGeno6JiYmOjm5hYREUFQ4ARTVj8SIRQQECAQCMrKyoaZSQcP
-      kr1q+lt2rdxwep2SkpKPP/4Y354iztDQ8PDhw01NTUlJSXw+38vLy83NTTS37u7unpubW1dXFxAQ
-      cPLkSRsbG/E0PYoSEBBQXV3N4/GG34wyWklJzYjNnTs3KSmpsbGRRqNpaWkxmUxnZ+fU1FR8Cw4A
-      KpaQkLBs2bJNmzbp6OhYWlrevXs3JiZGTbbUAnLAG8ZK/C7t6Oi4evWqnp6e6E5tcfjllr5re5Qp
-      KCiora11dnbG69SllZSUuLq6urq6enh4BAQEpKSk+Pr63r17Fyf3ARiNRrty5YqmpuaCBQu0tLTm
-      zJnT1dWVmJgocZNNWFgYbswlS5aEh4dbW1snJCRkZmZKJ4h4WxCS/RwvWpLY2mHXrl36+voCgUAo
-      FBoYGEjs2nLz5k2EUGFhoUoD/SeciuzEiRPSVX19fYsXL8bLTVQmKipKekfUBQsWeHt7C4fRyEOS
-      b5uBvr6+e/fuZWdn19bWynE6AIrV2NiYk5Pz22+/cblcomMZ5dR5YxKgttTtsuHz+WVlZTk5OSUl
-      Jf39/USHMwKoy0ARj8eLj4/39PQUT7sj7vTp0xMmTHB0dFRxYOLmz58/ZswYnHBbAl5gm5GRIXs4
-      UNkqKyvv3r17/PjxQWuHbGSF0NLSmj17tvIeH4DXMnHixIkTJxIdBQBgZCCTyeJ5NMGQCOvxiCst
-      LWUwGG1tbfv27ZOubW5uDgkJSUhIOHr0qCpXcmRkZOjp6YlyawkEgoiIiN7e3s8++0woFLq5ubm4
-      uOBNpRFCjx49io2N9fPzI6oTyefzMzMzvby8HB0d165dK32A7EYGAAAAAHhdRPYj6XS6oaEhlUr1
-      8PAwMzO7f/++ra2tqDY0NNTQ0HDs2LE0Gq2srOzmzZsq3lf6k08+2bt3b1BQkI2Njaurq5WV1dmz
-      Z9PT0x0cHEgk0s8//ywQCCZNmjR//nxnZ2dHR8dFixb9/PPPqowQIdTR0WFoaGhoaDhmzJhvvvlm
-      5cqVubm5on2D0FCNDAAAAAAgN5JQaht7II7P59fV1XE4HDMzs3fffVeitq2trb6+XkNDg0ajUalU
-      QiJUnvPlf/k7vEd0FACAkQE+MYAc4LIZ6dRlfaTa0tTUlJFtzsTExMTERJXxAAAAAACoCbVYHwkA
-      AAAAAEYc6EcCAAAAAAB5QD8SAAAAAADIA/qRAAAAAABAHvLcr32+/C9lhAIAAAAAAFTpDe+Xh7w/
-      4JUgHQMAYPjgEwPIAS6bkQ7mtQEAAAAAgDygHwkAAAAAAOQB/UgAAAAAACAP6EcCAAAAAAB5QD8S
-      AAAAAADIA/qRAAAAAABAHpqKfbgff/yxqqoqODjY2tpaujY0NJTH4x06dIhCoSj2eYevrq4uOjra
-      1tb2m2++ka69desWm812c3P79NNPVR+biEAg2L59u1AoDA8P19CQ7Os/efIkIiLC0tJyy5YthIQn
-      W1VVVVZWVnt7u7W1tZeX19ixYwkJQyAQZGRkUCgUNzc3QgJACDU2NmZlZXl7exsbG7+1MajDC9Hd
-      3Z2amjpt2rQpU6ao/tlbW1tTU1ObmppMTU0XL15sYWGh+hhGtPb29uLiYunyd955Z+rUqeIl+fn5
-      8fHx9+/f53K5RkZGLi4uX3/99fjx40UHGBoaenl5nT9/XulBq0pxcXF7e7t0+axZs8aMGYMQSk9P
-      T09PF5VTKJR33nnnww8/nD9/PplMFpXn5eUtXbr04MGDGzZsUEHY6mxgYODGjRslJSUaGhpOTk4f
-      f/yx+LewRHuKs7Gx2bhxI0Jo6dKlpaWl9fX1KoqYcEKFCg8PRwh9//330lX3799HCNHpdMU+4+vi
-      8XhGRkZ6enpcLle6dunSpQihrKws1QcmYcmSJQih27dvS1dFRkYihMLCwpQdw7myP1/3lN27d5NI
-      JCMjoxkzZpBIpAkTJty7d08ZscnQ399/5swZe3t7hBCDwVDxs2M1NTVBQUFaWloIoaKiorczBnV4
-      ITgczv79+01MTBBCUVFRqg/g6tWrY8eO1dLSmjVrlp6eHoVCiY2NVX0YqiHHJ8Zw5OTkDPrltXbt
-      WtExvb29X331FULIwcFh165dUVFRX3/9NZVK1dfXz8jIEB1G4KWoJAsXLhy0cerr6/EBe/bsQQjN
-      mTOHwWAwGAw3NzdTU1OE0OTJk69evSp6HNzIhLxHlHTZyKetrW3mzJkIIRqNhn92LliwoKurS3SA
-      RHuK27lzJz5m4cKFBgYGBP0PCKDgfmRjYyOJRJo6dap01c6dOxFCJ0+eVOwzyiEoKAghdOnSJYny
-      rq4uCoVibm4+MDBASGDi4uPjEUIbN26Urpo/fz5CqLKyUtkxvO7bm8ViIYRcXFy6u7uFQuGdO3eo
-      VKq5uTn+UzUSEhLwWDj+CFD9d0ZrayuTySSTyVQq1crKipA+nDrEQPgLIRQKd+zYYWBgQCKR7Ozs
-      CPmObGho0NXVnTBhQk1NjVAobG5uptFoGhoa9+/fV3EkqqGkDkFPT0/dP/3www8IoStXroiOwZ3I
-      HTt2iH96l5SUGBgY6Orq1tXV4ZLR149sbm4Wb5na2tpx48Y5OTmJDsD9HjabLSoRCARsNvudd97R
-      0NC4fv06LoR+JLZp0yaE0KlTp/Cfhw4dQggdOHBAdIB0e0p72/qRCl4fOXHiRBcXl7KyspqaGomq
-      S5cuaWtrr1ixQrHPKAd/f3+EUHJyskR5SkpKb28vk8mUnkpWPQaDoaenhy9W8fKmpqa7d+/OmjWL
-      RqMRFdur4Fn4uLg4PT09hNC8efNCQkKamppUOYuE59Nv3Lhx584dlT2pOH19/YqKil27djU0NDAY
-      jLc2BsJfCITQ48ePfX19y8vLDx48SEgAMTExXC734MGDNjY2CKHx48fHxMQIBIIjR44QEs8IpaOj
-      Y/VPt27d0tPTc3d3xwfk5+fHxcUtWrRo//794p/e06dPDw0NNTY2TktLk3hMLpd79erVn376KS8v
-      T3X/EyUYP368eMs8ffq0paXFx8dHxikkEmnZsmV4MHL9+vUDAwMSBzx9+jQhISEuLq66ulqZsauj
-      6dOnb9++Hf8sQQitWbMGIVRUVCTfowkEgtu3b//0009Xr17t6+tTVJBqR+E907i4OITQwYMHxQv/
-      +OMPpDY/BAUCgaWlpb6+Po/HEy9fvnw5Im4WUtrq1asRQr/99pt44bFjx5CqfjW+1s/EtrY2hNC8
-      efPEC8vLyxFCPj4+ig5taBwOh/BLDv+0JfaKIjwGdXgh2Gy2yt414qZPn66lpSU+Hi8QCMaNG2dk
-      ZKTiSFRDNQNLz54909DQWLFihajkyy+/RAilp6cPeS5C6NNPPz158qSRkZGOjg7+EgwODlZmvCqF
-      1+eVl5eLSmSMny1evBghlJ2dLfx7PPKHH37YtGkTnspACGloaFy8eFHZMavVeKSEkpIS9M+JweGP
-      R+bm5trZ2WlqampqaiKEZs2a1dvbq/yQCaD4gTdfX18KhXLx4kXxwkuXLqG/BwIJRyKRmExmZ2fn
-      jRs3RIVcLjctLW3KlCkffPABgbGJw80l3ZIaGhp+fn4EBfVKlZWVCKEZM2aIF9rb2+vq6lZUVBAU
-      FABEqqiooNFoeHgeI5FIM2fO5HA4z549IzCwEe3ChQsCgQD/7Mdu375NJpPpdPpwTk9LS4uKikpK
-      SuJyuY2NjRYWFjExMfjXzkg3MDBw4cIF0cK+IeFb3/CtC9iePXtqamrKysq4XG5OTo5QKCRqLF8d
-      dHV1bdu2Tb4v3M7OzuXLl//rX//q7u7u7OxcsmTJ/fv3MzIylBEn4RTfjzQwMPD29n7w4IH4zUrJ
-      ycn6+vre3t4Kfzr5BAQEoH9ObV+/fp3H4+FyNbFo0SIzMzPxIFtaWvLy8hYtWiR+B6KaaGlpQQhJ
-      BEYikcaNG9fa2kpQUAAQpr29vb+/X/qtamZmhhCCN4XcEhIStLW1vby8RCVPnjwxMTHR1dUdzum2
-      trYFBQWLFi0ikUgTJ05cunTpwMBAXV2d0uJVnaysrNbWVvEetmyWlpYIoadPn4pK/Pz8UlJS8Hpi
-      FxcXGo0mvUTtLeHl5WVhYdHU1MRisfA9CeKOHTu25p+4XK74AVpaWrdv3w4KCqJQKFQq9YsvvkAI
-      jdbGVMpCQDyQhscgEUKVlZVlZWW+vr6ieYS+vr5Hf2toaOjt7ZV4hIaGBtEBXV1dCo/QwcHB0dHx
-      ypUr/f39uAQP+zGZTNExLS0tohikP/Q7OztFtU1NTdJLTN4cmUz28/N79OhRYWEhLklOThYIBNLD
-      uhUVFVeuXElNTZVeztLV1ZWVlXX58uVbt25JXOjKID70gunr6/P5fGU/LwDqadB3BEII3hTyqa+v
-      /+233zw8PMQTivX19Ym+XIb0/vvvGxgYiP7E+bA6OzsVGychEhMTEUK+vr7DPF5bWxshJP7lNXPm
-      TBKJJPrT2NhYGd+/I0JfX5+WllZNTc2VK1fkuDyoVKqDg4Poz9F0mUlTcP5IbPHixUZGRiwWKyQk
-      BCGEFyeJD/U9fPjQycnJ1taWSqVyudz6+voFCxYcOHDgww8/xAdMnz5dT0/P1NS0r6+vvr7e2tp6
-      27ZteL2govj7+2/bti0nJ8fDw6O3tzctLY1Op7/77ruiA4KCgnJyciZPniwQCJ48eaKtrR0YGBgW
-      Fobfe6dPnw4JCZk2bRpCqK2tjcPh+Pj4hIeHT5gwQbFBRkdHs1gsnImAzWZTqVTxn5tPnjzx9fWt
-      ra11cXERCoVZWVlOTk4sFsvQ0BAh9J///Oe7775zcnKytraurq6uqKiIiYlR0pgrXgIi/aHT0dFB
-      YLpQAIgi4x2BECLwTZGYmIhXoSCEnJ2dPT09iYpEDgkJCQghiftIjI2N8fpsOeDEWKNAb28vi8Wa
-      NGkS/rIYDjw+IiPF76hpHDlkZmb29fUdPnx49+7d3d3dEgvMgoODly1bNvxHG90tqZTxSAqFsmLF
-      ivz8/KamJoQQi8UyNzd3cXGROOzChQvFxcXV1dXNzc2WlpZ0Ol18ocbWrVuLi4sfPnzI4XDWrVu3
-      Zs0afIuJojCZTBKJhGeNMzMzu7q6pMf5XF1di4uL//jjj+fPn585c+bkyZPi6yTGjh1bXFxcXFz8
-      +PHjwsLCqqqqefPm4S8JRZk9e7atrS0OksPhZGdnMxgMnF0W2759e1dXV11dXVJS0sWLFysrK3V0
-      dDIzMxFCNTU1wcHBMTExeXl5Z86cyc/PP3DgAIvFUtJdY+bm5uifUyTYs2fP1HAWHgBlGzNmzNix
-      Ywd9RyCpFSCqdO3atf/7261bt4gKQz7x8fFkMlniK3zq1KkvX778888/iYpKHaSmpnZ2dn722WfD
-      PwVnd8cZXoE0bW3tsLCwGTNmsFisQZO9A0xZCW78/f2FQiGbzW5oaCgsLJSdTMfY2Dg2NtbOzm73
-      7t3Stdra2sHBwevXr9+7dy+Px1NUhDhFEZvNxsm0ZOckIpFI7u7uJ06cYLPZ9+7dkz6ARqMlJyc3
-      NTWdOnVKURFi/v7+VVVV5eXlKSkpfD5fYjSxtbXVzMxMNHc2bty41NRU/B95/vw5Qkh8Y6Fvv/0W
-      /08VGyFGo9E0NTUl8iNUVFTweDyJPScAeEtMnTq1pqamu7tbVCIUCouKiszNzY2MjIiK6vz58+1/
-      G1l3UTx8+LC0tHThwoUSmzPhlfdJSUnSp1RVVbm4uOAsgKMbntSWnfFH3MuXLy9evKilpUXgRlMj
-      gp2dnfDvhCRgUMrqR9LpdEtLy+TkZDyWJr7ucFBkMnnVqlW5ubkCgWDQA5hMJofDGXR3LLkFBAS0
-      tLTcvn378uXLnp6eQ24c5+Pjo6Ojk52dPWithYXFRx999KpauYmyXbJYLBMTEw8PD/HaL774Iicn
-      Z/Xq1dItM3PmTAcHB39//9jYWPFvMiXB6dzy8/PFlxKfO3cOIURUCkMAiLVs2bL+/v4LFy6ISm7e
-      vPns2TN4R8gHT2pLr/8LCgoyMTE5fPiwxJDkwMDA5s2bb926hTc0GsW6u7uvXbtmZmYmfUfIoPr7
-      +wMDA1tbWwMDA2G+SITL5Zqamk6ePFl8zWhFRYWGhgbeBAgMSln9SJxbJzc3Ny4uzt7e3snJachT
-      rKysenp6XjV6jLflwBPlioJTFG3evPnFixfDyUmkqamJb+B61QFWVlaKjRAh9N577zk7O587dy4j
-      I2PlypUSyyz8/f1v3Ljx+PFjJycnOzu7AwcOiObRtLW18/LymExmaGioqanpypUrr1+/rtjYJISF
-      hZFIpFWrVlVXV/P5/ISEhMjIyOnTpw///kEARhO8ufPWrVszMzOFQmFBQUFQUJCent7WrVuJDm1E
-      io+Pxzm0Jcr19fUvXrw4MDBAp9PPnTv38uVLhFBZWZmXl1d6evqGDRsCAwOJiFd12Gw2j8dbtmzZ
-      q+b9ysrKcnNzc3Nz09PTIyMjHR0dExMT3dzcIiIiVByqOtPV1fXy8nr06NHmzZs5HE57e/vu3buL
-      iop8fHzw7XEidXV1xVJKS0uJipxYSty4JSAgQCAQlJWVDfPGDjwS+aq3gexa+eAURSUlJcPPSSQQ
-      CGTEILtWbgEBAdXV1a9KS+Tu7p6bm1tXVxcQEHDy5EkbGxtRqiBDQ8PDhw83NTUlJSXx+XwvLy83
-      NzcFrg2QMHfu3KSkpMbGRhqNpqWlxWQynZ2dU1NT8Q0HALxtDAwMMjMzJ02a5OHhoaGh4ezsjBBK
-      S0ubPHky0aGNPAUFBbW1tc7OzngptgRXV9eCgoIZM2Z8+eWXY8aMoVAo06ZNq6ysjI2NPXHihPg9
-      yKMS3kdXxi/2sLAwV1dXV1fXJUuWhIeHW1tbJyQkZGZmSucTeMudOHEiICAgJibG2NjYyMho3759
-      y5cvj42NlThsy5YtTlKGmcF0FCIk+zleRSexx8auXbv09fUFAoFQKDQwMJDYfOLmzZsIocLCQpUF
-      iXdeFy/p6enR1NQ8cuSIUCiMioqS3kBzwYIF3t7eKotQWl9f3+LFi8eNGzdo7a+//ooQOnHixDAf
-      Tb5tBvr6+u7du5ednV1bWyvH6QCMPuXl5dnZ2cXFxeK7P48+6rAxCYfDuXPnTnp6eklJyehu7VFD
-      HS4bCc+fP8/Ly/v111+fPXtGdCwjgLoMFPF4vPj4eE9Pz1f9cDx9+vSECRMcHR1VHJi4s2fP8vl8
-      vJeUtMrKyrt37x4/flzFUYnDi6YzMjIGHRmdP3/+mDFjcMJwpcYwe/ZspT4FACPLlClThrnFCHhD
-      hoaG8+bNIzoKMLKZmJgMc6UpQEqd1x6+0tJSBoPR1ta2b98+6drm5uaQkJCEhISjR4+SyWTVh4cQ
-      6u7ujo2N3bRp04YNG6SzJPD5/MzMTC8vL0dHx7Vr16osKqFQ6Obm5uLiIrqV7NGjR7GxsX5+fhoa
-      GhkZGXp6eqJ7GAUCQURERG9v72slhgAAAAAAeBUixyPpdDqZTO7t7TU0NHR3d79//76NjY2oNjQ0
-      dO/evQMDAyQSae7cuTdv3lR9eoLU1FSc0Bsnr4mKigoKChLVdnR0iGonTZq0cuXK0NDQ4W+r8OZI
-      JNLPP/+8du3aSZMmOTk5DQwMVFRUrF69Ojw8HCH0ySef7N27NygoaMeOHZMmTfrrr78MDAzS09PF
-      k+wDAAAAAMiNJBQKiY4BvKm2trb6+noNDQ0ajUalUsWr+Hx+XV0dh8MxMzMT361nOM6X/+Xv8J5C
-      IwUAjFrwiQHkAJfNSKcu6yPBmzAxMXlVgjRNTc33339fxfEAAAAA4G2gFusjAQAAAADAiAP9SAAA
-      AAAAIA/oRwIAAAAAAHlAPxIAAAAAAMhDnvu1z5f/pYxQAAAAAACAKr3h/fKQ9we8EqRjAAAMH3xi
-      ADnAZTPSwbw2AAAAAACQB/QjAQAAAACAPKAfCQAAAAAA5AH9SAAAAAAAIA/oRwIAAAAAAHlAPxIA
-      AAAAAMhDU7EP9+OPP1ZVVQUHB1tbW0vXhoaG8ni8Q4cOUSgUxT7v8NXV1UVHR9va2n7zzTfStbdu
-      3WKz2W5ubp9++qnqY8MEAsH27duFQmF4eLiGhmRH/8mTJxEREZaWllu2bCEkvCFVVVVlZWW1t7db
-      W1t7eXmNHTuWkDAEAkFGRgaFQnFzcyMkAIRQY2NjVlaWt7e3sbHxWxuDOrwQ3d3dqamp06ZNmzJl
-      ClExEP5CjGjFxcXt7e3S5bNmzRozZgxCKD09PT09fdBzbWxsNm7ciBA6dOjQoUOHfv3112nTpik1
-      WhUbsnHu3bsXHx8/6LlfffXVtGnTRmvLyK2hoSE9Pb25udnCwsLT03PixImiqhcvXnz//feDnrVw
-      4UIfH5+8vLylS5cePHhww4YNqoqXYAruR3Z3d0dHR5uYmISFhUlUFRYWHjp0iE6nE9iJRAiZm5uf
-      OXOmr69v7dq1VCpVojYyMjIlJYXATiRCSEND4+HDh2lpaQwGg06nS9QmJiZGR0dLN6+a2LNnz759
-      +wwNDSdPnlxUVDR+/PgrV67Mnj1blTHw+fyEhISDBw9WVFQwGAxCui9//vlnRETEL7/80t/fX1RU
-      REjXgfAY1OGFaG9vj4mJiYqKamtri4qKIqQfSfgLMQps3rz51q1b0uX19fW4q5Sfnx8dHT1nzpwJ
-      EyZIHIMPQAjxeLyOjo6BgQFlR6tiQzbOw4cPo6Ojp06d+t57kmkauVwuGr0tI5+4uLj169dTqVQ7
-      O7uqqqpvv/32f//736pVq3BtZ2dndHT0+PHjP/zwQ4kTcS+cz+d3dHT09vaqOm4CCRWqsbGRRCJN
-      nTpVumrnzp0IoZMnTyr2GeUQFBSEELp06ZJEeVdXF4VCMTc3HxgYICQwEfzbcePGjdJV8+fPRwhV
-      VlaqIIxzZX++1vEsFgsh5OLi0t3dLRQK79y5Q6VSzc3N8Z+qkZCQgMfCcY+BwWCo7Kmx1tZWJpNJ
-      JpOpVKqVlRVCqKio6C2MgfAXQigU7tixw8DAgEQi2dnZIYSioqJUHIA6vBCq9LqfGMPX3NxcJ6a2
-      tnbcuHFOTk6iA/bs2YMQYrPZMh4EHzP6XoIhG+eXX36Rff0T2zLKu2zk0NzcTKFQ7Ozs2tvbhULh
-      8+fPJ06cqK+v39PTgw+oq6uT/YGWk5NDyKcNgRS8PnLixIkuLi5lZWU1NTUSVZcuXdLW1l6xYoVi
-      n1EO/v7+CKHk5GSJ8pSUlN7eXiaTKT2brGIMBkNPTw9/JoqXNzU13b17d9asWTQajajYZMAT8XFx
-      cXp6egihefPmhYSENDU1nT9/XmUx4Pn0Gzdu3LlzR2VPKk5fX7+iomLXrl0NDQ0MBuOtjYHwFwIh
-      9PjxY19f3/Ly8oMHDxISgDq8EKPD+PHjrcQ8ffq0paXFjyo0aAAACnBJREFUx8dH7gcsLy8/ffp0
-      QkLC8+fPFRgnIRTbOKOpZeTA5XK3bdt29OhRAwMDhJCJiYm3t3dnZ2dtba0cj/b06dOEhIS4uLjq
-      6mpFR6pGFDyvjRAKCAjIyclhsVjfffedqLC0tLSqqorBYKjDnA6dTre0tMS9RvFJ9osXL6K/e5nE
-      0tXVXb58+dmzZwsKCpydnUXlLBZLKBSqQ4TSXrx4UVBQMG/ePPGlsZ9//vn+/fvT09PxGLAKrF+/
-      fv369QihQRcMqYC2tvaDBw8IeWq1ioHwFwIhdObMGfyPqqoqQgJQhxdiVMIzNr6+vnKcW19fHxoa
-      mp6erqOjw+PxjI2NCwoKbGxsFB0jYeRunFHfMsNhbW0tsfzx2bNnCCEzM7PXehwul7t58+bjx49r
-      a2v39PRoaGhcuHDhs88+U2SsakPxA2++vr4UCgX3yUQuXbqE1KOLhhAikUhMJrOzs/PGjRuiQi6X
-      m5aWNmXKlA8++IDA2ERwW0k3o4aGhp+fH0FByVJZWYkQmjFjhnihvb29rq5uRUUFQUEBAEabgYGB
-      Cxcu0Gg0+Va7rlq1ysHBobW19eXLl/v27Xvx4sWPP/6o8CCJ8iaNM7pbRj5paWnXrl375JNPTExM
-      XuvEPXv21NTUlJWVcbncnJwcoVBI1KyICih+PNLAwMDb2/vSpUv19fXvvvsuLkxOTtbX1/f29lb4
-      08knICDg0KFDycnJopCuX7/O4/ECAgKIDUxk0aJFZmZmycnJR44cwSUtLS15eXmLFi0aP348sbEN
-      qqWlBSEkERuJRBo3blxraytBQQEARpusrKzW1tbAwEDpqmPHjl2+fFm85MSJE7q6uuIlx48fF527
-      bt26sLAw6VVYI5eMxomPjy8uLhb9aWlpKTHwNrpb5nVdvHhx//79f/7555dffhkRESFR++DBgzVr
-      1oiXSFxpfn5+Z86cIZFICCEXFxcajTaKG1MpCwHxWBoeg0QIVVZWlpWV+fr66ujo4JK+vr5Hf2to
-      aJC+s6mhoUF0QFdXl8IjdHBwcHR0vHLlSn9/Py7BI39MJlN0TEtLiygG6Z5QZ2enqLapqUnhd7qR
-      yWQ/P79Hjx4VFhbikuTkZIFAID6mKzuGIRtZGfDKSHH6+vp8Pl8FTw0AeBskJiYieSe1EUKzZs0S
-      /Ruvs+rs7FRIYOrgTRpndLfM6+Lz+SQSqaenJy8vT45F3jNnzsSdSMzY2FgZPRk1ofjxSITQ4sWL
-      jYyMWCxWSEgIQojNZiOExIf6Hj586OTkZGtrS6VSuVxufX39ggULDhw4ILqRfvr06Xp6eqampn19
-      ffX19dbW1tu2bVu9erUCg/T399+2bVtOTo6Hh0dvb29aWhqdThcNoCKEgoKCcnJyJk+eLBAInjx5
-      oq2tHRgYGBYWpq2tjRA6ffp0SEgIvs+/ra2Nw+H4+PiEh4dLZ514kwijo6NZLNbMmTMRQmw2m0ql
-      Ll++XHSA7BiGbGTF0tTURAhJv1U6OjqIzfQEABCXmJiIV6EghJydnT09PYmN57X09vayWKxJkybh
-      T0UJwcHBy5YtG/6jaWlpKS404sluHCaTuXnz5mE+1ChrGTl8/vnnn3/+Oc5Z5uPj8/vvv4uveZsx
-      Y8Z///vf4T/a6G5PpYxHUiiUFStW5OfnNzU1IYRYLJa5ubmLi4vEYRcuXCguLq6urm5ubra0tKTT
-      6ffv3xfVbt26tbi4+OHDhxwOZ926dWvWrDl27JgCg2QymSQSCd+1nZmZ2dXVJb1809XVtbi4+I8/
-      /nj+/PmZM2dOnjwpvjZx7NixxcXFxcXFjx8/LiwsrKqqmjdvXkdHh6IinD17tq2tLY6Qw+FkZ2cz
-      GAxRLrRhxiC7kRXI3NwcIfT06VOJ8mfPnqnnRDwAb6dr1679398GzTuozlJTUzs7O0fr/QpvCBpH
-      4ezt7Y8cOcLn80U37QFpykpw4+/vLxQK2Wx2Q0NDYWGh7GQ6xsbGsbGxdnZ2u3fvlq7V1tYODg5e
-      v3793r17eTyeoiLEKYrYbLZAIGCz2bJzEpFIJHd39xMnTrDZ7Hv37kkfQKPRkpOTm5qaTp06pagI
-      EUL+/v5VVVXl5eUpKSl8Pl/28k3ZMchu5DdHo9E0NTWLiorECysqKng83tSpU5XxjAAAOZw/f779
-      byNu7T+et32TjD+jGDSOMuDss7DKXwZl9SNxbp3k5GQ8nCa+7nBQZDJ51apVubm5AoFg0AOYTCaH
-      wxFfJvzmAgICWlpabt++ffnyZU9PzyFzEvn4+Ojo6GRnZw9aa2Fh8dFHH72qVj6iVJcsFsvExMTD
-      w0P28bJjGLKR34Senp67u3t+fr74auJz584hhCBzHgDgzXV3d1+7ds3MzAxvxwDEQeMoxP79+ykU
-      yunTp0UlON8IzKrJoKx+JM6tk5ubGxcXZ29v7+TkNOQpVlZWPT09r8o2h3eDwBPlioJTFG3evPnF
-      ixfDyUmkqalpYWEhIwYrKyvFRvjee+85OzufO3cuIyNj5cqVw1ljITsG2Y38hsLCwkgk0qpVq6qr
-      q/GeeJGRkdOnTxdf0wkAAPJhs9k8Hm/ZsmWvmt2qq6srllJaWqriOAkxZOOA4cDTkjt37rxz5w6f
-      z//9999DQkLIZLKaZC1UT0q5zwbDuXXKysp++OGH4RyPB8le9R6QXSsfUYqi4eckEggEMmKQXSuf
-      gICAjRs3on/eqCTDkBEiRTejyNy5c5OSkjZs2CDabuejjz46f/48vgUHAADeBM6wLeN36ZYtW6QL
-      DQwMCEyGrzJDNg4YDhqNduXKlXXr1i1YsACXmJmZJSYmqkliaTVFyG6MeBWdxG6eu3bt0tfXFwgE
-      QqHQwMBAYnvKmzdvIoQKCwtVFiSDwZDYQ7Onp0dTU/PIkSNCoTAqKsrAwEDilAULFnh7e6ssQtkx
-      DNnIQ5Jv29O+vr579+5lZ2fX1tbKcToAYIRSq42SwUihhpcNn88vKyvLyckpKSnp7+8nOhx1py4D
-      RTweLz4+3tPTUzzlkrjTp09PmDDB0dFRxYGJO3v2LJ/PX7x48aC1lZWVd+/ePX78uIqjGn4MQzay
-      Qmhpac2ePVt5jw8AAAAoD5lMdnBwIDqKEUMtFlKUlpYyGIy2trZ9+/ZJ1zY3N4eEhCQkJBw9epRM
-      Jqs+PIRQd3d3bGzspk2bNmzYYG9vL1HL5/MzMzO9vLwcHR3Xrl1LSIRDxiC7kQEAAAAAXheR45F0
-      Op1MJvf29hoaGrq7u9+/f198S/jQ0NC9e/cODAyQSKS5c+fevHnTzc1NxRGmpqYaGhoihHDymqio
-      qKCgIFFtR0eHqHbSpEkrV64MDQ0V7dmjGkPGILuRAQAAAADkRhIKhUTHANTU+fK//B3eIzoKAMDI
-      AJ8YQA5w2Yx0ajGvDQAAAAAARhzoRwIAAAAAAHlAPxIAAAAAAMgD+pEAAAAAAEAe0I8EAAAAAADy
-      kOd+bdK/wpURCgAAAAAAUCVh1LY3OR3y/gAAAAAAAHnAvDYAAAAAAJAH9CMBAAAAAIA8oB8JAAAA
-      AADkAf1IAAAAAAAgD+hHAgAAAAAAeUA/EgAAAAAAyOP/AarkJHs4cLVkAAAAAElFTkSuQmCC
-    )
-  )
-  (image (at 255.27 175.26) (scale 0.75)
-    (uuid d6b589bf-79d6-4a14-adc5-455bad5b8447)
-    (data
-      iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz
-      AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h
-      aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73
-      +/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA
-      xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y
-      Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h
-      xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO
-      GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful
-      fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv
-      4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ
-      EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R
-      Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM
-      vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H
-      cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0
-      6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT
-      O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA
-      4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86
-      sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+
-      oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/
-      55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0
-      qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+
-      KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn
-      Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4
-      mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii
-      P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr
-      voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6
-      bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO
-      h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da
-      4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y
-      YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC
-      0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP
-      SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb
-      WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw
-      v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay
-      PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX
-      Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh
-      oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD
-      7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da
-      43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l
-      zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl
-      pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS
-      H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV
-      ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY
-      MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2
-      NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx
-      fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl
-      tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew
-      iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj
-      jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI
-      cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo
-      XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R
-      9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv
-      8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV
-      RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY
-      l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf
-      YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN
-      EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU
-      sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z
-      7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs
-      OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs
-      qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7
-      G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6
-      wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7
-      zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln
-      Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX
-      apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk
-      lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw
-      TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb
-      54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID
-      qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd
-      P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l
-      UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD
-      zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH
-      Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1
-      QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/
-      ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX
-      08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC
-      KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ
-      SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu
-      h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp
-      VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf
-      G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK
-      dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO
-      uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2
-      DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn
-      byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc
-      dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N
-      iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP
-      NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4
-      wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8
-      K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s
-      xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS
-      Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC
-      Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5
-      m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm
-      aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj
-      gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn
-      p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL
-      ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx
-      u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+
-      FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa
-      ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h
-      1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj
-      DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy
-      +Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj
-      wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj
-      7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ
-      lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN
-      2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY
-      CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi
-      mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E
-      uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x
-      j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD
-      45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO
-      4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni
-      buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY
-      HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH
-      NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ
-      azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N
-      SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP
-      hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe
-      nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4
-      b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN
-      xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S
-      pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq
-      3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB
-      Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL
-      4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw
-      qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX
-      9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n
-      frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/
-      eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK
-      TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u
-      RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9
-      DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j
-      2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx
-      BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy
-      91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7
-      jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw
-      pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ
-      cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M
-      xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23
-      7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8
-      D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw
-      YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu
-      QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs
-      uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA
-      PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6
-      yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN
-      xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq
-      JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT
-      +HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg
-      hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K
-      hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt
-      g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z
-      5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf
-      u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO
-      Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG
-      gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK
-      hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x
-      moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56
-      KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp
-      ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz
-      eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO
-      0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA
-      BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ
-      2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB
-      4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF
-      6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI
-      gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv
-      OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt
-      8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI
-      bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM
-      500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4
-      CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V
-      aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5
-      yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF
-      zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss
-      tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q
-      r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj
-      xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h
-      6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y
-      9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE
-      XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh
-      oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk
-      Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4
-      ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW
-      zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr
-      wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV
-      BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7
-      LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr
-      owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX
-      hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j
-      1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF
-      5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw
-      a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6
-      Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN
-      +SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds
-      lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ
-      i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu
-      fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy
-      r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28
-      dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az
-      70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk
-      EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL
-      p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf
-      nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA
-      ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c
-      q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu
-      Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR
-      TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53
-      en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA
-      x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ
-      t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+
-      R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf
-      5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH
-      e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG
-      po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh
-      6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln
-      9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU
-      xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ
-      rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W
-      lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb
-      afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs
-      FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR
-      OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC
-      P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp
-      EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh
-      6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK
-      GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ
-      hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s
-      amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+
-      fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij
-      TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv
-      I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf
-      kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ
-      BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD
-      9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn
-      jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8
-      I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI
-      8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs
-      Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN
-      MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5
-      2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU
-      2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss
-      ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m
-      sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq
-      LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT
-      tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9
-      oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p
-      zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu
-      WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy
-      diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX
-      ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY
-      5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau
-      Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7
-      oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG
-      xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q
-      zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik
-      sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN
-      ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc
-      MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E
-      YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3
-      bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz
-      DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC
-      TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES
-      3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K
-      Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd
-      b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5
-      99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys
-      7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa
-      Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e
-      8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1
-      vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK
-      VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4
-      ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD
-      CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4
-      qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr
-      1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe
-      GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK
-      yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj
-      po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO
-      Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF
-      tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D
-      mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM
-      eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN
-      veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu
-      5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL
-      Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t
-      rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl
-      sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx
-      mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG
-      PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk
-      Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk
-      caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO
-      jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS
-      gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E
-      OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+
-      p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO
-      cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM
-      S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc
-      vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3
-      boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn
-      DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD
-      90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw
-      0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT
-      5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI
-      7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP
-      QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw
-      oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E
-      mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/
-      N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm
-      vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC
-      +OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp
-      gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz
-      gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni
-      R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3
-      j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo
-      BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl
-      IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4
-      jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA
-      Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS
-      AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz
-      6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H
-      qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp
-      cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa
-      M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv
-      4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M
-      IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD
-      Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r
-      un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr
-      2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/
-      kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF
-      7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8
-      YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk
-      zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp
-      8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF
-      o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt
-      Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA
-      hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx
-      LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk
-      iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2
-      HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5
-      K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo
-      XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/
-      D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j
-      MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c
-      O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB
-      fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X
-      /V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI
-      a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe
-      L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37
-      zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY
-      BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg==
-    )
-  )
-
-  (text "Wiring of I2C to LCD from:\nhttps://alselectro.wordpress.com/2016/05/12/serial-lcd-i2c-module-pcf8574/"
-    (at 92.71 40.64 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 2eea87b6-6253-41ff-b6bd-8a96c7653ab7)
-  )
-  (text "LCD compnents including I2C interface." (at 92.71 34.29 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 6138e430-934a-4641-a002-b410d09e5754)
-  )
-  (text "CONTRAST" (at 203.2 81.28 0)
-    (effects (font (size 2.54 2.54)) (justify left bottom))
-    (uuid c24b6d8d-bd4b-49c8-9da2-390592b7000a)
-  )
-  (text "The six resistors connected to A0 A1 A2 \ndefine the I2C address ref to table 5 below:"
-    (at 74.93 111.76 0)
-    (effects (font (size 1.524 1.524)) (justify left bottom))
-    (uuid ed02c1a5-b65d-4ea0-bf31-1c566947c590)
-  )
-
-  (label "Vcc_LCD" (at 232.41 40.64 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 2debe4d7-da40-40c0-bf97-52f3075d0907)
-  )
-
-  (hierarchical_label "SCL" (shape input) (at 20.32 74.93 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 6e396f1d-9e79-4394-a431-e9f406774c1e)
-  )
-  (hierarchical_label "SDA" (shape bidirectional) (at 20.32 86.36 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid b5826874-d3d3-4104-8afa-556db95ba566)
-  )
-  (hierarchical_label "3V3Raw" (shape input) (at 21.59 53.34 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid d8118b62-1e88-4a04-95f5-44238e19a6eb)
-  )
-
-  (symbol (lib_id "Device:R") (at 107.95 63.5 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b90f41)
-    (property "Reference" "R303" (at 110.49 59.69 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 111.76 64.77 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 109.728 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 107.95 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 107.95 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 107.95 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 107.95 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 107.95 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 107.95 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 107.95 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 107.95 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 107.95 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 107.95 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ac80ab56-5966-42fd-8369-c78267a9cecf))
-    (pin "2" (uuid f77e5b49-e840-4f0f-b02d-7e5b701a8438))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R303") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 116.84 63.5 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b90f4c)
-    (property "Reference" "R304" (at 119.38 59.69 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1K" (at 120.65 64.77 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 118.618 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 116.84 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 116.84 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269704" (at 116.84 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 116.84 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06031K1%N" (at 116.84 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 1kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 116.84 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 116.84 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 116.84 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 116.84 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 116.84 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a33b1bb5-f8ec-4eb2-8719-3f7b58cc74ef))
-    (pin "2" (uuid 4dd13ec6-8697-4126-810a-05113277d82a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R304") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 97.79 63.5 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b90f99)
-    (property "Reference" "R302" (at 100.33 59.69 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 101.6 64.77 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 99.568 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 97.79 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 97.79 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 97.79 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 97.79 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 97.79 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 97.79 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 97.79 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 97.79 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 97.79 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 97.79 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c8cbc077-2e6d-42c3-bd35-cca03431cd4e))
-    (pin "2" (uuid b0c85ca2-aa4a-47bd-b480-e6055d0006e2))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R302") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 88.9 63.5 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b90fa4)
-    (property "Reference" "R301" (at 91.44 59.69 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 92.71 64.77 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 90.678 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 88.9 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 88.9 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 88.9 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 88.9 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 88.9 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 88.9 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 88.9 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 88.9 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 88.9 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 88.9 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2583853e-c3c0-47a8-97a8-88e94b158567))
-    (pin "2" (uuid 7612200f-b4d9-4faa-a157-5ff616d37c6c))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R301") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 189.23 40.64 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b90fbb)
-    (property "Reference" "R310" (at 187.96 35.56 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1R0" (at 189.23 38.1 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 189.23 38.862 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 189.23 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 189.23 40.64 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 189.23 40.64 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 189.23 40.64 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 189.23 40.64 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 189.23 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 189.23 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 189.23 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 189.23 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 189.23 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid de16c208-6a9d-400a-a938-ccc9384e4bfa))
-    (pin "2" (uuid ec791030-4432-4ead-a414-ec9517e2fce2))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R310") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C_Polarized") (at 215.9 44.45 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b90fc5)
-    (property "Reference" "C302" (at 218.8972 43.2816 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "47uF 16V" (at 218.8972 45.593 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4" (at 216.8652 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2895272" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "KNSCHA" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RVT47UF16V67RV0019" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.038" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d66ccd4c-3439-4d30-8ee7-00cb7cb44814))
-    (pin "2" (uuid fee8cc62-52a8-4972-bc95-218641457912))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "C302") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 203.2 44.45 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b90fd0)
-    (property "Reference" "C301" (at 206.121 43.2816 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 206.121 45.593 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 204.1652 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 203.2 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 203.2 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 203.2 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 203.2 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 203.2 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 203.2 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 203.2 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 203.2 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 203.2 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 203.2 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fb7737a1-400a-40d4-9794-11eea5e3924c))
-    (pin "2" (uuid 062f2ae7-eefd-4e7c-8628-3046b6667476))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "C301") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 203.2 100.33 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b90fe7)
-    (property "Reference" "R311" (at 208.28 99.06 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 207.01 101.6 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 204.978 100.33 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 203.2 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 203.2 100.33 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 203.2 100.33 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 203.2 100.33 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 203.2 100.33 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 203.2 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 203.2 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 203.2 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 203.2 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 203.2 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid afc0a8e1-a01c-45c4-a473-052897a82ed2))
-    (pin "2" (uuid 473eaaac-17c4-4f16-b752-5125697e461b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R311") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Transistor_FET:BSS138") (at 218.44 104.14 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b90ff3)
-    (property "Reference" "Q301" (at 223.6216 102.9716 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "BSS138" (at 223.6216 105.283 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 223.52 106.045 0)
-      (effects (font (size 1.27 1.27) italic) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF" (at 218.44 104.14 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Description" "N-Channel Enhancement Mode Field Effect Transistor" (at 218.44 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 218.44 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C400505" (at 218.44 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd" (at 218.44 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "BSS138" (at 218.44 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 218.44 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0196" (at 218.44 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 218.44 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 218.44 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 292fd703-5baa-4e53-8749-f2097c29e572))
-    (pin "2" (uuid b002b100-3c23-485c-ac3e-7ca3886ba277))
-    (pin "3" (uuid 6b250f59-6fe8-4085-a5a9-9986396245b6))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "Q301") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+5V") (at 180.34 40.64 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b90ffa)
-    (property "Reference" "#PWR0303" (at 180.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+5V" (at 180.721 36.2458 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 180.34 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 180.34 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 30f7d6da-4fba-4e5f-a235-79e2a5ba7a1f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#PWR0303") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 116.84 95.25 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062c6d2fc)
-    (property "Reference" "R305" (at 119.38 91.44 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1R0" (at 120.65 96.52 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 115.062 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 116.84 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 116.84 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 116.84 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 116.84 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 116.84 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 116.84 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 116.84 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 116.84 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 116.84 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 116.84 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 17fe85d4-088c-4a53-8541-0049f0cea481))
-    (pin "2" (uuid 6963339a-a2f8-41dd-b9e5-986217b643a6))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R305") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 125.73 95.25 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062c73c08)
-    (property "Reference" "R307" (at 128.27 91.44 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1R0" (at 129.54 96.52 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 123.952 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 125.73 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 125.73 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 125.73 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 125.73 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 125.73 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 125.73 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 125.73 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 125.73 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 125.73 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 125.73 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e299cc96-bc7d-414b-b284-5b1e8520a67f))
-    (pin "2" (uuid f3ce02b3-dabd-4cb3-adb7-7bd223bfedb9))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R307") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 133.35 95.25 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062c74117)
-    (property "Reference" "R309" (at 135.89 91.44 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1R0" (at 137.16 96.52 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 131.572 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 133.35 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 133.35 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 133.35 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 133.35 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 133.35 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 133.35 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 133.35 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 133.35 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 133.35 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 133.35 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 64d98481-e4d1-479c-a046-284c4f3a5431))
-    (pin "2" (uuid 91ddce6d-9a15-42d2-add4-e4b090914cc7))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R309") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 139.7 106.68 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062c8b28f)
-    (property "Reference" "TP402" (at 143.51 107.95 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "nINT" (at 144.78 113.03 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 134.62 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 134.62 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 139.7 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 139.7 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 139.7 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 139.7 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 139.7 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 139.7 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 139.7 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 139.7 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 139.7 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 55d2946e-de11-4bd3-b26c-19770c8ae74f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP402") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:PWR_FLAG") (at 167.64 49.53 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062e5ea08)
-    (property "Reference" "#FLG0301" (at 167.64 47.625 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "PWR_FLAG" (at 167.64 45.1358 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 167.64 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 167.64 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7a51edfd-de8e-4eb3-adf5-0e0e3af2922d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#FLG0301") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 226.06 59.69 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062e746dd)
-    (property "Reference" "R306" (at 228.6 55.88 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 229.87 60.96 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 227.838 59.69 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 226.06 59.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DNI" (at 226.06 59.69 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "DNI" (at 226.06 59.69 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 226.06 59.69 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "DNI" (at 226.06 59.69 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "DNI" (at 226.06 59.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 226.06 59.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 226.06 59.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 226.06 59.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 226.06 59.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 790105eb-7c6d-4e8e-b4ed-ecaee3754b2f))
-    (pin "2" (uuid e6d231e8-56fb-424b-808b-a6ff775221f1))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R306") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:PWR_FLAG") (at 198.12 59.69 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062e7d140)
-    (property "Reference" "#FLG0302" (at 200.025 59.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "PWR_FLAG" (at 201.3712 59.69 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 198.12 59.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 198.12 59.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 84f3c470-17c8-4878-9f7d-ce446d93b9fa))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#FLG0302") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 226.06 72.39 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062e82d99)
-    (property "Reference" "R308" (at 228.6 68.58 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 229.87 73.66 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 227.838 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 226.06 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DNI" (at 226.06 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "DNI" (at 226.06 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 226.06 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "DNI" (at 226.06 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "DNI" (at 226.06 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 226.06 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 226.06 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 226.06 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 226.06 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f773a457-a462-418a-856e-a3385939ef14))
-    (pin "2" (uuid 46bef5dd-0b35-4d18-b6a7-490faec63cff))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R308") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Nut_4-40_0.1875") (at 20.955 191.135 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid 014f6fe9-5a14-4755-b8d7-f8f5ef503162)
-    (property "Reference" "MF403" (at 26.67 189.8649 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Nut_4-40_0.1875" (at 26.67 192.4049 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 20.955 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf" (at 20.955 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DigiKey" (at 20.955 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "36-4694-ND" (at 20.955 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "$0.10000" (at 20.955 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 20.955 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 20.955 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 20.955 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "4694" (at 20.955 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Keystone Electronics" (at 20.955 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "#4-40 Hex Nut 0.187\" (4.75mm) 3/16\" Steel" (at 20.955 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF403") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 78.74 63.5 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 01787b6e-0ac1-4323-a778-5eba53025ce4)
-    (property "Reference" "R410" (at 81.28 59.69 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 82.55 64.77 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 80.518 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 78.74 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 78.74 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 78.74 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 78.74 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 78.74 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 78.74 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 78.74 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 78.74 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 78.74 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 29767ad6-c82a-44d2-81fb-18e6e6727b3f))
-    (pin "2" (uuid 7f28e3de-d9a1-43eb-be9b-53fce523d6d8))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R410") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Transistor_FET:BSS138") (at 53.34 72.39 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 09258e51-72b0-44dc-be50-3af085ca3b27)
-    (property "Reference" "Q401" (at 55.88 71.12 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "BSS138" (at 49.53 78.74 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 51.435 77.47 0)
-      (effects (font (size 1.27 1.27) italic) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF" (at 53.34 72.39 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Description" "N-Channel Enhancement Mode Field Effect Transistor" (at 53.34 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 53.34 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C400505" (at 53.34 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd" (at 53.34 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "BSS138" (at 53.34 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 53.34 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0196" (at 53.34 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 53.34 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 53.34 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 49a39b5f-2c1a-45a2-808c-1be3591faae1))
-    (pin "2" (uuid 35f9c926-c92d-4bdf-9c26-3ef4ad3a2b38))
-    (pin "3" (uuid 94f64d75-e799-4e45-a018-c9a9b04edd54))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "Q401") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Spacer_0.0182x0.125_inch") (at 92.71 181.61 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid 0bbbda63-c97c-4607-af22-6c234905b972)
-    (property "Reference" "MF408" (at 99.06 180.34 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Spacer_0.0182x0.125 inch" (at 99.06 182.88 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 92.71 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 92.71 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "94639A702" (at 92.71 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "McMaster-Carr" (at 92.71 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.1145" (at 92.71 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 92.71 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Off-White Nylon Unthreaded Spacer, 0.1875\" OD, 1/8\" Long, for Number 4 Screw Size" (at 92.71 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 92.71 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 92.71 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "94639A702" (at 92.71 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "McMaster-Carr" (at 92.71 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF408") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 226.06 77.47 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0ed72387-e6a5-417d-b992-3772bbdd9957)
-    (property "Reference" "#PWR0406" (at 226.06 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 226.06 82.55 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 226.06 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 226.06 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fa3e7eb5-54df-4572-a7ce-9e5b83299f5c))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#PWR0406") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 69.85 63.5 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 1359ea37-be74-47fc-a927-75aa27b82a04)
-    (property "Reference" "R409" (at 72.39 59.69 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 71.628 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 69.85 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 69.85 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 69.85 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 69.85 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 69.85 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 69.85 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 69.85 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 69.85 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 69.85 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 69.85 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f2132d97-6eaf-4441-bfa3-e8feeba7a2c2))
-    (pin "2" (uuid 909493e3-2cca-46e0-9ef4-e446976d857e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R409") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 203.2 49.53 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 217a5803-3f18-4063-ab30-799091d6baff)
-    (property "Reference" "#PWR0410" (at 203.2 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 203.2 54.61 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 203.2 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 203.2 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 158b63c3-41bd-464d-80bd-5bc7ad711ece))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#PWR0410") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 185.42 100.33 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 24afa58f-c8eb-47f2-aa08-6b895c802ded)
-    (property "Reference" "#PWR0402" (at 185.42 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 185.42 105.41 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 185.42 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 185.42 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e6ff38f2-8e87-477c-9174-ba8c12dbac55))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#PWR0402") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:LCD_20x4_Character-GPAD_SCH_LIB") (at 185.42 77.47 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 2ab4402c-7d6e-4745-b7e2-2505e19e98be)
-    (property "Reference" "U302" (at 162.56 55.88 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "LCD_20x4_Character-GPAD_SCH_LIB" (at 158.75 58.42 0)
-      (effects (font (size 1 1)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:LCD_2004A" (at 185.42 100.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 187.96 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "eBay   Aliexpress" (at 157.988 94.996 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "403534100457 " (at 182.88 97.536 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2" "Amazon  / Aliexpress" (at 156.972 100.584 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2 PN" "https://www.amazon.com/GeeekPi-Interface-Adapter-Backlight-Raspberry/dp/B07QLRD3TM/ref=sr_1_2 /  https://www.aliexpress.com/item/3256803213374992.html" (at 205.486 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Assembly Type" "" (at 185.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "4.99" (at 185.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "2004 LCD Display Module Character 20x4 Blacklight Gray Yellow Blue" (at 185.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "https://www.ebay.com/itm/403534100457" (at 185.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 185.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 185.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 185.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 185.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6799f5af-dda7-4072-9f74-25049e2a66ed))
-    (pin "10" (uuid f7dee6fb-df4d-414d-b6a2-9a2c5272937e))
-    (pin "11" (uuid c1d010ad-7e0b-4ca8-bc89-b932ad9e69f7))
-    (pin "12" (uuid 00d40a8f-3756-48e6-a893-33b7903eec31))
-    (pin "13" (uuid e86f44a6-c915-42ea-8731-0802990f017a))
-    (pin "14" (uuid e00c1ebf-60fa-448c-a601-6fc7c78e4649))
-    (pin "15" (uuid 122194bf-d0d7-4837-807d-a315db79cee3))
-    (pin "16" (uuid b292c015-a9b6-4eac-80ee-90f82c6274b0))
-    (pin "17" (uuid 5e8ef7f2-dd44-415b-9052-e6783d350fed))
-    (pin "18" (uuid 95baef0e-dbb1-4d7b-bead-7eafcaa37290))
-    (pin "19" (uuid 8375e995-0cf5-463f-be81-46027732fb0f))
-    (pin "2" (uuid 454a7a70-b195-490c-9d94-af41a95efeae))
-    (pin "20" (uuid edfcbad2-288e-41a2-80e3-d61ef8162b22))
-    (pin "3" (uuid b5318fbb-4bf0-4330-95f1-1b4b92986d4b))
-    (pin "4" (uuid e57840d8-ec70-4537-b18b-8c2b6ce1159d))
-    (pin "5" (uuid 4d8da57f-8ee4-4d44-b990-64fe7394351c))
-    (pin "6" (uuid 9edd2fd7-0276-48b4-94f9-5abb9a682561))
-    (pin "7" (uuid 2c9a51e3-5671-486a-b33b-14d7f7eff9fa))
-    (pin "8" (uuid bb387c69-f974-4605-bb1a-c50d220651bf))
-    (pin "9" (uuid dfd2bb7f-b83b-4198-ae74-10cb2ed4efa3))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "U302") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Spacer_0.0182x0.125_inch") (at 129.54 181.61 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid 2bc9d111-b8bc-4e61-b9fe-a5c44a2f224c)
-    (property "Reference" "MF411" (at 135.89 180.34 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Spacer_0.0182x0.125 inch" (at 135.89 182.88 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 129.54 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 129.54 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "94639A702" (at 129.54 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "McMaster-Carr" (at 129.54 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.1145" (at 129.54 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 129.54 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Off-White Nylon Unthreaded Spacer, 0.1875\" OD, 1/8\" Long, for Number 4 Screw Size" (at 129.54 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 129.54 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 129.54 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "94639A702" (at 129.54 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "McMaster-Carr" (at 129.54 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF411") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 208.28 106.68 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 2ce94dde-528e-4af6-b4b5-b03655a3503e)
-    (property "Reference" "R312" (at 207.01 104.14 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 208.28 110.49 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 208.28 104.902 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 208.28 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 208.28 106.68 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 208.28 106.68 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 208.28 106.68 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 208.28 106.68 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 208.28 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 208.28 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 208.28 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 208.28 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 208.28 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6dc617e0-32e8-4cea-94e0-9920112d1297))
-    (pin "2" (uuid 3c8dd449-f5c1-4f8b-a151-a38f197056da))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R312") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Nut_4-40_0.1875") (at 128.27 191.77 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid 321f509c-c1d5-4d92-a011-88911bf1dfbe)
-    (property "Reference" "MF412" (at 133.985 190.4999 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Nut_4-40_0.1875" (at 133.985 193.0399 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 128.27 191.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf" (at 128.27 191.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DigiKey" (at 128.27 191.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "36-4694-ND" (at 128.27 191.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "$0.10000" (at 128.27 191.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 128.27 191.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 128.27 191.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 128.27 191.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "4694" (at 128.27 191.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Keystone Electronics" (at 128.27 191.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "#4-40 Hex Nut 0.187\" (4.75mm) 3/16\" Steel" (at 128.27 191.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF412") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Nut_4-40_0.1875") (at 92.71 192.405 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid 52ea4c17-8c70-404a-bd81-759de8e6e1dc)
-    (property "Reference" "MF409" (at 99.06 191.1349 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Nut_4-40_0.1875" (at 99.06 193.6749 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 92.71 192.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf" (at 92.71 192.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DigiKey" (at 92.71 192.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "36-4694-ND" (at 92.71 192.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "$0.10000" (at 92.71 192.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 92.71 192.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 92.71 192.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 92.71 192.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "4694" (at 92.71 192.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Keystone Electronics" (at 92.71 192.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "#4-40 Hex Nut 0.187\" (4.75mm) 3/16\" Steel" (at 92.71 192.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF409") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 31.75 63.5 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 5941a990-7191-4ced-8da7-296ee1595fc0)
-    (property "Reference" "R405" (at 34.29 59.69 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 35.56 64.77 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 33.528 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 31.75 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 31.75 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 31.75 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 31.75 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 31.75 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 31.75 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 31.75 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 31.75 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 31.75 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 31.75 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 53a93d32-1486-4cd3-adfe-dbd9b6bdcce5))
-    (pin "2" (uuid ba3f4dbe-d7ec-4fa3-b209-f763c550b19f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R405") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Screw_4-40_0.375_Phillips") (at 58.42 171.45 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid 5f619803-b5b9-4c9f-8b28-2286ea24524c)
-    (property "Reference" "MF404" (at 62.23 170.1799 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Screw_4-40_0.375_Phillips" (at 62.23 172.7199 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 58.42 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 58.42 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "McMaster-Carr" (at 58.42 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "90272A108" (at 58.42 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0182" (at 58.42 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 58.42 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Zinc-Plated Steel Pan Head Phillips Screw, 4-40 Thread, 3/8\" Long" (at 58.42 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 58.42 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 58.42 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "90272A108" (at 58.42 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "McMaster-Carr" (at 58.42 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF404") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Spacer_0.0182x0.125_inch") (at 58.42 180.34 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid 60bc9650-1c6c-4288-8d5d-7a31cca2ad06)
-    (property "Reference" "MF405" (at 64.77 179.07 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Spacer_0.0182x0.125 inch" (at 64.77 181.61 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 58.42 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 58.42 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "94639A702" (at 58.42 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "McMaster-Carr" (at 58.42 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.1145" (at 58.42 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 58.42 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Off-White Nylon Unthreaded Spacer, 0.1875\" OD, 1/8\" Long, for Number 4 Screw Size" (at 58.42 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 58.42 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 58.42 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "94639A702" (at 58.42 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "McMaster-Carr" (at 58.42 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF405") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 40.64 63.5 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 6300a1e0-02b5-41f7-8f02-43b23eed6a01)
-    (property "Reference" "R406" (at 43.18 59.69 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 44.45 64.77 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 42.418 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 40.64 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 40.64 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 40.64 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 40.64 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 40.64 63.5 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 40.64 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 40.64 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 40.64 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 40.64 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 40.64 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c98c79ea-d35a-4689-9ea0-5dfb9e62ba7e))
-    (pin "2" (uuid 0ea940a1-aac9-442f-8278-289a2dee7c84))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R406") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector_Generic:Conn_01x16") (at 252.73 81.28 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 64bef9a2-6017-4149-bf8d-80701c5a4983)
-    (property "Reference" "U303" (at 255.27 81.28 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Conn_01x16" (at 255.27 83.82 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x16_P2.54mm_Vertical" (at 252.73 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 252.73 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 252.73 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C22465876" (at 252.73 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "PZ254V-11-16P" (at 252.73 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "XFCN" (at 252.73 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.09" (at 252.73 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Plugin,P=2.54mm Pin Headers ROHS" (at 252.73 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 252.73 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 252.73 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 252.73 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d6cae7c1-e48c-4f21-8ac5-a128661de828))
-    (pin "10" (uuid b359546b-6c4f-4d1f-a4b4-aa5a814c1013))
-    (pin "11" (uuid c61a0f9b-ace9-4519-bdb8-dee917b1bd3d))
-    (pin "12" (uuid df174ab6-58e8-4a61-b638-08db28e5cc51))
-    (pin "13" (uuid 8d9ca9a2-15dd-461a-a87c-ab32c9267c29))
-    (pin "14" (uuid 8bbc0226-7920-474d-b6f9-2eb4bef01a13))
-    (pin "15" (uuid 51031b1e-0fdb-45e4-94b4-6f3858d13b47))
-    (pin "16" (uuid e9bea479-ef21-4aa6-ad88-0b20e18972a8))
-    (pin "2" (uuid 52266cac-25c6-43b6-a683-463bd3cffabf))
-    (pin "3" (uuid c2fbcf4c-3976-4de4-8432-b3676c5d8efc))
-    (pin "4" (uuid 670e5078-9ac8-4af8-a97d-b0e88a034cd9))
-    (pin "5" (uuid dbb1a71b-cdd5-4da3-9704-26bb0549d88c))
-    (pin "6" (uuid 3642cfbc-01c6-4bda-89b0-4fc225be22b7))
-    (pin "7" (uuid 628dfcf0-6b56-46c3-8be9-9addd45fc29d))
-    (pin "8" (uuid afe132a1-4dbe-42b3-9c05-39e03dd49e96))
-    (pin "9" (uuid 0d7c75cf-03c6-4657-955c-15eccf6c65be))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "U303") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 156.21 105.41 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 664ce4fd-edb5-466e-a148-03aa5edcd405)
-    (property "Reference" "#PWR0403" (at 156.21 111.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 156.21 110.49 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 156.21 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 156.21 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2f2877ab-7567-43da-9887-a2dba42fd5fa))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#PWR0403") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 209.55 74.93 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 67faf9d0-d33d-47ff-8f6d-b0932c4ac42d)
-    (property "Reference" "#PWR0407" (at 209.55 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 209.55 80.01 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 209.55 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 209.55 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9820b8c7-569c-4886-9639-6714de86dd30))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#PWR0407") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Screw_4-40_0.375_Phillips") (at 92.71 171.45 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid 756a2495-fd18-4be4-9093-457c5824c477)
-    (property "Reference" "MF407" (at 96.52 170.1799 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Screw_4-40_0.375_Phillips" (at 96.52 172.7199 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 92.71 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 92.71 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "McMaster-Carr" (at 92.71 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "90272A108" (at 92.71 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0182" (at 92.71 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 92.71 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Zinc-Plated Steel Pan Head Phillips Screw, 4-40 Thread, 3/8\" Long" (at 92.71 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 92.71 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 92.71 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "90272A108" (at 92.71 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "McMaster-Carr" (at 92.71 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF407") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Screw_4-40_0.375_Phillips") (at 127 171.45 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid 7b9a9c27-6413-41e9-91d9-b1c74b2c007e)
-    (property "Reference" "MF410" (at 130.81 170.1799 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Screw_4-40_0.375_Phillips" (at 130.81 172.7199 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 127 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 127 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "McMaster-Carr" (at 127 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "90272A108" (at 127 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0182" (at 127 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 127 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Zinc-Plated Steel Pan Head Phillips Screw, 4-40 Thread, 3/8\" Long" (at 127 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 127 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 127 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "90272A108" (at 127 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "McMaster-Carr" (at 127 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF410") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 220.98 111.76 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 95bde4a0-d658-4db6-8cb6-1d6ce03efa0d)
-    (property "Reference" "#PWR0405" (at 220.98 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 220.98 116.84 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 220.98 111.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 220.98 111.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1069604d-daba-4157-9dd0-d70afe7a4522))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#PWR0405") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Nut_4-40_0.1875") (at 57.785 191.135 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid 99fac1dd-4999-406f-a43f-0df717311a06)
-    (property "Reference" "MF406" (at 63.5 189.8649 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Nut_4-40_0.1875" (at 63.5 192.4049 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 57.785 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf" (at 57.785 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DigiKey" (at 57.785 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "36-4694-ND" (at 57.785 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "$0.10000" (at 57.785 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 57.785 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 57.785 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 57.785 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "4694" (at 57.785 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Keystone Electronics" (at 57.785 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "#4-40 Hex Nut 0.187\" (4.75mm) 3/16\" Steel" (at 57.785 191.135 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF406") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 214.63 60.96 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 9ca882a4-64f8-4304-8de0-abda32ac092e)
-    (property "Reference" "TP102" (at 210.82 54.61 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Vcontrast" (at 210.82 55.88 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 219.71 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 219.71 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 214.63 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 214.63 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Red" (at 214.63 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 214.63 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 214.63 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 214.63 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 214.63 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 214.63 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 214.63 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20b27a6e-77b1-4db6-a2e5-91c88d5fa6cf))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP102") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP405") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 50.8 82.55 270) (unit 1)
-    (in_bom no) (on_board yes) (dnp no)
-    (uuid ba359b61-1929-414c-80f1-518864807323)
-    (property "Reference" "R407" (at 46.99 80.01 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 50.8 85.09 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 50.8 80.772 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 50.8 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 50.8 82.55 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 50.8 82.55 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 50.8 82.55 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 50.8 82.55 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 50.8 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 50.8 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 50.8 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 50.8 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 50.8 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6a0397bd-eb19-443a-846b-9e62b4dd2457))
-    (pin "2" (uuid 66d433d9-7e7e-4145-bf8f-a044cf42f52f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R407") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 62.23 93.98 270) (unit 1)
-    (in_bom no) (on_board yes) (dnp no)
-    (uuid c34b2ad2-aef4-47c7-8727-d9ca831d0e95)
-    (property "Reference" "R408" (at 58.42 91.44 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 62.23 96.52 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 62.23 92.202 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 62.23 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 62.23 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 62.23 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 62.23 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 62.23 93.98 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 62.23 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 62.23 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 62.23 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 62.23 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 62.23 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 840b5961-cc6e-4837-ba75-3f04b64e38a0))
-    (pin "2" (uuid 3cc5147d-f0aa-4cee-8907-d2a0cb57ac7b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R408") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Transistor_FET:BSS138") (at 63.5 83.82 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid ce51c2da-3d7d-48f4-84c8-2c3a8d973e40)
-    (property "Reference" "Q402" (at 66.04 82.55 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "BSS138" (at 59.69 90.17 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 61.595 88.9 0)
-      (effects (font (size 1.27 1.27) italic) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF" (at 63.5 83.82 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Description" "N-Channel Enhancement Mode Field Effect Transistor" (at 63.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 63.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C400505" (at 63.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd" (at 63.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "BSS138" (at 63.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 63.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0196" (at 63.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 63.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 63.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid db5c2538-a17b-4f2b-bf76-56fdf95ccdfc))
-    (pin "2" (uuid af8a60d2-c03f-4dc2-a602-fe7cc816cb38))
-    (pin "3" (uuid 85b02ee7-acd5-4a3b-989e-6c4d27dafbaa))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "Q402") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 134.62 67.31 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid d2692076-1e83-478d-b26b-489e383e9933)
-    (property "Reference" "TP404" (at 134.62 60.96 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "SDA" (at 135.89 63.5 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 139.7 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 134.62 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 134.62 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 134.62 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 134.62 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 134.62 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 134.62 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 134.62 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 134.62 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 134.62 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid baeafecb-bacd-4924-816e-e282c3e8caf0))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP404") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 215.9 49.53 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d609d9ff-e246-4f7a-87c2-bf60bf19a787)
-    (property "Reference" "#PWR0409" (at 215.9 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 215.9 54.61 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 215.9 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 215.9 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b6ec202e-f45c-4b1f-9b87-68ea76fe4dad))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#PWR0409") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 223.52 35.56 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid dab85703-edaf-43d3-9499-41b59d9a43e0)
-    (property "Reference" "TP401" (at 224.79 31.75 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Vcc_LCD" (at 224.79 34.29 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 228.6 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 228.6 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 223.52 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Red" (at 223.52 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 223.52 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 223.52 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 223.52 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 223.52 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 223.52 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 223.52 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 223.52 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 69f7ea91-da66-4f35-8c5d-b4bd16b7525a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP401") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:PCF8574AT_3_518") (at 156.21 85.09 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid e051ebe0-83f1-4aa8-b0c7-b7b5af8758eb)
-    (property "Reference" "U301" (at 149.86 63.5 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "PCF8574AT_3_518" (at 137.16 66.04 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Package_SO:SOIC-16W_7.5x10.3mm_P1.27mm" (at 156.21 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811151526_NXP-Semicon-PCF8574AT-3-518_C86832.pdf" (at 156.21 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 156.21 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "1.87" (at 156.21 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 156.21 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C86832" (at 156.21 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "PCF8574AT_3_518" (at 156.21 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 156.21 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 156.21 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "8 100kHz I2C SOIC-16-300mil I/O Expanders ROHS" (at 156.21 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NXP Semicon" (at 156.21 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3a5ad194-12eb-4a59-9b31-e28e59238a97))
-    (pin "10" (uuid 389b8006-63b1-49ce-810a-48e9aa2d663d))
-    (pin "11" (uuid d4b7136d-93fd-4677-bf29-226bbffa08ae))
-    (pin "12" (uuid 998ee018-9af7-40e2-a05e-af08d7338766))
-    (pin "13" (uuid 019e7b79-122e-4c86-8dd8-7ef120edbedd))
-    (pin "14" (uuid 51811ac5-c91c-43b0-873d-5a7aa0a35f20))
-    (pin "15" (uuid 3739fd5a-cfa5-49b0-8f7a-194c909a27c0))
-    (pin "16" (uuid b16c5b84-315b-4ae0-ab13-c124f155fd49))
-    (pin "2" (uuid d630269b-14ed-4b22-ba47-3ae8d2c15ecf))
-    (pin "3" (uuid 6e0502b5-df10-487b-be98-d439e28716cf))
-    (pin "4" (uuid 341e903e-89d3-4e18-90ee-2d961eb2a242))
-    (pin "5" (uuid c741e8b2-16af-41df-843b-7ed311de60e7))
-    (pin "6" (uuid c8cc664c-0f70-4d46-a80e-ee1967252084))
-    (pin "7" (uuid e911a7a8-b550-4a4e-859e-c273ccf177c9))
-    (pin "8" (uuid e437afbd-8282-456e-a65a-3dffef62b39c))
-    (pin "9" (uuid a661a92b-14df-464e-8226-58604d711499))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "U301") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:POT_0.375_10K") (at 209.55 68.58 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e6b2915e-b2de-400e-841f-313969e9ee14)
-    (property "Reference" "RV301" (at 212.09 67.183 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "POT 0.375 10K" (at 212.09 69.723 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:Potentiometer_Bourns_3386P_Vertical" (at 209.55 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.bourns.com/docs/Product-Datasheets/3386.pdf" (at 209.55 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C116281" (at 209.55 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 209.55 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "3386P-1-103LF" (at 209.55 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Assembly Type" "" (at 207.01 67.4371 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Distributor 2" "Digi-Key" (at 209.55 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2 PN" "3386P-103LF-ND" (at 205.74 74.93 0)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Cost" "0.6963" (at 201.93 69.85 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "BOURNS" (at 209.55 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 209.55 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "±10% ±100ppm/℃ 10kΩ Plugin Variable Resistors/Potentiometers ROHS" (at 209.55 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 209.55 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 209.55 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d020a011-230d-44ae-a806-9feff29695dd))
-    (pin "2" (uuid 0a464c3c-7a04-4abf-8126-95d001d2d2ef))
-    (pin "3" (uuid 60d54a8d-ee11-4071-8c23-4be852275389))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "RV301") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 129.54 104.14 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid edf21dec-b4ce-48a6-9b5b-615ecacb5660)
-    (property "Reference" "#PWR0404" (at 129.54 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 129.54 109.22 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 129.54 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 129.54 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 849a44a4-3285-42d3-803d-586f0ee2c1cc))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#PWR0404") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 199.39 76.2 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f1806f52-48be-4d9c-b4f7-ab880f2c0c08)
-    (property "Reference" "#PWR0408" (at 199.39 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 199.39 81.28 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 199.39 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 199.39 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bea2b4c8-42a1-4f53-b79a-b32385c40cf3))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "#PWR0408") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Spacer_0.0182x0.125_inch") (at 21.59 180.34 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid f199673c-0736-4cc4-bbb0-55abbef49738)
-    (property "Reference" "MF402" (at 27.94 179.07 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Spacer_0.0182x0.125 inch" (at 27.94 181.61 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 21.59 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 21.59 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "94639A702" (at 21.59 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "McMaster-Carr" (at 21.59 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.1145" (at 21.59 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 21.59 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Off-White Nylon Unthreaded Spacer, 0.1875\" OD, 1/8\" Long, for Number 4 Screw Size" (at 21.59 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 21.59 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 21.59 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "94639A702" (at 21.59 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "McMaster-Carr" (at 21.59 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF402") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 129.54 71.12 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid f4bf92a9-c0cf-47f9-a140-30daad06e0b8)
-    (property "Reference" "TP403" (at 124.46 64.77 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "SCL" (at 124.46 67.31 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 134.62 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 134.62 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 129.54 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 129.54 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 129.54 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 129.54 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 129.54 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 129.54 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 129.54 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 129.54 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 129.54 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 385d1835-f4d0-4125-bce2-4f32000fd09e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP403") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Screw_4-40_0.375_Phillips") (at 21.59 171.45 0) (unit 1)
-    (in_bom yes) (on_board no) (dnp no) (fields_autoplaced)
-    (uuid fbcd2f6c-e85f-48ea-bb94-218dde6e448f)
-    (property "Reference" "MF401" (at 25.4 170.1799 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Screw_4-40_0.375_Phillips" (at 25.4 172.7199 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "" (at 21.59 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.mcmaster.com/catalog/128/3306" (at 21.59 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "McMaster-Carr" (at 21.59 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "90272A108" (at 21.59 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0182" (at 21.59 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 21.59 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Zinc-Plated Steel Pan Head Phillips Screw, 4-40 Thread, 3/8\" Long" (at 21.59 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 21.59 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 21.59 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "90272A108" (at 21.59 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "McMaster-Carr" (at 21.59 171.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "MF401") (unit 1)
-        )
-      )
-    )
-  )
+(kicad_sch
+	(version 20251012)
+	(generator "eeschema")
+	(generator_version "9.99")
+	(uuid "d6e66b98-e037-42d7-96c2-757b973a5a2d")
+	(paper "A4")
+	(title_block
+		(title "KRAKE_PCB")
+		(date "2025-07-18")
+		(rev "2.0")
+		(company "PublicInvention")
+		(comment 1 "GNU Affero General Public License v3.0")
+		(comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
+		(comment 3 "https://github.com/PubInv/krake")
+		(comment 4 "Inherited from the GPAD")
+	)
+	(lib_symbols
+		(symbol "Connector:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 5.08 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 5.08 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Connector_Generic:Conn_01x16"
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "J"
+				(at 0 20.32 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x16"
+				(at 0 -22.86 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x16, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Conn_01x16_1_1"
+				(rectangle
+					(start -1.27 19.05)
+					(end 1.27 -21.59)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(rectangle
+					(start -1.27 17.907)
+					(end 0 17.653)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 15.367)
+					(end 0 15.113)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 12.827)
+					(end 0 12.573)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 10.287)
+					(end 0 10.033)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 7.747)
+					(end 0 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 5.207)
+					(end 0 4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -7.493)
+					(end 0 -7.747)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -10.033)
+					(end 0 -10.287)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -12.573)
+					(end 0 -12.827)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -15.113)
+					(end 0 -15.367)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -17.653)
+					(end 0 -17.907)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -20.193)
+					(end 0 -20.447)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 17.78 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -5.08 0)
+					(length 3.81)
+					(name "Pin_10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -7.62 0)
+					(length 3.81)
+					(name "Pin_11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -10.16 0)
+					(length 3.81)
+					(name "Pin_12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -12.7 0)
+					(length 3.81)
+					(name "Pin_13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -15.24 0)
+					(length 3.81)
+					(name "Pin_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -17.78 0)
+					(length 3.81)
+					(name "Pin_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -20.32 0)
+					(length 3.81)
+					(name "Pin_16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 15.24 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 12.7 0)
+					(length 3.81)
+					(name "Pin_3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 10.16 0)
+					(length 3.81)
+					(name "Pin_4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 7.62 0)
+					(length 3.81)
+					(name "Pin_5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 5.08 0)
+					(length 3.81)
+					(name "Pin_6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 3.81)
+					(name "Pin_7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C_Polarized"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C_Polarized"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Polarized capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "CP_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_Polarized_0_1"
+				(rectangle
+					(start -2.286 0.508)
+					(end 2.286 1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 2.286) (xy -0.762 2.286)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 2.794) (xy -1.27 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 2.286 -0.508)
+					(end -2.286 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(symbol "C_Polarized_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GND_1"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND_1"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_1_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:LCD_20x4_Character-GPAD_SCH_LIB"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "U"
+				(at -6.35 19.05 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "LCD_20x4_Character-GPAD_SCH_LIB"
+				(at 5.08 19.05 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "GPAD:LCD_2004A"
+				(at 0 -22.86 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 2.54 -2.54 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "Aliexpress"
+				(at -27.432 -17.526 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "https://www.aliexpress.com/item/3256803213374992.html"
+				(at -2.54 -20.066 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 2" "Amazon"
+				(at -28.448 -23.114 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 2 PN" "https://www.amazon.com/GeeekPi-Interface-Adapter-Backlight-Raspberry/dp/B07QLRD3TM/ref=sr_1_2"
+				(at 20.066 -25.4 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "4.99"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "Display, LCD,"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "NHD*0420H1Z*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "LCD_20x4_Character-GPAD_SCH_LIB_0_1"
+				(rectangle
+					(start -7.62 17.78)
+					(end 7.62 -17.78)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+			)
+			(symbol "LCD_20x4_Character-GPAD_SCH_LIB_1_1"
+				(pin power_in line
+					(at 0 -20.32 90)
+					(length 2.54)
+					(name "VSS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -10.16 -5.08 0)
+					(length 2.54)
+					(name "DB3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -10.16 -7.62 0)
+					(length 2.54)
+					(name "DB4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -10.16 -10.16 0)
+					(length 2.54)
+					(name "DB5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -10.16 -12.7 0)
+					(length 2.54)
+					(name "DB6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -10.16 -15.24 0)
+					(length 2.54)
+					(name "DB7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 10.16 -7.62 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 10.16 -5.08 180)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 10.16 11.43 180)
+					(length 2.54)
+					(name "MH1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 10.16 8.89 180)
+					(length 2.54)
+					(name "MH2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 10.16 6.35 180)
+					(length 2.54)
+					(name "MH3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 20.32 270)
+					(length 2.54)
+					(name "VDD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 10.16 3.81 180)
+					(length 2.54)
+					(name "MH4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 2.54 20.32 270)
+					(length 2.54)
+					(name "VO"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -10.16 15.24 0)
+					(length 2.54)
+					(name "RS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -10.16 12.7 0)
+					(length 2.54)
+					(name "R/W"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -10.16 10.16 0)
+					(length 2.54)
+					(name "E"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -10.16 2.54 0)
+					(length 2.54)
+					(name "DB0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -10.16 0 0)
+					(length 2.54)
+					(name "DB1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -10.16 -2.54 0)
+					(length 2.54)
+					(name "DB2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:Nut_4-40_0.1875"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board no)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "MF409"
+				(at 6.35 1.2701 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "Nut_4-40_0.1875"
+				(at 6.35 -1.2699 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Nut_4-40_0.1875"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "36-4694-ND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "DigiKey"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "$0.10000"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "AssemblyType" "HAND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN" "4694"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer" "Keystone Electronics"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "Nut_4-40_0.1875"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Nut_4-40_0.1875_0_1"
+				(polyline
+					(pts
+						(xy -2.54 3.81) (xy 2.54 3.81) (xy 5.08 0) (xy 2.54 -3.81) (xy -2.54 -3.81) (xy -5.08 0) (xy -2.54 3.81)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 0)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:PCF8574AT_3_518"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "U301"
+				(at 2.0194 20.32 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "PCF8574AT_3_518"
+				(at 2.0194 17.78 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "Package_SO:SOIC-16W_7.5x10.3mm_P1.27mm"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811151526_NXP-Semicon-PCF8574AT-3-518_C86832.pdf"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "8 Bit Port/Expander to I2C Bus, DIP/SOIC-16"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "AssemblyType" "SMT"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "1.87"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "JLCPCB"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "C86832"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN" "PCF8574AT_3_518"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "I2C Expander"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "DIP*W7.62mm* SOIC*7.5x10.3mm*P1.27mm*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "PCF8574AT_3_518_0_1"
+				(rectangle
+					(start -10.16 15.24)
+					(end 10.16 -15.24)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+			)
+			(symbol "PCF8574AT_3_518_1_1"
+				(pin input line
+					(at -12.7 2.54 0)
+					(length 2.54)
+					(name "A0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 12.7 -2.54 180)
+					(length 2.54)
+					(name "P5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 12.7 -5.08 180)
+					(length 2.54)
+					(name "P6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 12.7 -7.62 180)
+					(length 2.54)
+					(name "P7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin open_collector output_low
+					(at -12.7 -10.16 0)
+					(length 2.54)
+					(name "~{INT}"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -12.7 10.16 0)
+					(length 2.54)
+					(name "SCL"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -12.7 7.62 0)
+					(length 2.54)
+					(name "SDA"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 17.78 270)
+					(length 2.54)
+					(name "VDD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -12.7 0 0)
+					(length 2.54)
+					(name "A1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -12.7 -2.54 0)
+					(length 2.54)
+					(name "A2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 12.7 10.16 180)
+					(length 2.54)
+					(name "P0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 12.7 7.62 180)
+					(length 2.54)
+					(name "P1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 12.7 5.08 180)
+					(length 2.54)
+					(name "P2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 12.7 2.54 180)
+					(length 2.54)
+					(name "P3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -17.78 90)
+					(length 2.54)
+					(name "VSS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 12.7 0 180)
+					(length 2.54)
+					(name "P4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:POT_0.375_10K"
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "RV301"
+				(at -1.27 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Value" "POT 0.375 10K"
+				(at -1.27 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:Potentiometer_Bourns_3386P_Vertical"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://www.bourns.com/docs/Product-Datasheets/3386.pdf"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Potentiometer"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "C116281"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "JLCPCB"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN" "3386P-1-103LF"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Assembly Type" ""
+				(at 2.54 -1.1429 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Distributor 2" "Digi-Key"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 2 PN" "3386P-103LF-ND"
+				(at 3.81 6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Cost" "0.6963"
+				(at 7.62 1.27 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer" "BOURNS"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "AssemblyType" "SMT"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "resistor variable"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Potentiometer*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "POT_0.375_10K_0_0"
+				(text "CW"
+					(at 2.794 -3.048 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(text "CCW"
+					(at 3.302 2.794 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(symbol "POT_0.375_10K_0_1"
+				(rectangle
+					(start 1.016 2.54)
+					(end -1.016 -2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.143 0) (xy 2.286 0.508) (xy 2.286 -0.508) (xy 1.143 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 0) (xy 1.524 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "POT_0.375_10K_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 1.27)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:Screw_4-40_0.375_Phillips"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board no)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "MF407"
+				(at 3.81 1.2701 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "Screw_4-40_0.375_Phillips"
+				(at 3.81 -1.2699 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Screw_4-40_0.375_Phillips"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "90272A108"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "McMaster-Carr"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "0.0182"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "AssemblyType" "HAND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN" "90272A108"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer" "McMaster-Carr"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "Screw_4-40_0.375_Phillips"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Screw_4-40_0.375_Phillips_0_1"
+				(polyline
+					(pts
+						(xy -1.27 0) (xy 1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 0)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -1.27) (xy 0 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:Spacer_0.0182x0.125_inch"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board no)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "MF411"
+				(at 6.35 1.2701 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "Spacer_0.0182x0.125 inch"
+				(at 6.35 -1.2699 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Spacer_0.0182x0.125 inch"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "94639A702"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "McMaster-Carr"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "0.1145"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "AssemblyType" "HAND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN" "94639A702"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer" "McMaster-Carr"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "Spacer_0.0182x0.125 inch"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Spacer_0.0182x0.125_inch_0_1"
+				(circle
+					(center 0 0)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 0)
+					(radius 4.5791)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Nut_4-40_0.1875"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board no)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "MF"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Nut_4-40_0.1875_3"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Nut_4-40_0.1875"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "DigiKey"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "36-4694-ND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "$0.10000"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "Nut_4-40_0.1875"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Nut_4-40_0.1875_0_1"
+				(polyline
+					(pts
+						(xy -2.54 3.81) (xy 2.54 3.81) (xy 5.08 0) (xy 2.54 -3.81) (xy -2.54 -3.81) (xy -5.08 0) (xy -2.54 3.81)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 0)
+					(radius 2.8398)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Transistor_FET:BSS138"
+			(pin_names
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "Q"
+				(at 5.08 1.905 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "BSS138"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+				(at 5.08 -1.905 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Description" "50V Vds, 0.22A Id, N-Channel MOSFET, SOT-23"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "N-Channel MOSFET"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "SOT?23*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "BSS138_0_1"
+				(polyline
+					(pts
+						(xy 0.254 1.905) (xy 0.254 -1.905)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.254 0) (xy -2.54 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 2.286) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 0.508) (xy 0.762 -0.508)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 -1.27) (xy 0.762 -2.286)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 -1.778) (xy 3.302 -1.778) (xy 3.302 1.778) (xy 0.762 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.016 0) (xy 2.032 0.381) (xy 2.032 -0.381) (xy 1.016 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(circle
+					(center 1.651 0)
+					(radius 2.794)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 2.54) (xy 2.54 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.54 1.778)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(circle
+					(center 2.54 -1.778)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 -2.54) (xy 2.54 0) (xy 0.762 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.794 0.508) (xy 2.921 0.381) (xy 3.683 0.381) (xy 3.81 0.254)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.302 0.381) (xy 2.921 -0.254) (xy 3.683 -0.254) (xy 3.302 0.381)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "BSS138_1_1"
+				(pin input line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "G"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 -5.08 90)
+					(length 2.54)
+					(name "S"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 5.08 270)
+					(length 2.54)
+					(name "D"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:+5V"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "+5V"
+				(at 0 3.556 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"+5V\""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "+5V_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "+5V_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(hide yes)
+					(name "+5V"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:PWR_FLAG"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#FLG"
+				(at 0 1.905 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "PWR_FLAG"
+				(at 0 3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Special symbol for telling ERC where power comes from"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "flag power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_0"
+				(pin power_out line
+					(at 0 0 90)
+					(length 0)
+					(name "pwr"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(text "Wiring of I2C to LCD from:\nhttps://alselectro.wordpress.com/2016/05/12/serial-lcd-i2c-module-pcf8574/"
+		(exclude_from_sim no)
+		(at 92.71 40.64 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "2eea87b6-6253-41ff-b6bd-8a96c7653ab7")
+	)
+	(text "LCD compnents including I2C interface."
+		(exclude_from_sim no)
+		(at 92.71 34.29 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "6138e430-934a-4641-a002-b410d09e5754")
+	)
+	(text "CONTRAST"
+		(exclude_from_sim no)
+		(at 203.2 81.28 0)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left bottom)
+		)
+		(uuid "c24b6d8d-bd4b-49c8-9da2-390592b7000a")
+	)
+	(text "The six resistors connected to A0 A1 A2 \ndefine the I2C address ref to table 5 below:"
+		(exclude_from_sim no)
+		(at 74.93 111.76 0)
+		(effects
+			(font
+				(size 1.524 1.524)
+			)
+			(justify left bottom)
+		)
+		(uuid "ed02c1a5-b65d-4ea0-bf31-1c566947c590")
+	)
+	(junction
+		(at 173.99 80.01)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "006a337c-25fe-4614-8a1d-ab5651cb5aa1")
+	)
+	(junction
+		(at 116.84 87.63)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0732a23d-820a-438d-9d4c-055ac14e1e9c")
+	)
+	(junction
+		(at 156.21 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0e98f068-49ed-4294-a81d-a5ef36601031")
+	)
+	(junction
+		(at 31.75 53.34)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1086b71b-19bc-44cf-a77e-4a74c76529a5")
+	)
+	(junction
+		(at 53.34 53.34)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "12ce9d48-b071-47d6-95cb-4e885232f79c")
+	)
+	(junction
+		(at 78.74 74.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1835fb5b-0886-40d3-a050-1ee448fd430f")
+	)
+	(junction
+		(at 173.99 77.47)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2824dbb9-53e5-4246-af26-fd6a5e5d27e4")
+	)
+	(junction
+		(at 232.41 50.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2d178082-0252-4969-a394-9d05d786b92d")
+	)
+	(junction
+		(at 69.85 77.47)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "30a9a5f4-7c80-42a3-93d0-cd7912057c39")
+	)
+	(junction
+		(at 59.69 74.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3c15097b-077b-4ba7-9315-283872281692")
+	)
+	(junction
+		(at 226.06 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3c7f5362-0368-4bdd-a369-f12389d1e29b")
+	)
+	(junction
+		(at 69.85 86.36)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4313b860-9864-4308-ac9c-f97b93c39600")
+	)
+	(junction
+		(at 139.7 95.25)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4d27bf88-0810-451f-990a-d6135a10cfb1")
+	)
+	(junction
+		(at 129.54 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4e0948f6-c0ae-4d51-a397-01598c4e3bbc")
+	)
+	(junction
+		(at 125.73 85.09)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5d57bccc-55a8-4bde-80fb-98eb73bd9953")
+	)
+	(junction
+		(at 214.63 62.23)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6334eaa3-5f76-4df2-a559-2994bb9e04be")
+	)
+	(junction
+		(at 97.79 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6e0a20b1-9ce4-4818-b1bf-0ebbabf5ce1f")
+	)
+	(junction
+		(at 31.75 86.36)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "750effde-46e9-4b2b-a15a-055079e9bb5f")
+	)
+	(junction
+		(at 185.42 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "77869278-8f2d-49c4-a8c1-bf38aaef8cb1")
+	)
+	(junction
+		(at 196.85 73.66)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "785e5a8e-10bf-438d-8900-69972c79f93a")
+	)
+	(junction
+		(at 185.42 97.79)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7a47eb90-b9b3-4224-9661-653239d29f3c")
+	)
+	(junction
+		(at 173.99 82.55)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7be97bd0-5007-4244-a1eb-f236329ad5f0")
+	)
+	(junction
+		(at 195.58 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8954dc85-9394-4820-ae69-780a31ccea3a")
+	)
+	(junction
+		(at 88.9 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d70acb0-b9e6-4de2-8101-9b183eab5f5f")
+	)
+	(junction
+		(at 203.2 106.68)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9575c4cc-f98e-4ca5-bdb6-53004a8a890e")
+	)
+	(junction
+		(at 133.35 82.55)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9b7f52eb-a782-42e7-befc-f63c946687a8")
+	)
+	(junction
+		(at 107.95 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9f6e4daf-b5f6-4893-b66e-04429b24ec1e")
+	)
+	(junction
+		(at 196.85 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9f777e86-af67-4436-bba2-39b027ffd02c")
+	)
+	(junction
+		(at 40.64 53.34)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a1ade272-fc95-4882-abc4-d0d5bfb4497a")
+	)
+	(junction
+		(at 40.64 74.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a3791ff5-7f68-497e-aa5d-17c343c708ce")
+	)
+	(junction
+		(at 55.88 86.36)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a38bddbe-28a0-476c-a7d4-4370b0114814")
+	)
+	(junction
+		(at 195.58 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "acc208bd-ab17-4939-b0c5-5dc39a154b8f")
+	)
+	(junction
+		(at 129.54 74.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b14fd83f-ab09-4df7-b413-c4bb7ef0ea11")
+	)
+	(junction
+		(at 198.12 59.69)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf627c07-4f67-41ce-8d02-4968fcd27a25")
+	)
+	(junction
+		(at 116.84 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bfe329dd-1e9a-48d3-9d25-ad147d2d60c7")
+	)
+	(junction
+		(at 198.12 62.23)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c2bcf197-174c-49fe-8db3-8818d57448c4")
+	)
+	(junction
+		(at 203.2 85.09)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d3903c92-cb85-44ce-ade0-e813d12492c8")
+	)
+	(junction
+		(at 134.62 77.47)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d6db5469-5a73-4024-b470-f5c9b1faebdb")
+	)
+	(junction
+		(at 125.73 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d774ef8a-fafe-4294-b14a-ef23c2c8b2bc")
+	)
+	(junction
+		(at 223.52 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dc915a8c-95c7-4451-8ad1-7174d3e67bfb")
+	)
+	(junction
+		(at 215.9 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e308b888-6aa8-4d1a-8ded-3949757c3594")
+	)
+	(junction
+		(at 203.2 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e66c91aa-4498-4a8c-9f6c-07cfc12799ac")
+	)
+	(junction
+		(at 44.45 74.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "eaf43176-bbef-4c64-858d-0b0f7fc48010")
+	)
+	(junction
+		(at 196.85 71.12)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "edb3de21-79b1-4c6b-a399-27e4112a640b")
+	)
+	(junction
+		(at 78.74 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f8581ce5-d2a3-40c2-afc7-c8b784d3baa4")
+	)
+	(junction
+		(at 167.64 52.07)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fb105db6-9db9-4fdb-92a0-ce2fc25e94cb")
+	)
+	(no_connect
+		(at 247.65 81.28)
+		(uuid "0d7bd46c-729b-4dca-915f-addc2468fb80")
+	)
+	(no_connect
+		(at 247.65 86.36)
+		(uuid "14021638-de6d-4ff3-9ca2-21674e349441")
+	)
+	(no_connect
+		(at 247.65 91.44)
+		(uuid "14560989-699b-4a44-a9ba-b09c1d510c17")
+	)
+	(no_connect
+		(at 247.65 68.58)
+		(uuid "35a8ca10-3b67-419f-aab0-172b5788e16e")
+	)
+	(no_connect
+		(at 247.65 76.2)
+		(uuid "48c8f9ff-32be-4bd5-b9ea-8d60aaabc2ea")
+	)
+	(no_connect
+		(at 247.65 73.66)
+		(uuid "7d493c38-f742-45e0-83af-772d87c01e3c")
+	)
+	(no_connect
+		(at 247.65 63.5)
+		(uuid "86b78d04-aa45-43c3-86e9-38bd311c37c8")
+	)
+	(no_connect
+		(at 247.65 93.98)
+		(uuid "8fd5cc9b-77a4-44d7-9d4a-abfd0c1fa412")
+	)
+	(no_connect
+		(at 247.65 88.9)
+		(uuid "9b019e72-98d9-46ec-a050-43de18351068")
+	)
+	(no_connect
+		(at 247.65 99.06)
+		(uuid "a76473f2-db8f-4a4c-afc1-7723dbd47b39")
+	)
+	(no_connect
+		(at 247.65 101.6)
+		(uuid "b59c4135-0aee-4752-8cd1-4b0547267a5c")
+	)
+	(no_connect
+		(at 247.65 66.04)
+		(uuid "c2ae0133-8913-411f-aea2-d9cd16c7bf13")
+	)
+	(no_connect
+		(at 247.65 71.12)
+		(uuid "cfae85cf-9d89-4c21-8512-c5f5f3adbc33")
+	)
+	(no_connect
+		(at 247.65 78.74)
+		(uuid "d372e9be-1ff7-4b47-93c7-58c243980f45")
+	)
+	(no_connect
+		(at 247.65 96.52)
+		(uuid "e02a9c43-97f6-4478-bfa9-bcf2b9d469c6")
+	)
+	(no_connect
+		(at 247.65 83.82)
+		(uuid "f8b6ea35-596b-4e8d-b3ce-c0710df9a5c7")
+	)
+	(wire
+		(pts
+			(xy 175.26 77.47) (xy 173.99 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "008bdd3a-b81a-4699-bd1c-f92c6c4d9c52")
+	)
+	(wire
+		(pts
+			(xy 232.41 85.09) (xy 203.2 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "073eec33-3077-4a8d-82ca-b534fe2dc484")
+	)
+	(wire
+		(pts
+			(xy 138.43 95.25) (xy 139.7 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "080abc10-2483-4c57-9a3e-37b1fb94bf27")
+	)
+	(wire
+		(pts
+			(xy 55.88 86.36) (xy 58.42 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "096c8ee4-01c3-4ef6-895e-1e0df1a276f5")
+	)
+	(wire
+		(pts
+			(xy 78.74 67.31) (xy 78.74 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "098ea7bc-690b-4a51-8a04-baab32c421b2")
+	)
+	(wire
+		(pts
+			(xy 134.62 77.47) (xy 143.51 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "09b2f4ac-e5f0-4069-99b1-5bac1f1e6feb")
+	)
+	(wire
+		(pts
+			(xy 168.91 80.01) (xy 172.72 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "09d7b137-59d5-4c8b-846e-acfbbacbefea")
+	)
+	(wire
+		(pts
+			(xy 196.85 73.66) (xy 199.39 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0a1247b8-d9c6-4987-b787-8f52a8525b9e")
+	)
+	(wire
+		(pts
+			(xy 195.58 66.04) (xy 196.85 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0b6b7e0f-4afa-43cc-873e-967e7d723df7")
+	)
+	(wire
+		(pts
+			(xy 97.79 59.69) (xy 97.79 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0bdf910c-bb1b-4e7d-a5d7-5e3047724f16")
+	)
+	(wire
+		(pts
+			(xy 187.96 55.88) (xy 198.12 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0bff4e3c-1738-48d8-b52c-79544a1bd28d")
+	)
+	(wire
+		(pts
+			(xy 31.75 59.69) (xy 31.75 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0e77b8be-e75b-467f-b9a5-909960e0df2b")
+	)
+	(wire
+		(pts
+			(xy 223.52 40.64) (xy 232.41 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0f9c324b-1266-463c-9406-f7243791a44e")
+	)
+	(wire
+		(pts
+			(xy 214.63 62.23) (xy 220.98 62.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "13bc7ced-1f29-4677-86ec-73012264cdea")
+	)
+	(wire
+		(pts
+			(xy 20.32 86.36) (xy 31.75 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "161cdd39-58e2-45a2-a66a-8432e8179869")
+	)
+	(wire
+		(pts
+			(xy 185.42 52.07) (xy 185.42 57.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "16f783d4-bed4-4351-b6f9-464552a06198")
+	)
+	(wire
+		(pts
+			(xy 59.69 74.93) (xy 78.74 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "18260755-070a-4d95-b482-50d2df2ddb06")
+	)
+	(wire
+		(pts
+			(xy 116.84 91.44) (xy 116.84 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1ad38b58-8e4e-4768-8a3f-6d628e1beddc")
+	)
+	(wire
+		(pts
+			(xy 167.64 49.53) (xy 167.64 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1af19294-66e9-4563-bf51-569cb516a5cd")
+	)
+	(wire
+		(pts
+			(xy 220.98 109.22) (xy 220.98 111.76)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c35f332-cef2-4ceb-ae7d-b0bfe83f33b0")
+	)
+	(wire
+		(pts
+			(xy 175.26 80.01) (xy 173.99 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1d6fffe9-3353-4d21-ae1a-68964d183086")
+	)
+	(wire
+		(pts
+			(xy 198.12 62.23) (xy 198.12 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1d8e5fde-74c4-4113-bc6b-90dde1f29821")
+	)
+	(wire
+		(pts
+			(xy 20.32 74.93) (xy 40.64 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1f669b75-c7c4-4f52-bb97-b54fdce1b183")
+	)
+	(wire
+		(pts
+			(xy 200.66 57.15) (xy 209.55 57.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2225b221-acbb-457c-8c5b-4dea86ecff40")
+	)
+	(wire
+		(pts
+			(xy 196.85 71.12) (xy 196.85 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "230069ab-6bb1-439b-8543-78ce5bf10bd5")
+	)
+	(wire
+		(pts
+			(xy 78.74 59.69) (xy 78.74 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "254826f2-0a6f-4c81-9f03-08db99a4a1c6")
+	)
+	(wire
+		(pts
+			(xy 171.45 82.55) (xy 171.45 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "25791ba3-9b8c-44ca-b39e-e43fecd63389")
+	)
+	(wire
+		(pts
+			(xy 40.64 53.34) (xy 40.64 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "29e827e0-b584-4e69-963c-a5d1ddbf784e")
+	)
+	(wire
+		(pts
+			(xy 88.9 87.63) (xy 88.9 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2b0d5ad9-e0f6-43b2-9b15-be1d10d407d2")
+	)
+	(wire
+		(pts
+			(xy 172.72 67.31) (xy 175.26 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2b86384e-8ea6-48af-bb38-89c180c7e0e0")
+	)
+	(wire
+		(pts
+			(xy 167.64 52.07) (xy 185.42 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2db90e54-6119-4af5-ba68-6dccee291a29")
+	)
+	(wire
+		(pts
+			(xy 209.55 64.77) (xy 209.55 57.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "315afea8-e29d-4f8f-bf76-a90b680ab867")
+	)
+	(wire
+		(pts
+			(xy 195.58 82.55) (xy 220.98 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "318435ee-0084-41f1-ba04-b9435ddaa498")
+	)
+	(wire
+		(pts
+			(xy 199.39 73.66) (xy 199.39 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "324aa349-16cf-4fc0-85ba-dbbbd9aa8f4d")
+	)
+	(wire
+		(pts
+			(xy 31.75 53.34) (xy 40.64 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "32dc1403-8095-4bd2-b193-dcd39e47d072")
+	)
+	(wire
+		(pts
+			(xy 171.45 77.47) (xy 171.45 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3507e91b-2b1f-458c-9f7d-cb091894c360")
+	)
+	(wire
+		(pts
+			(xy 195.58 40.64) (xy 203.2 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3914746d-cfa9-4b65-95f9-e88ad5ba53cc")
+	)
+	(wire
+		(pts
+			(xy 203.2 106.68) (xy 204.47 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b00d74a-d04b-4258-a61e-a3b0dc92c6a1")
+	)
+	(wire
+		(pts
+			(xy 125.73 99.06) (xy 125.73 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b378689-a8e3-41f4-a4c2-0cb8a8101e31")
+	)
+	(wire
+		(pts
+			(xy 133.35 91.44) (xy 133.35 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3bdd3739-dfee-4973-a967-77c13d08bd71")
+	)
+	(wire
+		(pts
+			(xy 125.73 85.09) (xy 97.79 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3c4254b0-2121-4dd5-b884-e67bed4a06db")
+	)
+	(wire
+		(pts
+			(xy 31.75 67.31) (xy 31.75 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3d1e5d3a-438b-4d59-bff8-579ed9dbbbc4")
+	)
+	(wire
+		(pts
+			(xy 196.85 66.04) (xy 196.85 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e4ffcd1-0bb4-4b0a-88e3-e19049a6ba94")
+	)
+	(wire
+		(pts
+			(xy 175.26 82.55) (xy 173.99 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e8afb99-45b3-4ba6-a2c4-5288c06e86b6")
+	)
+	(wire
+		(pts
+			(xy 116.84 59.69) (xy 116.84 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f44639a-3d33-4a51-af43-796cfc906faf")
+	)
+	(wire
+		(pts
+			(xy 125.73 91.44) (xy 125.73 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4041712a-5081-4dcb-8900-aa3e4c10db02")
+	)
+	(wire
+		(pts
+			(xy 40.64 74.93) (xy 40.64 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "43528e26-4d0c-4965-8d51-bc41f45b107d")
+	)
+	(wire
+		(pts
+			(xy 88.9 52.07) (xy 97.79 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "43a1ba09-4cb0-4737-8975-65905cd7d5e5")
+	)
+	(wire
+		(pts
+			(xy 215.9 48.26) (xy 215.9 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "43af2c86-314f-43e5-9b0a-63dfd715c409")
+	)
+	(wire
+		(pts
+			(xy 156.21 105.41) (xy 156.21 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "440af2a6-ceda-4b9a-a704-d60e314d0ba5")
+	)
+	(wire
+		(pts
+			(xy 143.51 87.63) (xy 116.84 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "460c2f51-0bb3-4c5d-911a-4b15d04b6acc")
+	)
+	(wire
+		(pts
+			(xy 69.85 52.07) (xy 78.74 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4695d358-133c-4233-abf2-21be8c981366")
+	)
+	(wire
+		(pts
+			(xy 78.74 74.93) (xy 129.54 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4c00a07c-0e21-4cb3-ad81-2e4093277b6b")
+	)
+	(wire
+		(pts
+			(xy 68.58 86.36) (xy 69.85 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4d386865-9145-4197-a577-3496b0914474")
+	)
+	(wire
+		(pts
+			(xy 125.73 101.6) (xy 129.54 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e55b9ef-ab30-4a8f-964e-4a0b0811040c")
+	)
+	(wire
+		(pts
+			(xy 107.95 52.07) (xy 116.84 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4f0416b7-77df-4af5-98a8-1595cedcbb1d")
+	)
+	(wire
+		(pts
+			(xy 44.45 74.93) (xy 44.45 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5021ef44-61d8-4d36-b1ee-2d0b09d5a4a8")
+	)
+	(wire
+		(pts
+			(xy 44.45 82.55) (xy 46.99 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50f53b89-0c46-4df8-93dc-c645abf17785")
+	)
+	(wire
+		(pts
+			(xy 59.69 82.55) (xy 59.69 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "53dc84ec-55af-4fa3-9b77-8d8a07c73e62")
+	)
+	(wire
+		(pts
+			(xy 44.45 74.93) (xy 48.26 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "55089a63-b7a3-47f6-a7ab-c925f5710969")
+	)
+	(wire
+		(pts
+			(xy 66.04 93.98) (xy 69.85 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "56de1817-59ec-4395-9a00-7cdb8ac294f7")
+	)
+	(wire
+		(pts
+			(xy 196.85 68.58) (xy 196.85 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "58176eee-d9fb-4488-b2a3-6012ddb01b11")
+	)
+	(wire
+		(pts
+			(xy 226.06 55.88) (xy 226.06 50.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5a6a7136-60be-45ad-9edc-c11f1a7b7fa1")
+	)
+	(wire
+		(pts
+			(xy 143.51 82.55) (xy 133.35 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5aefe056-768b-4f65-887a-d44267a180a8")
+	)
+	(wire
+		(pts
+			(xy 69.85 77.47) (xy 69.85 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5cca0a25-ccf8-48db-8126-cb37838c24c7")
+	)
+	(wire
+		(pts
+			(xy 226.06 64.77) (xy 226.06 63.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d3300be-2cf1-471c-bc9e-13414d01ff0f")
+	)
+	(wire
+		(pts
+			(xy 168.91 77.47) (xy 171.45 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d46e26b-7b2f-450e-825a-dd334182a711")
+	)
+	(wire
+		(pts
+			(xy 173.99 77.47) (xy 173.99 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5ed7ba09-3d98-48bc-a81c-5b132f4a5eda")
+	)
+	(wire
+		(pts
+			(xy 220.98 82.55) (xy 220.98 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f751036-c3b9-40e1-9c80-551fc89ab237")
+	)
+	(wire
+		(pts
+			(xy 203.2 106.68) (xy 203.2 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6004ca5c-8b01-4214-b4d1-6621fb4f4776")
+	)
+	(wire
+		(pts
+			(xy 168.91 90.17) (xy 175.26 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "605a9bed-2a00-45b1-a309-fb956113b4b5")
+	)
+	(wire
+		(pts
+			(xy 116.84 101.6) (xy 125.73 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "65ba4950-c779-4fe2-8a7b-e09d86aac682")
+	)
+	(wire
+		(pts
+			(xy 129.54 74.93) (xy 143.51 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "683730a6-e936-4ec0-9cb8-3c223e9cceb1")
+	)
+	(wire
+		(pts
+			(xy 195.58 68.58) (xy 196.85 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "685cf876-58f8-4085-a39b-1f62a7a77e82")
+	)
+	(wire
+		(pts
+			(xy 133.35 82.55) (xy 107.95 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6c4aabb1-ab02-4555-9600-91ed64a6f5cf")
+	)
+	(wire
+		(pts
+			(xy 116.84 87.63) (xy 88.9 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6df45332-a220-4834-9469-e802c05ecfe4")
+	)
+	(wire
+		(pts
+			(xy 173.99 80.01) (xy 173.99 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6e73c6a1-7fc7-4bfd-bf78-58ff52671ed6")
+	)
+	(wire
+		(pts
+			(xy 173.99 82.55) (xy 173.99 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "740ee9f0-5549-415c-8eb3-dd81bc4824a3")
+	)
+	(wire
+		(pts
+			(xy 226.06 77.47) (xy 226.06 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79ff1507-d922-4014-a0d4-e3962d5f0e74")
+	)
+	(wire
+		(pts
+			(xy 168.91 92.71) (xy 175.26 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7aeaa9bf-2c98-4708-af8b-cd249810a187")
+	)
+	(wire
+		(pts
+			(xy 63.5 78.74) (xy 63.5 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7af25b63-c68e-4dae-bb93-ddc37fb635c0")
+	)
+	(wire
+		(pts
+			(xy 69.85 86.36) (xy 69.85 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7f9cb05d-f67d-421a-ac68-38189759b0be")
+	)
+	(wire
+		(pts
+			(xy 78.74 52.07) (xy 88.9 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "811895b1-b12e-4630-bb95-596ea3759896")
+	)
+	(wire
+		(pts
+			(xy 226.06 50.8) (xy 232.41 50.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "82d4de34-23d5-4a46-83b7-16eb611fc91c")
+	)
+	(wire
+		(pts
+			(xy 170.18 62.23) (xy 170.18 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8953df68-99db-4abe-b946-aab894d8142c")
+	)
+	(wire
+		(pts
+			(xy 180.34 40.64) (xy 185.42 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8959acee-068d-42dd-af9f-d19c745f6292")
+	)
+	(wire
+		(pts
+			(xy 198.12 62.23) (xy 214.63 62.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "89d919dc-f6cb-4d67-a62f-a5472bd47e2f")
+	)
+	(wire
+		(pts
+			(xy 232.41 40.64) (xy 232.41 50.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8ad4ab84-c2a1-41ff-9d2f-a728c2569264")
+	)
+	(wire
+		(pts
+			(xy 63.5 53.34) (xy 53.34 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d611956-cfd7-4305-90c5-d5d34f615971")
+	)
+	(wire
+		(pts
+			(xy 215.9 40.64) (xy 223.52 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8de77463-b6d0-42f1-8c7a-14a3b3de1051")
+	)
+	(wire
+		(pts
+			(xy 212.09 106.68) (xy 213.36 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8e0d7597-215d-4b52-ac25-083fb802c72b")
+	)
+	(wire
+		(pts
+			(xy 55.88 93.98) (xy 55.88 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "95e41dff-c38f-42cc-9e41-04c0ef0ab7b4")
+	)
+	(wire
+		(pts
+			(xy 107.95 82.55) (xy 107.95 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "96cc55d7-0ca8-4036-b85a-326d66f02395")
+	)
+	(wire
+		(pts
+			(xy 116.84 52.07) (xy 156.21 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "972612bb-2a95-4abe-8f94-55580dae5ed4")
+	)
+	(wire
+		(pts
+			(xy 173.99 74.93) (xy 175.26 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "986f604a-cb17-4afc-a9e7-2ebf0e8ab006")
+	)
+	(wire
+		(pts
+			(xy 195.58 40.64) (xy 195.58 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9a16c4f2-7424-4c91-82e4-0afb120fd9f3")
+	)
+	(wire
+		(pts
+			(xy 226.06 68.58) (xy 226.06 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9b03cdcd-9bb5-405b-a191-784b238940ea")
+	)
+	(wire
+		(pts
+			(xy 213.36 104.14) (xy 213.36 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9cc5598b-2e0b-4f7c-9413-464f9875e405")
+	)
+	(wire
+		(pts
+			(xy 54.61 82.55) (xy 59.69 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d1ead57-d620-4ab5-95c9-65f0346d0ad6")
+	)
+	(wire
+		(pts
+			(xy 53.34 53.34) (xy 53.34 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9dff7048-bb7a-4753-8423-50507c298e77")
+	)
+	(wire
+		(pts
+			(xy 175.26 62.23) (xy 170.18 62.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9e6df786-506b-4de8-9a59-344340b9d7ae")
+	)
+	(wire
+		(pts
+			(xy 168.91 82.55) (xy 171.45 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab4ed50b-42cd-4983-818a-257e3b33706b")
+	)
+	(wire
+		(pts
+			(xy 168.91 85.09) (xy 175.26 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ae989c2b-4a84-4885-b890-f85cd7dbf401")
+	)
+	(wire
+		(pts
+			(xy 187.96 57.15) (xy 187.96 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b4401739-8c86-4c0d-9669-62ef4755f714")
+	)
+	(wire
+		(pts
+			(xy 138.43 95.25) (xy 138.43 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba445c7a-e6a9-40b7-89dc-efdd56d159d6")
+	)
+	(wire
+		(pts
+			(xy 203.2 85.09) (xy 195.58 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba47b6a3-272e-41d8-9e90-9e9468f06554")
+	)
+	(wire
+		(pts
+			(xy 55.88 86.36) (xy 31.75 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba8e623d-95f0-4c94-a869-1d2cb1968353")
+	)
+	(wire
+		(pts
+			(xy 97.79 85.09) (xy 97.79 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bad0e315-c603-4d52-9357-ab64320d7933")
+	)
+	(wire
+		(pts
+			(xy 193.04 40.64) (xy 195.58 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "badea7f8-6028-40ec-ae9d-7dfd3ed23fee")
+	)
+	(wire
+		(pts
+			(xy 195.58 71.12) (xy 196.85 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb456279-7e27-4cf8-9fad-5c7e7b7415cc")
+	)
+	(wire
+		(pts
+			(xy 138.43 80.01) (xy 116.84 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf36015e-e427-4765-a532-fd9023e4031e")
+	)
+	(wire
+		(pts
+			(xy 69.85 93.98) (xy 69.85 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c03cea06-654f-4cb1-8b69-417361deea8b")
+	)
+	(wire
+		(pts
+			(xy 58.42 74.93) (xy 59.69 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c0aa1839-876b-4b5f-b9ce-4fe82d436709")
+	)
+	(wire
+		(pts
+			(xy 107.95 59.69) (xy 107.95 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c144ca66-599c-48ca-b402-2fffc403a14a")
+	)
+	(wire
+		(pts
+			(xy 58.42 93.98) (xy 55.88 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c2ccef5a-4d4d-49c2-8fa3-8b7f1e59c76a")
+	)
+	(wire
+		(pts
+			(xy 129.54 101.6) (xy 133.35 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3e87a41-7065-443c-84fd-ad6763a2eb4c")
+	)
+	(wire
+		(pts
+			(xy 198.12 59.69) (xy 198.12 62.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c6f655ec-70ac-48f1-a834-619d1cefea21")
+	)
+	(wire
+		(pts
+			(xy 173.99 82.55) (xy 173.99 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c722c434-85f8-4fc9-98eb-f9e49b60217d")
+	)
+	(wire
+		(pts
+			(xy 223.52 35.56) (xy 223.52 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c847124c-4c1c-4056-a097-c57097f52fb9")
+	)
+	(wire
+		(pts
+			(xy 129.54 104.14) (xy 129.54 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c96dd83f-70e2-437b-8352-b501ea16d769")
+	)
+	(wire
+		(pts
+			(xy 40.64 74.93) (xy 44.45 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c98355fe-019a-4690-b373-94d41f43b684")
+	)
+	(wire
+		(pts
+			(xy 97.79 52.07) (xy 107.95 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c9f2caad-3499-4089-8a70-a3e67c33a7f1")
+	)
+	(wire
+		(pts
+			(xy 88.9 59.69) (xy 88.9 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cac5c1e8-57fd-4c56-8e0a-7e6e9ae2bade")
+	)
+	(wire
+		(pts
+			(xy 214.63 60.96) (xy 214.63 62.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb504c8f-e8ae-439b-a690-e434d2862ef2")
+	)
+	(wire
+		(pts
+			(xy 200.66 52.07) (xy 200.66 57.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb8cc4e3-1f44-4f65-a3f4-522d4025c201")
+	)
+	(wire
+		(pts
+			(xy 195.58 52.07) (xy 200.66 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cfb56ac0-b283-411b-beb5-9b6ca9df1b59")
+	)
+	(wire
+		(pts
+			(xy 116.84 67.31) (xy 116.84 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1c2cf19-2577-4a6b-8022-8a1f719a663d")
+	)
+	(wire
+		(pts
+			(xy 156.21 52.07) (xy 167.64 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d220b500-e5bf-47da-ba1c-eb9fe5460652")
+	)
+	(wire
+		(pts
+			(xy 69.85 59.69) (xy 69.85 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d6bb833b-c0cf-4785-a0f1-205b8d2129eb")
+	)
+	(wire
+		(pts
+			(xy 173.99 97.79) (xy 185.42 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dc368b4f-7051-4d0c-8cce-085563fa03d7")
+	)
+	(wire
+		(pts
+			(xy 21.59 53.34) (xy 31.75 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dd7f75f1-9ae6-47aa-ba72-02cb187ecccb")
+	)
+	(wire
+		(pts
+			(xy 203.2 49.53) (xy 203.2 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dde0360b-08a3-46ea-a7da-35fd0a32cb26")
+	)
+	(wire
+		(pts
+			(xy 168.91 87.63) (xy 175.26 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "debbbcab-1923-45de-8b3c-f81ca07967d9")
+	)
+	(wire
+		(pts
+			(xy 143.51 85.09) (xy 125.73 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df64eb95-b936-461d-8032-502b1f2a6074")
+	)
+	(wire
+		(pts
+			(xy 134.62 67.31) (xy 134.62 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dfbf037b-7be1-42b4-b6af-ae313d825faf")
+	)
+	(wire
+		(pts
+			(xy 129.54 71.12) (xy 129.54 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e0554f3b-1a48-4c78-bde8-d6951467f7a6")
+	)
+	(wire
+		(pts
+			(xy 209.55 72.39) (xy 209.55 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e1281661-8e64-43bc-a95f-dbfe5fdd665b")
+	)
+	(wire
+		(pts
+			(xy 116.84 99.06) (xy 116.84 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e3e6815c-d14d-40d2-b5dc-44d7bfe96478")
+	)
+	(wire
+		(pts
+			(xy 203.2 96.52) (xy 203.2 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e71442e7-1300-4524-8850-4673965388bf")
+	)
+	(wire
+		(pts
+			(xy 220.98 62.23) (xy 220.98 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e7c48bec-d59f-429c-ac22-b0c92dc431fc")
+	)
+	(wire
+		(pts
+			(xy 139.7 95.25) (xy 143.51 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e7dcd6d2-1131-42d7-8791-e82bbabb6170")
+	)
+	(wire
+		(pts
+			(xy 133.35 101.6) (xy 133.35 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e7fd0444-b47f-4760-ac75-dc2f9da89bf2")
+	)
+	(wire
+		(pts
+			(xy 198.12 55.88) (xy 198.12 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e8463605-bd2f-4188-b118-069a4f89bc2e")
+	)
+	(wire
+		(pts
+			(xy 232.41 50.8) (xy 232.41 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e8d78172-28d8-44b0-9b8d-4e1ab48eb435")
+	)
+	(wire
+		(pts
+			(xy 170.18 74.93) (xy 168.91 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f0075947-43b9-4a1b-8b9c-d38c0dda7412")
+	)
+	(wire
+		(pts
+			(xy 171.45 106.68) (xy 203.2 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f089ba46-8363-40fb-bc16-85bb20707181")
+	)
+	(wire
+		(pts
+			(xy 139.7 106.68) (xy 139.7 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f36fb2a6-0f48-405c-b0de-5fbe4f2f012b")
+	)
+	(wire
+		(pts
+			(xy 171.45 64.77) (xy 175.26 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f398c1c2-4929-4669-8754-04662947e2ad")
+	)
+	(wire
+		(pts
+			(xy 69.85 77.47) (xy 134.62 77.47)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4456118-0581-438e-be0f-8958e5ac2419")
+	)
+	(wire
+		(pts
+			(xy 195.58 52.07) (xy 185.42 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4685cc5-7d7f-4464-a820-55998b62794d")
+	)
+	(wire
+		(pts
+			(xy 185.42 100.33) (xy 185.42 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f5005ee0-dad0-45a4-b43d-537969f99867")
+	)
+	(wire
+		(pts
+			(xy 156.21 67.31) (xy 156.21 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f577ac61-5f6c-4e31-8013-7aac1acd7feb")
+	)
+	(wire
+		(pts
+			(xy 195.58 73.66) (xy 196.85 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f626a8f6-a6b5-4bf1-9cf0-fdf755d8fe7b")
+	)
+	(wire
+		(pts
+			(xy 203.2 40.64) (xy 215.9 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f646cf5f-9c0a-4a65-82ab-d45cfbb6b31f")
+	)
+	(wire
+		(pts
+			(xy 198.12 68.58) (xy 205.74 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa364e93-70ae-4bea-8ce2-c984e9cbe28f")
+	)
+	(wire
+		(pts
+			(xy 172.72 80.01) (xy 172.72 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fd7cc602-0557-4028-a36e-ad5d8693650f")
+	)
+	(wire
+		(pts
+			(xy 220.98 64.77) (xy 226.06 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fea9a6db-58f2-4032-b2bb-d8b108e36602")
+	)
+	(wire
+		(pts
+			(xy 40.64 53.34) (xy 53.34 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ffb5c72d-3de5-4793-a369-f2913723dc38")
+	)
+	(image
+		(at 124.46 137.16)
+		(scale 0.639421)
+		(uuid "c55b7e6d-ffe3-4f11-805c-2b986f9696bf")
+		(data "iVBORw0KGgoAAAANSUhEUgAAA20AAAGWCAIAAABkWvxuAAAAA3NCSVQICAjb4U/gAAAACXBIWXMA"
+			"ABXgAAAV4AGNVCw4AAAgAElEQVR4nOyddVwVWRvHfzfo7gZBUECwAzsQu3vtrnXNNde11jVX19i1"
+			"27UTu1CRUEwURARJ6a57udx8/ziX8Xq5ICLW6/l+7h8zZ86ceebOnJlnnvM8z2HJZDJQKBQKhUKh"
+			"UCgfCftrC0ChUCgUCoVC+S6heiSFQqFQKBQKpSpQPZJCoVAoFAqFUhWoHkmhUCgUCoVCqQpUj6RQ"
+			"KBQKhUKhVAWqR1IoFAqFQqFQqgLVIykUCoVCoVAoVYHqkRQKhUKhUCiUqkD1SAqFQqFQKBRKVaB6"
+			"JIVCoVAoFAqlKlA9kkKhUCgUCoVSFageSaFQKBQKhUKpClSPpFAoFAqFQqFUBapHUigUCoVCoVCq"
+			"AtUjKRQKhUKhUChVgfu1BaBQlGB9bQE+H7KvLQCFQqFQKNUJtUdSKBQKhUKhUKpCVeyRxSLxwkv+"
+			"FVRwNjWa1rphBRWOPo2YeuomgCMjenR3r6myzrDDly5HxADIWz2jCkICSMorfJOVq1ToaWVmoqNV"
+			"tQY/Bf+Yt+deRCmWaKpxbQz0vBysmthbKVWWymQXwt+cD4t+lZ5dIpaY6Wq1qWk33quulb4uU+ef"
+			"gKdlz47Qxc2pi6sjWc4s4l+PjEvMK9TkcupZm7d3sWez3hn8wlOzsnh8pd1bO9lx2KwsXnF4aqbK"
+			"9uvbWBhqaSiWpOQX3XgdD8BYW7OXh7NS/cwi/p8375NlLTW11T3aqGz2Uxh2GJcjACBhKQw0Vddx"
+			"WIH8YnhaI+CXaj8+hUKhUCg/IlXRI0vEks33nlRQoW1Nu4r1SKFYmi8oASCSSMurwxOKSJ0qs/N+"
+			"6Mob95UKH88e+VX0yGdJ6eX9aU3trY6M6OFsakRWk/OLBuw//yAhRbHOraiEdbcfHhrWva+nCyk5"
+			"/fy1f8xblQ0aamkSPXLPgxe/nLklEIuZTe6WJr7j+jHHmnL6RmBskuK+uhrqhWtmAgiMTeq775zK"
+			"9kNmjWj6vu47/dytM8+jANSzNi+rR54MjVQ89wH1ajWys1TZcpXhCZEvAABZ+UPH+cXIF6BQUL1H"
+			"plAoFArlx6UqeqSOutq5sX3JckYRf9LJ6wDqWJqu7NaaFJp+DUWtLJHpOQAMtTQcjAyYQhcz468n"
+			"EQD81NCtU21HGWSpBbxjTyPCU7MeJqb23nv2xdyxHDaLJxR13HYiMiMbwJimnjPaNjLW1roSETPz"
+			"3O2iEuGQgxcezR5Z19pMscGdgzqb62orlrhaGAN4kZI58eQ1mQxG2pqTmtdPzC04+jQiIi172OFL"
+			"IbNGkJqR6dkAbA31TLTll6yWuVzFVOOwDTTfMzoWCYUSqcxYW7OR7Xta4N03iUSJLI/jzyIBtHO2"
+			"f/I2rbBEePTpq2rXIykUCoVCoXx5qqJHqnHYfUqtYvE5+WTBVEeLKSTIZAhJTIlIyxZKJDYGuu2d"
+			"7XU11Mu2llnE94tOKBAI61qbeTlYV3zoHL7AP+ZteiHPSEuzrbOdpZ5OBZXJsO+oJh6b+npX/uw+"
+			"N03trUY39SDLM9s0qrf+wJus3Ii07Pvxya2cbLcGPCFK5KgmHvt+6kqqTWpRnycUzfG9I5RIVtwI"
+			"Oj26j2KDnWrXqGFsgDJcjoghxrlNfbxHNqkDIDm/0D/m7cPE1LRCnqWeTr6gJItXDGBrv45K1w5A"
+			"d/eaih4FIonUYsk/uXxBN/eaHPa7kXGxVDr9rB8ADS6nRCwpK0ZibgExeXZ3dzLU0jgfFn0yNHJ9"
+			"r3aKw+tlkckQkoiINAglsDFAe2fovqfTgieEXxTSCmFvhA7KsstJK8SdaBSWoL4Nmtq/tylfgLhs"
+			"ALAxAF+EW69RwxjeteRbc/jwj0F6IYy00NYZlnrKhw6Mxds8SKRwMEbbmtBSUz5ucBwyiqDOgbsl"
+			"mtqDXc65phXy0gp4AJxNDTW43Hsxb2Oz82wM9TrVrsFlsyVS2b3Yt1EZORZ6Ot3cndQ5HGbHzCL+"
+			"vZiktMIiA02NejbmnlbvPi1Ij9NS47qYGQXEJkWmZ+trarRztlN0iqBQKBQKpVr4XPHasdl5/fef"
+			"D03OYEqMtTXPje3bpqadYrVtQc9+OnSRGXjt4OJwdmwfJTMYw/rbD5dcDWQqq3HYi31aLOncojwZ"
+			"ojNzAdQy/8oGyArQVldr62xH9N34nPxWTrb7Q8LJpt87vXdeY5vVjc7MtTHQq2GsX8nGuWx5EJWT"
+			"iVzLtDOS7yuVylD6/wCoVQkb7bXI2Fy+AEDPOu/5s+66/zwsNbOLq+Or9OyE3IKyO554FkkWfGrX"
+			"0NVQPx8WnZRXGBSX3NrJtrxjxWaj/36EJr8rMdbGubFoU3rk4DgMOIDU0qPZG0GjzI28PQizz0NQ"
+			"OqTf0hEl74b3cScaffcBQF9PXH0FgRgmOshaCQDrb2PJ1Xc7qnGw2AdLOstX9z/ErHPyMXSCiQ52"
+			"DMSAegAgkWLWeWwLgqK/Rh1LHB8JD2UnWADYERS6/HoQgFXd2+wNeRGTlUfKvWs5rOjSasyxq1GZ"
+			"OaSkkZ1l0PRhGlwOgLV+Ib9fDVD0CRncwPXI8J5Ev++261RCboG1ga65rjbTAdU47PW92s9o00iF"
+			"EBQKhUKhVJXPFa894sjl0OQMLpu9/6dulyb0N9TSyOELxp+4plTt5ut4DyvThR29iFZxOzphzNEr"
+			"Khs89vTVvIt3BWLxsEbuQdOHTW5RXySRLr0WeOjRS5X1k/OLeEIRADaLteRq4LQztw4+ChdKVBjM"
+			"vi7EHAXAQEsjo4hP9AY7Q72apoaK1Qy1NLYP7LS4U/PhjetUsuX2LnIT3KWIGAAZRfzb0QkAXM1N"
+			"rA10AbzOyAHAZrGS8gvn+N6Zff72zdfx5bV29MkrAGocdhdXJ6Ywhy/4/UoAgN87tSjPL/H4s1cA"
+			"LPR06lqZM9E/R59EVCD5iCMITQaXjf0/4dIEGGohh4/xJ+RbM4vQcw9SC8BhY5wXZrRBiRjR70cE"
+			"+UVh6mm5djinHUY1weO371RDRc6FgcVCp9qobwMAx55i3kUIxBjWCEHTMbkFRBIsvYZDjwDgZRrG"
+			"H0e+AMMaIX4J4n7H6KbI4WPmOSTlAcDuB9gaAIkUG/sg/Q88+xWN7RCVicmnKjhdAFh0+V5aAa+d"
+			"szwKyi8qoeWWI3E5ee2c7XXU1QA8eZvmGx4N4Obr+AWX/EUSacdaDgG/DB3T1BPAiWeRJ0JfKTaY"
+			"kl8Un5M/uUX9mW0bG2hqiCTSmef8/KISPiAHhUKhUCgfw2exRxaWCFvUsHE1N65pakTGcHt7uBx8"
+			"FB6dmUtGVJmac9o1Wd+rPYsFiVTWfPN/jxJTz4VFv0rPdrMwUWpz9a0HAIy1NfcO6arB5TR1sLoc"
+			"EfM2r3DFjSAyaKtEdKkhZ8qpG0zhrvvP/aYO1uR+E1kzJVLZkScR1yJjAWhwOS0dbZPzC8kmB1Xj"
+			"1OXRassRxvQIIH7JZLLQ2M7ywNBu8y/6r/ULOfAwvEBQUiwSN7az3P9TN1KB2COlMlnnHSdJyd/+"
+			"j2e3a7Khd3ulQxSVCC++fAOgbU07fc13zglLrgbm8AUdXBxaONrkF6sIinqdkfM0KR1AF1dHFgs1"
+			"jA1czU0iM7LPvIja2r+jotgMhSVoUQOu5qhpitFNAaC3Bw4+QnQm0gphqYcdwcjhA8Dq7pjbAQCW"
+			"dkbLLXiV/q6RVbfkC1cnook9AMxuhyYbISzzHWFvBL+pcDaVb1p9CwCMtbF3CDS4aOqAyxF4m4cV"
+			"NzCyCR6/hVRG/ls4GAHAnsHYPRjc0vMIKdXT2jvDXBfmugicrsJWWpam9lYXJ/Q319We43tn491H"
+			"AGqaGl6ZOKCWmfHBR+Gjj14BEJaaOai+K08omtqyQTa/eFX3Nk4mhraGevsfhgG4F5M0tKE706Cp"
+			"jtbTX0fbGeoB6Fe3VputRwFsvvfEu5bDh6WhUCgUCqVyfBaNSk9DfX2vdgCEEklQXPLTpPTwtCyy"
+			"Kf19PbKVky1xk+OwWSMa13mUmArg7ptEJT0ym1cclpoJoIm9FRna47LZnVwd9z54EZOVF5OVp2S9"
+			"g8KgbS8P5151nLcFPXualB4cl7zJ//ECb6/PcdaVZMWN4E3+j2VARiGfGaNf27OdsbYmk8eHU6Hv"
+			"oBLJ+UXlbUor4BWLRADSC+VWT4FYTEqg8BfN7dDUzlB/xfWgLF7xxruPBtavreSoevFlDDHu9vJ4"
+			"54oYnpq1I/gZgLU925YnADOo3aN0NLyrm2NkRnZmEf9WVAJjnlRETwPrewGAUIKgODxNQniafFN6"
+			"ISz1cDtavjqyiXzBSBu1zN7pkUIJAmMBwNVcrkQCqGsNLTUVeuTMtnA2BQB1DrJ5CEsFgCb2cuWP"
+			"y0YnV+x9gJgsxGShXum/MscXQXHo44kurjBR8NElRk0AbbZiVFN0c0P7cnw3lVjTsy0JlqpnbU5K"
+			"fvNpTvwNXM3lfaFQIATQx9OFOLMm5RWeeBbJjFwzl5hgY6BHlEgArZ1szXW1M4r4gXHvxeZTKBQK"
+			"hfKJfC7LXHohb9m1oKNPIwoEQgBMZEYFaVkcSr33kvIKlTallb4jb0cnGC7cTJYZJSwmW4UeOaF5"
+			"vZ4ezvE5+Y1sLdU47FZOtq6r9wA4+yL66+qRuXwBcTQEYKyt2crJdnrrRsRKxARN56my7ZXH87lj"
+			"7I1UOE0eeRKx4JI/gN4eLqu6t0kv4g0+eCE8NavrrtOxiyfpa6ofHNbtz+6tc4sFDWwsAKhz2JNP"
+			"3QBw9kWUkh559Kl8GFrROXLGOT+JVDaovmvj8oOvmR2D4pLDU7MAvC29uMeeRqjUIwGkF2LZNRx9"
+			"igIBAHBKrX3k5knJBwB1Diz0VO6NbJ5cX7Q3Kk+udygq7Gml993taBgulC8zo+Ex2ehUG5v7Yv5F"
+			"CMQ4/Rynn4PNQpuaWNQRPrUBYGpLPE3CoUcoLME/AfgnADrq6FEHf3SFy3tB9uWKwZh7WaVl5MNJ"
+			"kdPPX6/1C3n8Ng2V61kAbA31Mor4uXyBSCJV49DZBygUCoVSPXwWPTIlv6jp34eS84t01NXW9mw7"
+			"oF7tLfeeVJxyEoBYKo8bYJeJbmUGQF3MjAbWc1Xaam+kWqGw1NNhbJ+1zY0NNDXyBSXM2PHXYlX3"
+			"NlNaNgCgxmET1zcGeyN9HXU1nlD0OiOnRCxRUiCOPo2w1NNxNDZ0MNZXDHbW11RXygpOYGyBG3q3"
+			"r2lq6A6TSS3qrbxxP5tX7Bed0NfThctm1zA2qAH5GHqzUt0xOe89A2cOX3DtVRwATyszJjA8r7iE"
+			"eFueDI08GRrJVH6eksGatU729zwAockZxAUTwCb/x0rinQ+LLnuOAFLy0fRvJOdDRx1re2JAPWy5"
+			"h8333lUgp16B1sT8Nx87CyEzPO1ihoH1lLcSrXR6G4xojEsRuBIBv2hkFuHuG/jH4MZkdKwFNQ4O"
+			"DsXyLjgXhuuRuBcDnhAnnuFWFCIWwLw6AqZXXA9eei0QQHtn+0U+zd0tTGyWbavEqcnPjVNe6DiF"
+			"QqFQKB/PZ9EjtwU9I4Ote4Z0GdLArZJ7xWbLg1UV0z0SrPR1WSzIZNDX0FjWpWVlWtsZHJqYW8Bm"
+			"s/7oKs9qKZJKAWipfWXnSC01rkq1D4Aah92xVg3f8GiBWHz6+ethjd65u71IyRx2+BIACz2dpGVT"
+			"Kk6aQ8jhF5MFI235BC/6GvLj5vIF+YKS7UHPcvkl7pYmo5p4ABCVBiFpqb/3F50KjSQqvqIxks1i"
+			"ObxvBE3MK5DJoMZhW5fmlyERNgBGNqlDTJ6Esy+iAmKTCgTCSy9j+terhffZFoTkfADYMwRDGqg4"
+			"LztDvM6ASIKEXLmTohKmOtDkQlAm+OaDWOmj9DbDsi7lVjPSxojGGNEYQgmWXMVaP8hk2B+CjqWn"
+			"UsMYs9piVltk8TD0MG6+RjYPvmGY0Pzj5CkLTygiMwO5W5rcnDKYw2ZV0nRN8nNZ6ulU5s6hUCgU"
+			"CqWSfBalihmYtjeUqxp8kapYWeC/Jy871a6hra5WIBDuuv8cIMGzNZSq6WuqN7W3CklIfZKUllpQ"
+			"RDLhTTx5PSojR09TfWu/jmUTKF59FUfiW4c0cKtjaRqSkMoXigAwCs2K68E5/GJPK7NxXnWr46Sr"
+			"hwUdmxGxf/W909DWgviJ5vIF445fJRV+82muMjylLI4mhkFxyQDOPH89oXk9gVh8tnRixhrG+jrq"
+			"an/deZTNK7Yx0B3SwE2Dy7kdnUi2NrAxV2zn2FO5OqjoHKmvqc4E9BAMF27OF5S4W5iGzh0NQCbD"
+			"8dId/+jaWnHk3UpfNyA2CcCJ0Fdl9cgk+dcE7EtdFfii9yp418KtKADYcg8begNAdOa7ABcAXDba"
+			"OuN6JOJzcPEletYBAN9wFH5I49LXRFN7hCTgSRJSC2ClDwATTyIqA3qa2NoPZrpIykNGERraQkcd"
+			"6hyMaoK1fgCgxgGAbB7SCpHLRysnADDVQV9P3Hz9rsInklnEJzkHbAz0iGWR3NVlicvJe5SYSqbc"
+			"PB8WnVHEB9DO2V5lZQqFQqFQqsZn0SPr25gffAQAE09e7+PpEpqcQWbKBiB9343rzPOowNjkpvZW"
+			"ocnpxHNuTFNPld5+y7u06rrrlEgi7b7rzLTWDYPjk/c+eAFgUH1XlVm4F3b0uhTxRiKVddx2opWT"
+			"7d03iQDYLNbMto1JhX0hLxJyC3p7uHxTeqSXg/WyLi2XXQtKK+TVW7/f28VBX1PjVlR8Dl8AYHRT"
+			"j2mtKppwUpGpLRscfRIhlckmnry+/2FYcn5RYm4BAE8rszY17bhs9sKOXr/63knOL2q88WBNE6Mr"
+			"r2IAWOjpDGv0Lv49Ob/oXuxbUt7E/iMmoQlJTCHpJOtYmipd0M6ujhw2SyKVXQyPKSoRKmWnr2+D"
+			"0psHfTwRmiyfOBuQx0pPao5N/kgvxMa7uB8PXQ3cfQPR+wE0i31w8zWkMvTbB5/ayObhYWKlxF7e"
+			"BV13QSRB912Y1hrB8dj7AAAG1UcNY9x5g47bIJWhvTNmtQOHjfW3AYDNwthmAPBvIJZeA4DJLdC/"
+			"HjKL5FqmuS56eVT+zysXW0M9Ex2tbF7xraj4KaduqHHYzLeBUs8qEAibbTrc2slOW417MyoeAIfN"
+			"mtuhaTUIQaFQKBRKKZ/F435Si/rEzvQyLevPm/cDY5MYEyMTI0wY28xTncO++PLN27xCDps1pqnn"
+			"tgGdVLbZ2dXx5Kje9kb6z5LTxx2/uvfBC211tXkdmh0e3l1l/WYOVmfH9LU11Esr5J1+/jqLV2yl"
+			"r3t8ZK+WjjYq6387LO3c8uL4/g1tLUQS6bXIuJOhkTl8gaOJwa5BnfcN6Vb5YcnmNax9x/VzMTMC"
+			"cD8+JTG3gMVCbw+Xq5MGEovm7LZN/ujaWkddLTw1yzc8WiSRNrCxuDllkOKw+/Fnr4h+0t3d6aOG"
+			"RI+UZojs5u6ktMlQS6OVoy0AgVh8PixaaeukFuhfDwBepuHPmwiMRafa8k1knNpIG7emwNMKAO7H"
+			"4+ZrtHJEs/ez2bRywolRMNOFWIqrr/A0CeO9YKD5YbE7u+LkKNgb4Vkyxh3H3gfQVse8Djg8HADa"
+			"O+P8OLiY4c4b9NqD7rtw9w3cLXFhvDxH+u+dsKo7jLWxIxg+2zH0MBLz4FMb/r/AWLviI1cKLpt9"
+			"aFh3M11tmQw7gkO3BjytbW5C5otX6lkORvrd3Grei3l7LTJOIpVZ6eueGdOnoa1FOQ1TKBQKhVIV"
+			"WLKK4zw/gZT8ojdZudrqap5WZhw2q6hEBEBTjaPJ5QolEr5QDEBHXY3NYoWnZfJKRLXMjT84MbdU"
+			"JnuTlZuSX6SvqeFuafLBTJBSmSwyPSejiGeuq1Pb3Pj7CjJILSgiATf2Rvqu5iZVdmyLzc5LyitU"
+			"53JqmRkbaysrUwKxODw1iy8UORgbOKiyBH9xWABS8vEmC9rq8LQCh42iEgDQVIOmwgWPykRaAWoY"
+			"w94IPKHcJGmg+S7ORiTByzTwhHCzgLE28gWQycBhQ0+1e+o7pDK8yUJKPvQ14W753kEJiblIKYBY"
+			"AnsjFVHhEineZCGzCFwOapkpapDV09eEEkl4alZRidDRxNDOUK+oRCiWygCQD4AaK3Yk5BbUszYP"
+			"nTs6Ob/oTVaukZZmHUvT7+vmp1AoFMp3wWfUIymUKvF/rO58ib6mqEd+gcNRKBQK5UeGZpKjUCgU"
+			"CoVCoVQFqkdSKBQKhUKhUKrCNzHTNIVCqS68aljXMDZwNqvEZD4UCoVCoXwa1D+S8q1B/SMpFAqF"
+			"Qvk+oPZIyrcGVbYoFAqFQvk+oP6RFAqFQqFQKJSqQPVICoVCoVAoFEpVqMq4NmvWumqXg0KhUCgU"
+			"CoXyhZH9Pe9Tdq9KnE1iPu9TDkn5XnBY9m/Csp+/thQUCuX7gD4xKFWA3jZfHXsDnU/ZnY5rUygU"
+			"CoVCoVCqAtUjKRQKhUKhUChVgeqRFAqFQqFQKJSqQPVICoVCoVAoFEpVoHnIKRQAul9bgC9A0dcW"
+			"gPIDQnsWhfJ/zpfWIyUSCa+oCICGhoaGpuYXPvq3D5/PE4vEAPQNDCpTv7CgQCaTcbhcHZ1Pirei"
+			"UComPS2VzWIbm5pyOJyvLQuFQqF86whLSgQCAQBtHR0u9//ZZled57Z2+VJBcbFiibGJiaOzS5sO"
+			"3oxW9DriZdfWLQDMXLBo1oJF1Xj0/w9mjB9348olAAl5lfrGbe7hWlhQ4NWy1YnL1z6zaD8K2Vn4"
+			"5y/5sqYW5i/98C6H92LtcgDYshsdOquu09wDhQVwdcfp7+1CXbt4YcncOelpqQB09fQCn780MjZW"
+			"rFCZjs+QmpJ88vChxyEPMjMyuFxubTf3br37dOjchcWSz6seHxt7cNeO8oRZukaevFYmkz0JCXkR"
+			"+pRXWGhhbd3Wu6OFpRVTjcfjhT17qrSvlY2tg6OjWCx+/OC+ysZt7e1t7R2UCu/cuJ6VlQmgZZu2"
+			"1rZ2Sls3rv6zMD+fLE+aMdPSyro8ySlPH+LiWfmyax0MHvHhXaZPwO3rAHA/HHr6qut8gz3L99TJ"
+			"3+bMBLBl974Onbt8bXGqyOG9e9YuXwJg/8kzTbyaf21xPiPxsbFpKckqN3m1aq2yvDKX+PC+PSsW"
+			"zgdw4tLV8tr5/6A69cjDe3cXFhSULdfQ1Jy98LfJM2YB0NTUcvPwBGBmbl6Nh/5O2bv9XwAOjo4d"
+			"u3QjJXYODuT/qSSu7nWKioocnGqS1Su+51NTktXVNUaMG1/t0v4gXD6HfQpqTLfe8Kz/gV2EQhQW"
+			"AIBIXG6dwgIUFqDoexsBKywomDlxfHExn8vltmrXPiM9XUmJROU6fmnNPcsXzhMJhUxJWOiz08eO"
+			"tOvos+3AYR1dXQBpKcn7dmwrTx6iR2ZnZY0fOvjpwxCmnMPhzJy/cPq8BWQ19PGjob17KO27eOWq"
+			"CdOm83m8wT26qmx84fI/FKUF8Co8bOyQgVKpFMCuI8eU9MioyFeb165mVq1tbSdMm16e5JTd/+KK"
+			"r3zZwBD9h4Cr9oFdinnynlVBmuNvsGcJRULSI0RiUZUbKft2+MIIhSXkLCTi8p9r/xcc3LVD5TNH"
+			"U1PrdVqmyl0qc4lNTEzJ21xbRwdAakryFd/zALxatqpTt161SP6NUP22Vk1NrZUb/wYgKBaEPw89"
+			"fexIiUCweunv1rZ2vfoPcHJxuRao2hjwA0I+Vjp168E8KZasXvtRLZy+dlNx9eCuHQ+CAvX09ake"
+			"WWUunAEAr1YICwWvCL6nPqxH/h/z6mV4cTEfwPBx45ev/auCaQsq7vgATv53aPGcmQAsLK0W/7m6"
+			"aYsWGWlpa5YtCfK/e/fWzQUzpm3de0Cxweat24yZPEXlsX6bPYMoke06+ng2aHj2+LHkt4kbVq2s"
+			"26BhO59OAGKiogBwuVwXVzdmL/LsZrFYevrvmbZKSkqEJSUA2nTwVjrQsvlziRKpkgtnTgPQ1tap"
+			"37hx8D3/86dOUj2yPHg8+F0HAJ+uuHkV+Xm464eO36up7ktQ9u1A+UxoamkpPROIjlj2gfBR9Bk0"
+			"uM+gwcxqQmwsuaZLVq+leuQHUFNXGzh0OLNav1GjBTN+AXD80IFe/QcIBMWx0dEAzMwtzCwsmFVj"
+			"U1NLK+vszMz7gQH5ebm13Nw/aEh/8/p1WOgzHq/I3NLSq2VrpRE0kVD45NHDhNgYiURibWPbpHkL"
+			"Yu0gREa8lEokmppaTi4uAkFxsL9/akqyuaVlO28fNXV1AJUXLC83NyQoIDMjw8DQyKtlKzMLCyU5"
+			"M9PTH94Pzs3J1jcwbNS0qY2dPSmPCHtBFgoK8iPCXljb2hkaGb1NiCd3sLtn3ZTkpLycHACW1jbG"
+			"JiakcmFBwduEeAB6+vp2DjXIiWjr6NZwcoqPjeXxeACkEklE2AtDIyN9A8PE+DgA6uoazrVrMyKR"
+			"Q6upqbu4ulb8J/9opCTh0QMA8O4MAwNcv4xL57DoD7DfT2wgleLhfcRGw8AQrdqpbiozHcEB4BXB"
+			"3RP1G723SSLB6wgA0NOHsQluXIaGJrw7Q0MTAIQleHgfifFQU0eDRnCurbzv8yeIiwWvEGYWaNoc"
+			"JmbKx33yEFmZUFeHS23Ua6QsfFkiwl5EvnzJ4/FMTE0bNWvGDBAXFhS8KB0dVlfXiAh7Udu9Tnn+"
+			"kRV3fB6Pt2rJYgDqGhrHLlyuWasWAEsr6z3HTrRpUDczPf3CmdPTfp1X282dacHG1q5z954qj3Xr"
+			"2lUADo6O+0+eYbPZrdq2IybGG1cuEz0yPjYGgIurW9mvVj19/fDEFMWSsUMG+l27amVt4+5ZV7H8"
+			"0rmzD4ICNTQ1SwQClWL4njoJwKt169btOwTf8w9/HhoXE+NYs6bKyj841y+iRAAA037FowfIy8WF"
+			"Myr0SD4fQf7ITIe1LVq2Ud1UlXtWXi5CgpCZAQNDeLWEmYXyvtXeswBkZ2UF+d8tKixwq+PRoElT"
+			"Uhj75o2gmA/Axs7ewNCwtP30zIx0ANa2dilJb0mh4tuBlLxNiH/68GFhYYGVtU3zNm20tVV7xr95"
+			"/VooLKvYCBkAACAASURBVAFQ06UWE4qQlpqSk5UFwMLK2sTUFECJQHA/MCD5bSKHw3F0dmnczKu8"
+			"Ds7s6+TioqmpRQpTkt7m5eYCcKntSl6dlZfw22H+0uXzly5nVsNCn/Vo1xpAx66qBy6UUHmJSXl6"
+			"agoAMmBIHkoA0lJSIsJeKP5j3zuf3feTPNYBJCUmAIiNjlb0j2RWh48dz+awjx7YLxbJrcR9Bw/Z"
+			"tHOPyjazMzOnTxgbePcOU6KpqbVw+R+jJ00mq9cuXlj866zM9HSmgo6OzqxFiyf8/AtZHdDFp7Cg"
+			"oG6Dhv0G/7R53ercnBxS7uLqev7mHV09vUoKtnPLpg2rVjKvGa6a2vRf582Yv5CsisXilYsXHtq9"
+			"SyKRkBIWizXgp2GrN21RU1cn7QN4EBjQtXWLv7btGDh0+IqFCxj/yIDbfvN++RnA6EmTl6+Vu+wd"
+			"PbCPvI9nLVg0c8EiciLEP3L+L1PDQp8B4PF4XVu3GPDTsKVr1vXv7MPn87hc7sNX0SZmZgBioqLI"
+			"odt36nzg5JlKXscfBMZ/q3V7aOvg+mWkpuBxCJoqfDtkpmPCMDx7LF/V1kbtOsrtHN6LP36TvzgB"
+			"NPaCwlgueEXo2lpenpKElCQAuHEftd0QcAezJiPz3Z2Lrr2wYTtIGNXzp/hlHBLi3m3lqmHydPy6"
+			"GCwWJBKsWITDe1B6uwFALVf8sx+131nl3iMq8tXMieNfvnjOlLDZ7AE/DVvx1wYtLe3gAP8/FslH"
+			"indt3bxr6+awhORKRoApdfxbV6+QXta9T1+iRBK0tXUWLFsRHRlpbmmp9sFhTuasOVwRhLb2Dmw2"
+			"G4CVjS0pZ2yHcbExAJycnT/YVF5urv+tmyjzzhAIiv/8/TcAA4cO/2+figfR86dPyEda6/Yd2nbo"
+			"SAovnjnFjK1TFLlwFgAMjVC3AVq3x8WzuHkZAgEUgy2fhGDyKGSkyVetbaGhodxOlXvWzi3YsOrd"
+			"jlw1TP8VM+bLV6u9Z8ml3bP7l3FjmBdEizZtd/13TE9f/+zxo1v/WgdgzOQpy9asJ1uXL5x38ewZ"
+			"ABdu+/fq0JYUKr4dBILi+dOnnT95gmnfyNh4w7ad3l1UqDv/bFx/7sRxADsPH+3SsxcpXDDjlzs3"
+			"rgM4cfmaiWkrf79bsyaNz87KYvaq7eZ+5PzFstYQADs3byKDv1cDgpkvrg1/rjx97AiAoBcvbe0d"
+			"PkrCbxbyfchisTp0+rDBvLxLDOD8qROMfySA+dOnkTrkWUr+sc90Cl+Yz54/klHm9PQrev38t2/P"
+			"od27nGo6t2rXnnwPnTtxnGhFSkil0rFDBgbevcNmsyfPmLX+3+0Ojo4CQfHS+b/eunYFwIOgwCmj"
+			"hmemp5tZWCxf+9df23a4uLryeLyVvy08vPe998GLZ0+XLZirrq7RrqMPeTtGR0YeO7i/koL5nj61"
+			"asniEoGgz6DBZ6/7DR87XiwSbVz955njR8m+a5cv3b9ju0Qi6dyj16ade9p08JbJZKeO/rd2+VIA"
+			"YydPJdXsaziOnTzVpbayabBLz97keyXI/y5TyGjPvQYMUqrfrXdf4uavpq4+dvJUEuUweORIAGKx"
+			"+PL5c6Taw/tBZKHjd9W3vwxkUNvUHK510E6uG8D31Ht1po6WK5FtvfHzbNjXwLNH71UI8sfiOSgR"
+			"wMgYE6ZhwE948ezdC0yRxw+QkgSvlrCxg6094mMxYSgy01GnLo76YtXfYLNx9QKWzQMAsRgThyEh"
+			"Dq7uuB6Mp9FYtgZiEQ7twc2rAHDsIA7shESC31fhaTSuBqBuA8TGYNEsFYcGkJOd/VOv7i9fPOeq"
+			"qf08+9d/9x/y7tJVKpWePHL416mTATg4OjEvgGYtWo6dPFVdo7If0Eod/1HpXdeitbKVacBPwxYu"
+			"/2PclJ+dXFwq2XiLtm0BPH/6JCsjA8CFM/Ir1LJtO7IQGx0FwMTMbPe/W3+fO3vnlk052dkqm7p8"
+			"/qxYLAbQsWt3xfIdm/5OSXrbun2Heo0aqdzx4pnTZKFNe++atWqRcYbzp09W8hR+KPJyEXAbAFq1"
+			"A5uNth0BgM/HzSvv6mRnYewQZKSBw8HgERg7GUIh4mLea6fKPcv3NFYtQYkAfQbh7HUMHwuxCBtX"
+			"48xx4DP0LIaAO7dru7n/PPvXps1bAAi+5z9n6mQAoyZMIs/2i2fPMFaGh8HBAMwsLOo2aKjy7bB8"
+			"wXyioi1YtuLMtVuNvbxyc3KmjB5Bhs6U6N1/YOmfJn9liEWikMBAAJZW1k2bt8jNyZkyanh2Vpa1"
+			"rd3hs75EnX39KmLDqpUfOKvy+SgJv02kUinxV6nfqLFKfVqJ8i6xEpbWNl179SbL5FmqW17g2HfI"
+			"59UjU1OSV/4mN84xj3iV6Orp7Th05OaDR0fOX2Rc3VXqkXduXA998hjA8HHjFy7/Y9CwEf/uP6Sj"
+			"o2NlbePvdwvA36tWErPE3mMnR0+aPHDo8GO+l8mg9pb1a5S8nWYuWBQcFnHw9Ll/9x9SedAKBNu2"
+			"8S8AhkZG67dua9Ss2fJ1f1nb2AIgrve5OTn7d24H4FbHY/vBw30HD9l15JiNnb2ZhcXD+8FSqZSJ"
+			"PHV1r7N0zbr6jRornamBoSGxc0RHRmakpQEQCYXkWeNRr35ZW8uoiZNqODkB0NTUXLpmXe+BgwCM"
+			"m/IzsdmcPXmcVHsQFEgWvq9vxC9AbDTCnwNAO2+wWLC1R81aAHD1AhhH84f38fA+ALTvhENnMG8J"
+			"rgSgz/sq/T8b5AsHT2PxSmzYjgu3oaZKAeOqYf8JnLgM/yfQ0cH+nSBxz2s2o2VbDBuDnv0A4NRR"
+			"pCQhPRVpqQBgXwOu7jAxw5jJiE5HWAI6dQOA0FITaYvWMDGDuyfOXENMJs6UE8d6cPdOoofN+33p"
+			"vCXLevTtt/vIcTIuc+nc2TevX7u61xk8YiSp3Llnr6Vr1jHjWRVTtuNnZmSQVcav44Nc8T3fwtOd"
+			"+ZGwA8L6f7Z7d+laVFjY3NOtiavzXytX6Ojo/DJ3fo++/QCIRaKkxEQAh3bvWvnbwkO7d61astin"
+			"eZO4mJiyR7lw+hQAbW0dRQU3Jent9k1/A5g+b4HKECLmZWNjZ088RtqX+mW+ehleyRP8cbh8Xt6D"
+			"2vkAQLtSrzPG/A/gyD7k5QLA/KVYtxVL1+D2Q2Wnjir3rG0bAcDQCOu3olEzLF8HaxsA2LwWQPX3"
+			"LIYJ06ZfuO0/b8my45eu1mvYCMD1SxfevH5tZmHRd+BgAFkZGcQ0EB8bS1IieHfuymKxyr4dsjMz"
+			"Txw+CKBD5y5TZs5u7OW1fut2ACUCwY4tm8oeunX7DmQonDE9PHvymM/nAejZrz+bzU5PSx08fGSf"
+			"QYNXrP+rTQfvMZOnkL4ZEhz4gbMqh4+V8NvkYXCQ/EJU7v1Y3iVWqlbDyWn0RLl+SZ6ljKPC/wHV"
+			"r0cWFRaS535DF0cv99ohwUEAajg5TZk5u4K9Bg0bwWjrHvXkcQ3F7ycTIQTcvU0WuvSQ2+o96zeI"
+			"SE5/EPH6j/UbSwSCRw/uA6jl6kYuKgAzCwvvzl0AZKSlvQoPY5py8/CctWARV03tvYPy3ztoeYLl"
+			"5uRERrwEUK9hI3UNDQBcLrd1B28ACXFxCXFxD4MDSVxqx27diSFTS0s7OCzi8euYC7f92ZXxrAGI"
+			"LohSk+SThyECQTGAPgOVjZHlYedQgwxqPHv0kAzDMZqoFXmUUkph3mrepaMZ7TsCQHYWAu/KS4L9"
+			"5Qv9h8gXOBzUbfCuEZFQ7mFZsxbqNZQXutWBymSp7TvK8wSRd+H9ewCgqQmPUifs9j4AIJMh4A4s"
+			"LGFiCgA3rqBvJxzYiYQ4qCsM/LmXevcN6Iol83D3ZkVRrgACS7vSwGEjSs+FM3DoMLJ81++m6t3K"
+			"oeKOLygd96l8+kk+n5f8NpH5FZSm1wFQWFCQn5cLQFhSQj6xxBJJMY9HvhLfJiYSE6OLq+u6rf8S"
+			"5TIrI2PpvDlKh0hLTSFytvH2VlcYQ121ZLFAUOzdpSuxMZTl0YP7pS8b+b3SzseHLJBBMYoipGex"
+			"WOjgAwBmFqhTFwBu35CHYwMIuidfYHqWgSGcFHxNq9yzcnMQGQEA9RrK+wuXi9YdACAhDglx1d+z"
+			"GJo0b04SWnE4nH6DfyKF9wMDAIyfJneyIjcMM0zk0011VM3D+8HEcsk46Du5uDg4OgK453erbH2u"
+			"mlr3Pv0AxL55k5qSDAWFkrxWiIa6edder5at79y4vmPz38V8HoCs0k++j+VjJfw28T0tH9zw6da9"
+			"4pqECi7xj0P1+0fKZLLkt4ny1rlcJ2eXzj17TfplhlI8VAVwuBW9achrA4DKVG3Z2VnkVq7h9J63"
+			"O5MZR9FpUpHKpAlVFIw4RAMIuufvYS+XpKSkhCwkxMWmp6WXymmFqtKxa1dtbR0+n3c/MKDv4CHk"
+			"7mSxWD37D6h8IxOnTSfpBs4ePzZoxEjiwd2xK40BVOa8fKASjx/g9SsAYHKKXTgtH+ZOL3XeKnXJ"
+			"UyY3ByJhRRUUKc2ZKCczAwBKSlC3hrxEUmoHTYgDVw3bD+HnMchMx9OHePoQS+ejliuGj8XICWCx"
+			"MHIcwkNx5jh4RTi4Cwd3QVsb3l0w5zc4qor9yEhLB6Cnr89EcUGh45TXU8qj4o7PZAvKz8+rZIO9"
+			"BwxcueGdGUOjVM+TSqVjBvWLffNGQ1Nz8669rnU89m7benjvnj3b/jEyMZk2Z65jzZphCclJiQkk"
+			"mKD/T8OehISkpiQH3LnNKypSjLe7eOY0iUBX7A4hwUEXz55hs9mKrvdKMMpiekrq32tWAeDzeKTk"
+			"wpnT85cuZyld2h+Y9DQ8CAQAPX0c2isvJF8TIiGuXsSgYQDkbpFq6jAtJyNclXtWZqleFHQPHqXW"
+			"8NJHNRLi4OBYzT1LJTb28qRRJFVhbTf3tt4d/f1uXb3gu3Lj34/u3wegoanZql17lbsz/XHz2jXb"
+			"/pYbZsldl5qSLBIKywZt9Bow8Mj+vQAeBAT0HTzkQcA9AE7Ozp715R++L18837Bqpf+tm+S7i1g3"
+			"KsjJUDFVkPBbQywSXT5/FoCNnb2r+zu39+YeboUF8u/YJs1b7D9xWuXuSpf4x6H69UhdPb374ZFk"
+			"WUdXt9pnv2AsecSOqATz+FYav5aVrrIqZwj8IFyO/K9zrFmTfPYpYmNrR4x/ANRUyVlJtLV1Onbt"
+			"euHM6YfBgQAe3Q8G0LR5i49Kd9ygSdNGzZo9CQm5dP6sk4s8xIE6RyoREYbYUh+evduVt16/DGEJ"
+			"1DXevZ/Ke9h+sEIFkHtKUxPjpipvatAYAJq1QPALBAfg1lUE3kVcDKIisWQesrIwZxG4ati4A7MX"
+			"4dol3PNDSBD4fFw8i8C78AtRDj5lRFXqKcxqJU3mDBV3fMb9NzI8XCkKOzLiZXxMjK29fQ2nmrp6"
+			"eky5mpq6ypieiLAXsW/eAOjWuw8ZK/j9zzXHDh4Qi8WXzp6ZNmcuAH0DAyYUgMvletZvkJqSLJVK"
+			"M9LTHRX0yPOnTpIzVXSov3bBl/wPnZo3VTgsJg77iUQHikWiqxfOk8Lrly9ev3xRsVry28TQx48U"
+			"wzZ/cC6dk/eFgnxsWlNm61m5HgkWUGGvqXLPYj7/HWuiex/lrUQrrd6epRKJuDTasrRnTZg23d/v"
+			"Fp/Pu3PjxuOQ+wBatWtfnusIY8Vo3qYNM9TGoDI7VdPmLSwsrdLTUkOCg3r07Rf65AmAnqV+k4F3"
+			"74wa2E8sEtk51Ji7eEnrDt5De/dQHK/7WKog4bfGXb+b+Xl5KGMVLizIZ/xb+OWnKi17iX8Qql+P"
+			"ZLFYlYzorBqMf1V8bAyxmUul0qsXfI1NTMwtLB0cHUmejjdRkYp7Rb58SRbsqilCytzSksViyWQy"
+			"XT19lRPzkOw8AOJjY5nCIP+7EonEyNjYzcOTsYDyeBWl0O09cNCFM6fjYmJSkt4+CQkB0GvAwIpl"
+			"Y0wjDBN+nv4kZFh0ZOTpo/8BsLC0YsboKYQLpZHr/YegjkJur2sX8PA+igrhdx1de8Gq1BcgLhaN"
+			"mqlox8gEGpooESiHCFQGSytkpkMgwJSZqkfrAKhroF1HuXH0+iVMHgmpFCcOYU7pPWhrj/FTMX4q"
+			"crIxfTwC7iA3Bzeu4KdRyk3Z2jskxMXxiorSUlOYLxPirQHA1r6yjoyEijt+e59O61YsA+B75tTP"
+			"c+Yqmv83rvrz+qULAFas2zBq4qQPHojkGQHAJEzR0NRUU1MXi8XkHeDvd+vJw5CC/Lxf5swjOQqY"
+			"XMGaWu/+1tjo6PDnoQAaNGlCcqAQDI2MFJ04iwoLSLMmpqbkBAP975KonUbNmil+Q0aGh588chjA"
+			"uVMnqB7JcLG0Z81ZBJ13nwnYsRkZaQi4g+xMmJjB2gax0RCLkPwWNsrTBgGf0LPMLcFiQSaDrh5m"
+			"lR9MX409SyWMZcHWTn56rdq1d3WvExnx8vihAyQSpeznPfN2YHqoWx2PSk4Fx2aze/UfsPvfrSHB"
+			"gaFPnxCfKCb+5u81f4pFIg6Hc+rq9cr4OHFK+6yih4lE+i6CvQoSfmsw4wxKOTvnL11BkigBqOC/"
+			"KnuJVVKBJvqd8v1pze1L84kQlQiA3/WrU0ePGNKz27o/lnHV1Nq09wYQHxt79+YNUuHN69fE2atm"
+			"rVqVjwmtGF09PRIZExb6jBlqXzDjl8Hdu4wdMjApMaFJ8xZkzutL586STM4ZaWnjhgwa0a/3qAF9"
+			"id2UvE3fJiRUMJTQtkNH8r7c8+8/AkExl8vt0bd/eZWJjVYikTDpxwide/S0c6gBgIQidezajY67"
+			"KSKTvdMjf12McVPe/UZOkJcTH69W8nQc+G+ffJSNV4Qbl981xeXCqyUAJCXiVqkb/o0rqPBjQQ5J"
+			"RSmT4Y78zsWR/RjQBaMGwO8axCK8TcCzR0gtzX7YuQeMTADI5wXJzUFUpNyHDICxCTqXTumiMqMO"
+			"M53X/h1yA2xxMf/o/r0AuFxu9c7n5u5Zt11HHwAxUVFrlv7OxKiePX6MKJHWNrYDhw+vqIlSyJ0M"
+			"4N5tP15REYAbVy6RLkZ03zdRrzevXb1/x3aSo4DP54U+fgTAxNRU0ZDvWxrl7fN+pPaM+QuDwyKY"
+			"H5PGa/XmreOm/IzS0BwAw8aMGzflZ+Y3b8kyUn7F97xEMUPMD0xivDy5gZ0Dps97r2eREBapFJd9"
+			"AaBlac/aXzqbVFwMnj1511SVe5aunjzNZFjou6RCC2ZgcHeMHYKkxOrvWQznThwnd2ZRYeHRA/sA"
+			"sFgsJrs1i8UiXpL3bvuREkX1Rent0NirOUkDefv6NVLC5/MG9+g6uEfX2ZMnlne/EaNDbHT0Vd/z"
+			"ADzq1WeybqUmpwBQU1M3M7cAIJVKS1SGvpfCuKYE3fMHIBAU79yyiclaUGUJvx14PN6tq1cB6Orp"
+			"ebVspbhpxLjxTDfv1vs9m3bFl1gRbum9khgf/3nO4Kvx/emRXq1at/XuCODCmdOTRgxduXjRzInj"
+			"AWhoas6cvxDA/KXLydDApBHDlsybs2rJ4oHdOolFIjabzWTqqhZmLfyNxWKJRaLRg/qf/O/QvF9+"
+			"PnZw/4OgQC0tLVt7Bx1d3Wm/zgOQGB83sGvn9X8sH9yjC7nhfl28hIz6kZQiifFxI/v3mTRiqMqj"
+			"qKmrd+3VB8CR/fsAtO7gXUGcFxP0PX7okO5tW5HoPABsNpvJnQk6qF2G0MdIfgsAtVxh/b73VVtv"
+			"uS/XrWvg8dCgCdp0AIBnj+DTHGOHoIWn3P2L4Ze58gTFk4Zj1ED09saEoajMqM6YyTA2AYBFs3Bg"
+			"J7asw/KFePQA8bFo1hL5eejjgz4+GNAF504g8C5+/xXZmQDkFpFDu+HjhQFd8NtsBN6F72ls3wQA"
+			"JmbwUXXBh40ZS2KNd2z+e+roERtX/9mrfVsyZDxl1pxqD8NavWkLmVdw979b2zeuP33C2L6dvGdN"
+			"ngDA0Mho15FjlcxX7ODoSJJTxkZHt21Ub0AXn8kj5LFBoyZOBjBo2AiiL/6xeOGkEUO7t21FUleO"
+			"//kXxc+nC6dV2x4qRlhSQgayWSxWO28fxU1mFhbE8ywzPf3BD+ZoXx6X5NnG0L6T8qYOpSUXTgPA"
+			"sDFyz8jd/6JvJwzvi45e7yVSxSf0rFkLwWJBLMLoQTj5H+b9gmMH8SAIWlqwta/+nsVw9YJvq3oe"
+			"44YM8vGSpwsYOGyE4uyafQYMMre0JMt1GzRkllHm7WBgaEie4ZERL6eNHXXyv0OjB/R7EBjwIDCg"
+			"QZOm5fmP1W3QkCTxIK+PXgqO9XU86wIQCIrHDx28eunvPdu3ITbR8gagG5dGz2xZt6apq0t9R4dV"
+			"SxZrKESnVU3Cb4dbV6+QN2Zb746Vd+X84CVmcPPwIMF8506dmDjsJ8UpVb93vj89EsDO/46OGDee"
+			"q6Z27eKF3f9sKSosrOXqdvT8JTKXpYur65nrNxs1ayYQFB/ctZOkjqvt5n7ozPlPnOZIibbeHbcd"
+			"OGxta/fyxfO506aeOHxQS0t78oxZTJbyqbPmLFuz3sjYOCz02T8b1se+eWNiarpm89aho8eSCov/"
+			"WEU+8u7d9nsYHCQuZxpT0vmVRiVUMm7qNLc6HgBevnge+TJcMfvAgGHDibVSU1OLpN+jMJwrzRBZ"
+			"9m2nb4AmXgBQIsCNSwCw7YDclBIXA79rMDRCt97v7dLEC//uh4kpxGLcvYnw5xgyEpVJFmZhieOX"
+			"UL8RcrKxdD42rIKwBF164tQV6OrBxAwnLsKrFZISMXMShvXBoT0wMcPC5Zg2BwCmz8O8JTA0wn/7"
+			"MKwPpo9HShJat8epyzBU9emhpaV98vL1Xv0HcNXULp8/t3nt6qjIVyZmZsvWrJ+zaPFH/H2Vw9rW"
+			"7lrg/ZETJmpr6yTExfmeOvn0YQiXy+3Rt99l/0DG978y/LP3wKBhI9TU1TPT0x89uC+RSMwtLZnQ"
+			"bD19/SPnLzZo3ERYUnLt4oXY6GhNTa1f5s5XnDs7LPQZ0Zjtazh+1KxOftevFRUWAqjboCEZNFeE"
+			"yRXCRH3+4JwvDV7v4KO8qWU7+TQzj0OQkgQDQxz1has7ADx9iIA7aOIldwtmqHLPauuNbQdgbYuX"
+			"LzB3Gk4chpYWJs/App0Aqr9nMQwaPlJdTf3WtSspyUkcDmfQsBF/bvhbsYKaujozC5T3+yMAZd8O"
+			"sxctnrVgkY6OzqVzZ+dOmxoSHGRhabVh+86KZ8ElDpECQTGLxerZ791Y1uI/V5OXBQnWLizIJ85O"
+			"vKIilSHbzVq0HDlhIvkSS09L1dXX+2P9xu7vD45VTcJvBN8qfVh+8BIz6Ojq/r5yNVdNTSQUXr98"
+			"8eWLF9Ug9LcBqwrBWYn5yu53VUYikZCRKXUNdca/WCwS8fl8AJqamuplJzQopbiYHx0ZyefzrW1s"
+			"7Gs4lq2QmZ6elJggkUitbW2Uvg8KCwpkMhmHw2GCN2UyGXGk5apxtbV1Ki+YVCqNj43NSEvV1dNz"
+			"qe2qUcavTSKRxERH5WRlGRobO9eqrRQYLhAUR7x4oa6h4Vy7diWT81WMVCqNfBkuKC52cqmlaLlM"
+			"SXrb3MMNgE/X7nuOnSi/gXc4LPs3YdnPny7S94Duh6u8T3oa3sZDzwC1XCESgqS10dZ+N84lFiEq"
+			"EnwenGvD0AiFBZDJwOFApxKHSk1BUiI4bNSsBQND5a15uUiMB58Hcws4OEHpO18iQUIssrPB5cDR"
+			"WfE9V+74H4/Hi4l6zefzzczMHZ2dPzbC5mMRi0SvXoZnZ2Xp6Oq61fFQjK35KORi83jmFpYOTk5l"
+			"DR4pSW/fJiZqaWnVcnOrls5FqRhVT4yP7lmxb5CZATt7WNuCzwdxbdXTfxdnU+WeJZUiPhYZadDV"
+			"g0ttuRarSHX1LJFQSJLWaWtrs9jsqFcRfB7f0dlZMTECw9yfpxC32iv3gpSmXVb5dhCWlES/jiws"
+			"KDAzt/jE3iqTyeLevMlITzMxNXOuXVtYUkJSjmjr6JSXwCQ9LTU+NtbI2LimSy0Oh1NczBcJRQB0"
+			"9fQYST5Wwu/xRfNRl1iRnOzs6NeRJiamTi4un/tJW3nsDT5p7sqvrEdSvhhH9u9dNGsGgK17D/Sq"
+			"XNqg77F7V5WPftt9h/y/OXdTvjWqRY/8Dql6z5JIJC083NJSU5xcXO48UjHvxo/Aj/Si+Ub5RD3y"
+			"W1GHKZ+JhLg4AEWFhbu2bgZgbWOr5CZMoVAolC9JWmoKmZH56IH9aakpABT91ymU74vqz/tD+XaI"
+			"j41t37g+SZ6XkZbGYrH+2LCxMhnXKRQKhfKZWLNsScCd23b2DmSO3wZNmg4aPvJrC0WhVBFqj/x/"
+			"piA/r3Ezr5dhL7IzM+s2aLjv+KmP8iCmUCgUSrVjbmHJZrOfPX5kaGQ0Ytz4Q6fP0c97yvcLvXf/"
+			"n6nboOGpqzc+XI9CoVAoX4pFK1YuWrHya0tBoVQPVI+kUEBjUCiUzwPtWRTK/zl0XJtCoVAoFAqF"
+			"UhWoHkmhUCgUCoVCqQp0XJtCoVAoFArli8Ln88QiMQB9A4OvLcsnUZU85KxZ6z6HKBQKhUKhUH40"
+			"lPKQH967Z+3yJQC27N7X4f3pIr8ikREvB3TxATBi3IT5S5d/eoMThg65ceUSgIS8z+VG3NzDrbAg"
+			"v0nzFvtPnK6g2ifmIa+KPfLbTz3/XeTH//aF/BYk/OoyfHUBqAzfiAD/fzI4GFZlspkK3nnfwv/z"
+			"zUL/nPJwWPavUolQWEKmKRaRaTG/DaQSCZFKUFxcLQ3aOTi4eXhWS1PlUViQX1hQwC/6vOFudFyb"
+			"QqFQKBQK5YuyZPXary1C9UD1SAqFQqFQKN8oMVFRz548kkokjb1aODk7K27Ky80NCQrIzMgwMDTy"
+			"atnKzMKClKckvc3LzQVgYGhoY2cPICsjIyM9DYCmppaTiwupViIQ3A8MSH6byOFwHJ1dGjfz4nA4"
+			"iu1HR0Y+fRTC4XKbtWipUjaZTBb+PPTVy3CxSORc27VxMy82+73wZT6fFxIYmJKcpKGp6VbHo07d"
+			"wIEJjwAAIABJREFUesymtwnxxMDp7lkXQHxsLJ9XRFYLCwqC793Nyc528/Cs36gxAB6PF3j3dlZG"
+			"hnNtVyVhsrOyHgYHZaan6+nru3l6urrX+ei/+NOgeiSFQqH8iHw+rywKpVqIe/Nm1IC+d2/dJKss"
+			"Fmv1pi0/jRpDVndu2bRh1UoyUzkArpra9F/nzZi/EMCjBw+mjx8DwNbeISA0jM1mz5g4LvDuHQBz"
+			"Fi2ePm8BAH+/W7Mmjc/OymIOV9vN/cj5i0QZFYtEi2bPPHH4IHPo5q3bKIn3NiF+6uiRL549ZUpc"
+			"3etsP3SEUXZPHjm8YuF8oiwSGjRpuv3gYStrGwArFi5Q9I+c/8vUB0GBbDZ75Ya/Vy1ZXFRYSHaZ"
+			"vfA3KxubP35bWJCfT0pGTZy0Yt0Gsrx908a//vxDLHrnANCzX//Nu/cpKcSfFZr3h0KhUCgUyjfH"
+			"6qW/37vt18Sred0GDQHIZLJVSxaLxWIAvqdPrVqyuEQg6DNo8NnrfsPHjheLRBtX/3nm+FEAvQcM"
+			"bOfTCUBSYoL/rZvxsbFEiazl6jZ11hwAuTk5U0YNz87Ksra1O3zWd9ma9QBev4rYsEo+z9Dm9WuJ"
+			"Euni6jptzty2HX2C7/kryiYWi8cMHvDi2VMDQ8N/9h08eOqsmYVFZMTL8UMHCUtKAPhduzr35ymF"
+			"BQVudTz+2rZj9KTJAJ49ejhh6JAK4pulUumiWTN0dfU86zcgJRtX/zl32lQ2m82YIQ/t3pWZng4g"
+			"4M7tNcuWiEWiVu3an752c9CwEQAunj1z6eyZ6rsIH4bqkRQKhUKhUL45ataqdTXw/ulrNy/eudfE"
+			"qzmAgvz8xPh4ANs2/gXA0Mho/dZtjZo1W77uL2sbWwCb164m+67+e7O2tg6Aw/v2/Ld3NwAWi7Xu"
+			"n21cNTUA6Wmpg4eP7DNo8Ir1f7Xp4D1m8hQy/B0SHAiguJi/99+tAEzNzX1v3Z37+9KDp86u+nuz"
+			"omy3rl6JjowEMG3O3J79+rfz6TR74W8AYqKiLp8/B+DvNasAqKmrHzh9duDQ4cvX/tW5Ry9jE5Oi"
+			"woI3r19XcNY/jRoT9OLlpbsBHvXqk5IOnbsEvYg4eeX6wKHDAchksqjIVwD4fN7I8RN69uu/etOW"
+			"Jl7NZ8xfQOqHBAd9+p9feei4NoVCofxYpCS9lUqlZuYWGpqaX1uWz4iwpEQgEADQ1tHhcunL7vtj"
+			"/tLljLefm6fnowf3AQiK+bk5OZERLwHUa9hIXUMDAJfLbd3B+8ThgwlxcQlxcQ6Ojta2dvOWLFu2"
+			"YO6dG9cf6gYBGDVxUoPGTUhrru51lq5ZB6CwoODOjeuvX0UU83kAsjIyADx/+pTH4wHo0qOXjq48"
+			"rQGzLyE4QG6eJAougPadOpMF/9u32nfqHBb6DED9ho0sraxJ+a7/jlbmrFdv2sJisQC4e3iGPw8F"
+			"sGLdX7p6egBq1qpF6hQVFQLo3L1n5+49AaSmJF88eyYi7AXZSs7ii/HlutbZ48fI3wqgc89eXi1b"
+			"la2TlZFx++b19JQUPX2Dxl5ejDL+ZXj6MORiqTXYtU6dwSNGlVdTJBReu3RRICju1ruvjs4nJV76"
+			"WDau/rOw1Eli0oyZzA3KIBaLQ4ICX754LpVKa7m6tW7fQU1d/euKBCArI8Pv+tWMtDRzS8v2Pp3N"
+			"LS2rUYDKXLhHD+5LxGLFEh1dXWbg4NOpzO1NSE9LvXfbD4ChkZFP1+7VJQAqdyEePbgf+uSxoLjY"
+			"zt6hbUcfI2PjahQgOyvrn7/kyWU1tbRUpliTyWQhQYFhoc+EQqGdQ40OnTqT52N1UfkLkZ2ZeefW"
+			"DW1tnW69+1SjAKjchXgVHvYwOLiwsMDG1q5D5y4GhoafcsTrly48CAxULOFwuRZWVnUbNCwbOpCd"
+			"ldXcww3AnEWLc3NyAMxa+BuTCfmfDeuzMzMB6Ojp/frb76RQWFKyeunvAEzMzKbNmfspolbMrWtX"
+			"gu7eBdB38BAylAng0rmzT0IekOWfZ/9qam5Olnf/syUlKQnAnN9+V3kXHd63Z8XC+QBOXLrq1ar1"
+			"5xP7ixEZ8fLEoYNKhabm5rXd3Zu3asNoPJ8JkozQ1b3O6Ws3P+uBVMLlvFNXMjPSyULQPX8Pe3n/"
+			"KikpIQsJcbEOjo4ARk2cdOrofy9fPC8sKDA1N5+35L0n0ssXzzesWul/6yYZKCfxMWTEOT01ldSx"
+			"trUtTx4ysgxgWN9eSrE1CXFxzFZLaxXdv2KIEgmAuauZEqI0K3LF9/z2TRuJjybT06uQF/xT+EJ6"
+			"pEQi+XPJb4yOnBAfV/b5fvzQgSXzfmV8ZgF06tbj3/0Hy/5xn4nd/2694nueLBsYGvYfMpQYwBUR"
+			"i8Vnjh3ZtGZ1SnISgOatWn9JPTIq8hVjtAdgbWs7Ydp0xQpZGRmjB/Vn3qMAnFxc9h0/7Viz5tcS"
+			"CcDJ/w4tmj1TJBSSVU1NrfX/bu/Vf0B1yfDBCycSCgd16yyVShULvbt03Xf8VLUIUJnbm2HpvF+v"
+			"XvAF4ObhWY165AcvRIlAMHHE0Ls3bzAlOjo6m3bv7dStR3XJcPnc2X07tjGr3Xr3UdLUs7Oyxg8d"
+			"/PRhCFOib2Cwde+Bdh19qkWASl6Igvz/sXfmcTVmfxz/3KV916qiRJsSEaUFKdnG2I2xM/axjiFj"
+			"GIOx88NgMIMxRhJCCEXWKNmivShZWqVUt/Uuvz9OPa5KWu69xZz3qz+e55zTfT7POc/yfc75nu95"
+			"t+/37Qf3/FFUxDNq1VqyduQnG0IgECyZM/ukrw+Toqauvv3P/Z79BjT4oOGhoeI1L45xa5P123/v"
+			"0duDSbkXdoekZ6Sn+/x9AEDvvv3c3HsD4PP52zeuZ27VmfMWkDdZXEw0+f1Bw4Y3WGRdKOIVkQMp"
+			"q6gwdqTP3wcY1zSXXr1IRQmFwm3r1/J4PB09PdKxVB1tbR0Sn0+58il9YM9uACZt2jSmtpuQ1JTk"
+			"jzW0iqrqwqXLqj9+JQgJRlgo5WCEdYGxKdu0bTtwyLAquUbGrchGVmbGi+cpZDs3J+dZYgJzUYVe"
+			"vzZx5DB+eXkrE9PFy39x6+0xZvBXcdFRJJex22oxyJge7uGjv22hoyuepaunx1iW1a0ICbJj4/r/"
+			"rV8LoLtbjzmLFptbWXWzMpfe4T6GjPwjw0NvkYc7eXHeuHKZzMlniHxw/6cF80pLSlqZmC5YuszB"
+			"yQlA8IXzOzZtkI1CHo8XEnSJUfguL+96yAefXEKh8Kz/SU/HLkvmfk+MSNlz1v8kAGVlFecePQGc"
+			"OXG8SoE5300iRuSgYcPJpLbkpKTpY0fzP+yKk6WkuJjonxbOLy8rs7axnbvYW1tHp6SkeNHsGWmv"
+			"XkpEwCcbDkBK8jNiRLa1sLC27UD+unV3logA1OHyFi9JjEiJ88mG2PW/LcSI9OjXf8a8BUpKyjwe"
+			"b8H0qWT4RkIaTgBwcnUj/SIB1TQsnjOLGJHDRn87fe58RUWl/HfvZk8c97Hqqi+fbAgej/fHtq3O"
+			"Hax3bd1cVCSxExfn0w2xZRMxIu0dus5a8IOqmlpBfv7sSRNepj5v/NEnzZj5p4/vroP/rN60lQx4"
+			"vXqROmX0yLiYaKbM3duhABydXRi3/Zgnj8nGs6REYkSStyDzX8x4WTfnj34gSQRHlwpJ0ZWSAJC3"
+			"e4WkqIo3fWpKCrl0PxaQBcCQUd9cCg27FBrGWA+rf/Je/ZO33+HD0pEvO7q79fjTx3fvYZ8NO3aO"
+			"/26qgqIir7Dwt+XLyIfBF4+egQEx9VTV1BcuXVbljxn8XbHoh4L8fHUNDTNzc4FAsGTu98y85m0b"
+			"1vLLyzkczomLQYNHjmqhrS3++8TVEsDzZ88+pkG/cpzBs//AKgLGTZlqYGRErtjnycnMv8RFR10L"
+			"Dnp0/x4z87oxFBXxdm7dDMDcysrnzDnXXu5KSsqN/9kGICM7kjxMVdXUFiz9CQCfz7949ox4AZ+/"
+			"D5I3/a6DhxYuXfa3nz+x4oMCz8lGYdC5s6QrdM6PizW1tFD5PmDIysxYOHNayrNnAEgB2UNezE5u"
+			"bn0GDAQQ/TgyRewqj3xwP+zWTQDuXn13Hfxnw46doydMApAYHxcSdLFJJAE4sHsXv7ycKyf376mA"
+			"H39esXLD5hba2satWt0LC5OIgE82HIDnyRWSzly+Rt4rl0LDZs5fKBEBqMPlTeDz+SuX/IiaxiYa"
+			"zycbgkjSMzD484jvstW/jZ08BQCvsDAxLlYiAtJevSTeSx59+7n2dAdw/vQp8T7gtFcvQy5dBNCr"
+			"j9e2vX/9vGbtxOkzAPB4vNs3rktEwycb4vrl4I2rVhbk5ysoKkrpmVt7Q/DLy//c9TsAbV1dn4Dz"
+			"S39dvXbrdgClJSUH99Tcz1QvbDt26jtw0KBhwydOn/Gnjy+5yMvLynwO7mfKRITdAdDN2bkbY7Q9"
+			"jiQb8dHRADS1tIxbmwCIi66wIxlDk7HzpIS+QUsyIslIysxIJ4PvpG+bMW3fS3J2FQgEsVFPYqOe"
+			"vEx9zissPO137ELAmdKSkpw3b0g6sTgZazg//11s1BPxb4yXqc8DThw/cnB/yKWLUvrAkCxGxq36"
+			"DhzU/+vB306c/NvW7X/+W+F4V6W3svbzEolEj+5FHD9y+MjB/VcuXaj+SZmdmRlw8sTRQwcjH9yX"
+			"3rk0AFU1NRJVMSryUVZGBklcOn/uNwP7TRk98tWLVADnT58iUXVGjhk3efosAHHRUXt2bCOF01+n"
+			"AZCTk9fV0wcgFApLS9+PhdrZ25Oe+Evnz5JuI5FIdPq4n7gG117uZIN5vUZFPhrSp/fYIYP+2LZV"
+			"RUWFdFU8fnCfTMcRCoWL58yeNGr4EE93iXRFvX3zhnz1GbQ0JCPaxcVFjf/ZBiALO7KstDTo/FkA"
+			"Lj162dh1JMGZqrzsZ81f6Bd4ye/8xY6duwBQUVUlHdelJaUyUAjg7KmTADS1tOzsO5MhnsuBgSUl"
+			"75c/Mmhp+O2EiQOHDL1w8/awb76VjSpxHj98QLro3dx79+ztSRLP+b8fmb0ZcoVsDB89hmyMGDOW"
+			"bFy/LBV3lk9KQuU91qFjJ9Lug0eMfPQs9dr9yMEjR0lEwycbDpXflNo6OowTmASpy+VNOHro7/jY"
+			"mF6efciTS4LUpSGuhN9/nltw/cFjMhzDPDRbaOtIRAPjourm3ruHhweA9LTX9yvd2gCoqWucuXLN"
+			"7/zF37b8j6QwToHi3iwNpi4N0f/rwR07d5k2Z15oZLSpFJw9PtkQD+/fI2Hh+g8aTFxiBg4Zqqio"
+			"BOD6leAafrFxuPfxIhtkiiuAwoICYk51c3ZtaWjU2rQNxGyy2OgoACZtzIgnDDPMF/34MQBNLS0L"
+			"K2uJi6yCo4sbSNTojAyIdUD29OzzoaQKQ7ObiwuvsLC/m3N/N+cFM6Z6OnVdMGPqrInjnqcknznh"
+			"R9KjHj0E0N+tYggiPPRWfzfnyxcDAZSUFM+f/p1rR9t506b8/MOCKaNHOttakw+ez4ielZ4hTEN/"
+			"8rxePE8Z0MNlSJ/ei+fM/vmHBd+NHuVsayU+z/ffA/tdOtrMmzr5pwXzBnv0Gt7Ps6zS4aE5sPCn"
+			"n1ksFr+8fNKo4cePHF4y93vff/4Ovx2qpKRk3Nok9+3bX5YsIiXHT50+/NsxZJDk980bnyUmArDp"
+			"YAegpKR46phv1q9cMci9R3JSEgDy6SuvoEDCAxXk5/d37T5tzOge9nZ/7vxgvnZPD08ycPrv/r+2"
+			"/Lb68P6/po8b8+hexP3wcPImWrziVzabLRQKxwz5auOqlWOHDCKjhYNHjJRIqHADQyPi4B56/drP"
+			"PyxY6f3j1+49SVYVJy5pIws78ua1kHd5eQDcenuwWCzyeA0PvZWZkc6UMTM3d3JxdXJ1I53V/seO"
+			"ElOgfQfprj5JyMvNvXU1BIBrL3c2m03uyaIi3uULF8SLrdmy7Y9D/4rHo5cl5yrfiD3cPdpaWJAg"
+			"BWdOvh81e5pYEUrA2saWbFhatycbSfFxTSIpJzv7bU4OAENj41cvUg/v/+uv3TvDbt2UlBdwHRvu"
+			"WVISABOztqf9jq1Y/MOWtWvIB6JEqMvlTaRuXbsawLzFSyXuBP3JhiCwWCwVFZWiIl7AyRMnfHwA"
+			"2Nh1bG1qKhENxGLT0dOzsrFl/B3Fh7bV1NXtHbo6ubq1MjEFUFJSzPgItreza7yAujQEm80OCLm+"
+			"/Ld1kp3pxfDpmzSh4sKzqrxJ5eTl27RrB+B5cnK5pN/TjHNYC52Kr4X7d8OFQqGOnh4JlUy6TFKe"
+			"PeMVFgKIj4kGYNq2LTGySeefQCCIj4kB0K27C+M3Jj26OVdYe8RSJBr0DVq2t+0A4HlyMul0Idaw"
+			"hqYm85QDcD88PO3VSycXV6NWrUmXqjhTZs4mG61N20yZOdvc0grAqqXeZ477AVj662r/S1ccnJxy"
+			"376dNWk8sSo+FxinCO3Kz8JPnteCGVNjo55wudwtf+z92++kuoZGXm6u99yKKrp94/ryRQtKS0q0"
+			"WrSYNmfeiG/HPnn0SCLfe5Kip4fnH4f+NTRuFfPk8eI5s/3+/UdJSXnm/IXb9+0H8NvPP5HpYj16"
+			"e7Rp21ZFVZX0qpSVli6ZNxvA8rXryYvyWnDQ3h3bCvLfkXm9vMJC4hsze+GiuT8ukZOXz8vNDb5w"
+			"Pi/37bgpU8UFsFisg8dOEkf/nVs2rfhxYdqrl7YdOx07f4H0nTs4Of17KqCdpWVWRsYf27beuXlD"
+			"XkFh8sxZW//YJ5Ea4HK52/b+pa2jIxKJjhzcf2jfXjNzc2JZpiQ/lcgh6qpEBsdg3iXuffoA6NXH"
+			"66Svj1AovHDmzOSZs6qXv3PzxopFPwBgs9nTvpei1zBD4JlTxIOQRC7t5VHxFjx3yl/cr1wGz9CP"
+			"QbwzARi1at3O0hKAex+vIwf3P0tMjIuJJvcDGf0BwKwNpa6hQb6HcnPfNokk5hWeGB/n3rVzWeV8"
+			"OicX179P+JPgXo2hjg33/NlTAA8j7jIzPPZs/9+uA4f6fz24kQJQ58t767o1ebm5zj16dnF0LMiX"
+			"gHMMQ10aQhwb45ZCoZDD4Xw1dNgv6zdK5KpOTkoib/1eHn1YLJZxa5O2FhbPEhMvnj2zatOW6iFX"
+			"ysvKvp80kbzSenp4SuTrvI4NIb27uF43qZ6+HvOP5NEvFArz373T1tWt4afrz9ucnLBbN8kkawBf"
+			"Da2Yi0CcIxnnYCc3t5O+PiKRKDY6qqtTd9If2aZtO01NLQDx0dFCoTDl6VNiunWT8qA2oXvlxOqY"
+			"J4979+0XVyGpwrQVCoXxMTH2Dl2JA2VXJ2fxqbJcObm/jvj27tuvvKysepyKlRs2kWFfJuZLTnY2"
+			"iTXdu2+/WQt+ALB55x73rvalJSV7f9++aeduGZxvI+HxeLFRT1YtXUJ2SUN/8rx4hYVdujm1Nbc0"
+			"adOGhCT0GvDVSV+flGfPsjMzdfX1d23dTH7wn5OnySDh1DlzB7n3kPinTo18N+v772Z9XyVx5YZN"
+			"VSZUDRg8pN+gr58nJ2dlpKuqqZlbWjFxrLbu2bd1zwfm2upNW5k1YACYtGlzMTQs5enTrMwMbR3d"
+			"dpaWZaWlZMY3mZXFYrF+XP7LzPkLkxLiWSxWe9sOHC6XxKCQV6i4tDQ0NXceOLT2fzueJSaU8/nG"
+			"rVszjpUE117uIXcfvEx9np6WJi8vb2FtLf7W++voMfHCfoGXPnnKVWrG3avv3djEhLhYHo/XysTE"
+			"0MiYx+OJRyaJfpEG6SP1/sji4qIrFy8CsLCyJh+IPXp7kDs/oFp/CYDLFwMnjxpBOiPXbPkf6TeW"
+			"NmRIjsVi9e7TF4Cuvj7pdLwafEl8RaMm5F54GLHJPPr1Iym9+lTt8mGsNPE3JenMLy76YJxXZpKY"
+			"79ek+Pi25hbf//AjGUcLvx26fcP6qr9Yf+rYcMRBTVVNbeWGTXN/XMJms/nl5Uvnz2m8I1QdL++E"
+			"uFifgwcA/LRqTSOPWJ26NIQ4ZMhDIBBEPnjw6N49iWg4d6qiH86jX3+y4e7pBSDnzRuyjIQ4xcVF"
+			"k78ZceXSBQAWVtY7/jrYeAH1fc5IgzrdpMxrWOwmVVWtiO7RePemH2fPNNFUNdFUtW9rMnvS+Lc5"
+			"ORwO54effmamJ0eE3Qbg5FJhq3XrXmEaxkVHv83JIUPJFlbWVjY2RM/z5GTGJbGWGS0SxLi1CVk1"
+			"jhyX+GhaWFu3M7cgHyRx0VFvsrJIb1MVf013T6/effsBqGOws4iwOwKBAGIhAM3MzYmDJuMm1Dw5"
+			"6etDGrq9kf6Ifn3IgGmf/gN/XPEL6nBeKqqqP69Zu3nXHzPmzr8fHn5o396ESj/pN9lZ5WVlxNe5"
+			"rYUFMSIBWNvYKja/aKNsNtusXTsnVzfbjp3qGwyVxWKZmZs7ubqZW1mxWCwFRUV1DQ11DQ3x715V"
+			"NTV7h66dujjIKyhwOBxSgDiiMKhraNh37datu3MVI5KhlYlpt+7Onbo4NL7rpDpy8vK2HTs5OruQ"
+			"o6uoqBCREj9QLUi9P/LyhQvkbc2VkyPh3QFoamm9zcl5dP/ei+cpxLAghFy6OHPCOH55ubKyytY9"
+			"+yQe161GMjPSw0NvAVBTVz984C+SSLxWy8vKLp4LIGsNNS3MeygzLZ1UY1GlT/RZ/5PeK1exWCyl"
+			"ytgWPF4hcxkRc0pNoiH66i6JubFNzcwCrlxTUFQcNW5Cry4dRSLRhYAzy1b/1hgBdW+4W5FRr168"
+			"YHM4xOsrNSX5rP/JvNzcu6GhTOTYhlHHy/tX78UCgeCrocOYeaMSpC4NIV7+0u3whxF3t/y2+tWL"
+			"1FkTxx2/EMS8bBoMM3R7PzyMvJAYR/KzJ0+Ih/UpLSmZPGoEmRDW08Nz18F/JPLIq9dzRkrUpSGU"
+			"lSsm9xQVvv+Gya/sn1ZVU2+kBq0WLZRVVDMz0sm81AlTp02ZNYcJ+1VaUhL54AGArt0rWtykTRuD"
+			"loYZ6Wlx0VHtKme5mltZaVfGMYmPiU6IjQGgoqIiM5ceR1fXM8f94qKjysvKniUlAjC3tCYOAEnx"
+			"8XEx0UxrdvvQtK1vZzMT5G/Hxg1/bKvorCKtlp72usZOzWaCsrKKlrZ2Xu5b4pDQ3a3Hop9XMDdy"
+			"Xc7rTVbWtg3rzpzwIw674qEHc9++Jf2OTAAdCqUWpG5HMg5DZN5cldzzp08Rb1YAyUlJc7+bxC8v"
+			"N2rV+tAJfxk4dDMaiL9a/rt32yvfQO9zT/k3uR3JLy9npp0GBZ6rMof99csXkffv2XftpqtbMVKW"
+			"l5tLPuiZ4AKMd5SMJWlWhrm279qN2JSmZmatTU1TU1IaH/en7g2noKjIRIIA0MmhKxl/zEhvbJ9/"
+			"XS7v/HfvSPS786dPnT99ismNi44y0VRNzWtUMLY6NoR4orWNrbWNrUFLwymjRwqFwuNH/m2kHRkb"
+			"9YRxuiLx+cQJCjxXVlrKTFFf6b2YGJEz5y/0XrmqSvzeBlP354yUqGNDMDG0xScLE7dOrpycmnpj"
+			"7ciff1s3csw4n78PLFs4H8Dd27eX/vq+C/zR/Xv88nI1dXUrMW8HRxeXgJMn4mKiiaOhnLy8Wdt2"
+			"XDk5bV3dnOzshLhYMtjt4NS9Sjxz6eHo7HLmuN/z5OToJ49Jv5qljQ0AS+v2SfHxibGxrU1MASgr"
+			"qzRyrQoOt+KMuvfowXS8Mch4skK9GDB4yNY9++Kio7726FVWWvrk4QPxi+eT55WZkf61e8+M9DRl"
+			"ZZWfVq0ZMHjI33v3MHO96xI9kUJhkK4dWZCff+1KMABtXd3vf/iRSS8uKtq8ZhWAM8f9yPNdJBIt"
+			"mDGVx+O10Nb2O3+BeOLLBuYNtGjZchWxfru9O7ZlZWTcunY1JztbUk5LDSP0xnUyW6WLo6N4zNX4"
+			"6OjjPv8COH3Cz75rN+vKOUkJMTHEGYusHAWAuKjLXlJLQyMVVVVeYWHay/dWI5mD3/hVTOrYcInx"
+			"cUHnzr7Ly+s3aDBxk2BCiFUZnqgvdby82Ww2mW/BkPbqpUgk4srJ6Ru0bIwA1LkhSkqKjx76m1dQ"
+			"oKOnRwKLMldLbk5OIzUwc6KHjx5j0/F9l9WlswERYXcKCwpCgi4RV9SrQZd8//kbwLQ58yQ4xF/3"
+			"54z0qGNDMHcic2+WlZamPH0KwNK6vaQMtbGTv7sREhJ0/mxCXOzcqZP/8jlGfplEIO/a/QOfwm7O"
+			"LgEnTyTExDzrmADA3NKKxFxrb9vh1rWrzxITyMiy48dD60scR2dXAEKh8NK5sySF1Ju1bYfzp089"
+			"TUokN5SDk1PDVjvk8So+3pilhqxtbBcuXdZ45TLG2rbDslW//bp0MY/Hm/LNyHNXb5BX1SfP69/9"
+			"f5Gv6I07d1dfEkJLW1tBUbG0pCTl49ETKRQG6dqRF88FkO5xD69+VdxmT/n5PktMTIiLTYqPN7ey"
+			"uhp06fHDBwC+nTiZxWKR+E8A2Gy2oTS71l88T3l0/x6AViam85YsFc9KTko6cnC/UCgMDDgzYeo0"
+			"6Wn4JGdPVsQNGTv5OyamD4DszEzyiroQcGbl+k2e/fqv/slbJBIdPXRw0PARHA7nSOVob5+BEluz"
+			"pF6SOByOex+v86dP3QsPe5qQ0M7S8vaN6+T51cWxUZ6vdW84fnn5lrVrALx+9ZLYkczaGOJGTwOo"
+			"++V9J+qDGI22rQ0L8vPNLa0uhTY2iGYdG0JeXmH7hnXv8vKUlVU8+w3Q1dcnnYIAWhrVe9kucUQi"
+			"EWNH/rh8hfjdqqdvQEIVnjt1ktiRZOkFNXX1MZOmMPc4AE2tFo35rqh7QzT4EJ+kjg1hZWNr3Nrk"
+			"1YvUi2fPLFmxUltX96SvD3EH9xogyUUyN+3c/eThg/S01yGXLm5ctZL4kIR/OMmG0N21B4CiIt7V"
+			"4GBUxkMBYGVje+va1Uf375Ohg24ycY4ktLWw0NHTe5OVRfrvjVubkM428nn8JiuLhKdpwFICXC6X"
+			"z+e/TE0ViUQsFsvBqTsxmK4GXVryy68sFquoiDd51AgARsatNu/eI7Mu2AYzacbMm9dCrgZ9LYpf"
+			"AAAgAElEQVRdev3yxfTx3x47e0FOXv6T55X++jX5d2bkurj4vQ89l8t1cnG9EXLl1YvUK5cuEOfa"
+			"4Avnec1gJRtKM0S682zOV4aUq+6F1turwhU9wP8EgNPHKyYu7f7fFhc7G+bPy9lRugorxxndvbyq"
+			"KazQfFZWfvo1UlZaSsbIWCwWMx+ZoKuvT+ILZGdmhofeam3ahgQev3vn9gA350HuPQJOngDQ08Oz"
+			"lmX6pCoJwJxFi7lcrlAoHOzZ69uvB07+ZgQANpvdyP6hujdc+w52ZPLHhYAzY4cMGtnf6/qVywB6"
+			"eng20nei7pe3lKh7Q7DZ7EkzZgEoKuL1dXUa2d9ryZzZANhs9qhxExqjIfL+vdcvXwCwsLKu8snX"
+			"08OTvIavXLrI4/GeJSaS2QAF+fnuDp3Eb3O/I41aX+QzaggWi7VkxUoA7/Ly+rl1Hztk0PJFC0mx"
+			"yZVRaSSCppbWjv0HSb/jvt+3+/37D5/PfxgRAaDK08DM3Jws5kEse6ajmhiUJFFBUbFTteFRqUJ8"
+			"LcjRmU5cJj4USXes/5LZHbt0AfDiecqE4UNmjB+joak57fu5AOJjY+ZMmXj8yOFJI4aFh94KD71l"
+			"37Vb8zciAbBYrC2795I4VvfDwxfPnQ3gk+fF1OTS+XO2/LZ68jcjyEABKkfz5y72JhfPjHFjJo4c"
+			"Ntij17Qxo5vzQD+lCZGiHZmTnX3r2lUAXC6XhOUUx7NyXid52UtqdZP6cqYyQj2Z8CuOS69exKXv"
+			"/t1wSS3i1wBCgi4RP2g7+87Vh9eZ6bHEZFyzeeu4KVO5XG58bMyTRw9ZLNbAIUN3/y3hRcDqJcna"
+			"tsOfR3wNjYwLCwru3LxRWlJiaGS878jRRvrk1avhdvx5YMiob1gsVuj1axFhd1gsVv+vB+88cKgx"
+			"Aup1eUuJejXE/CVLZy34QUFRMSc7OyLsDp/PNzQy3vuvT5UlsOvL6RMVDVHdhlPX0CCtXFpSEnz+"
+			"3L3wO4050Mf47Bpi8MhRa/+3XU1dPSsjI/T6NYFA0KGT/dGA80xUdknh6Owy58eKcDDLfljwIOJu"
+			"URFPUVGpik8hi8USH7NmjDZrsdi99l0cZDzjhPSSVlHS0tCIWUtMXkGhY/1nrS1fs45EWbp5NSTi"
+			"zm0+n//DsuULly5TUVE5f/rU4jmz7965rW/QcuuefeO/m/rJX2smaOvobNv7F3FqPO13jEysqf28"
+			"xk6eQoYIEuPjdm7ZdC/sDrMCOxnL7urUffffh7V1dPh8/vXLwdGPI0dPmNR4/12ZoPpf+msWsBrg"
+			"SPviXXNfNsrk192pv1aNPtXckJ7Id3l5TxMShCKhaRszJpZkA5CgQoFAkJyUlPMmW0dXz8zcvO6z"
+			"KySoIS83l6xkwARrlbGABiNBDcXFRYlxccVFRXr6BqZt2zZJQzSMJhcgWQ1lpaXxsTFFPJ6BoZGp"
+			"mZkMNLzJynqamKCkrFx94oWkaA5t9ElKSopjnzyRV1BoZ2nJeEiXlZYmJcQX5Ofr6um3addOUtO/"
+			"xGmSyqn9vDIz0p8nJyspKVm1t2FzOGRCt4KCAhNng19enhgfV8QramdpqamlVZCfLxKJOBwOCScn"
+			"KSRdM83FupIJkvE0aK3RqIBEsohDTpExGpqaXRyl6w9QXzgcjrmVlTmk6KD2STS1tJpbtcgeJSUp"
+			"mhGUuiOvoCCNIFC1oKOnx8wW/y+jqKjUuVvV54C8gkJTLVQmVWo/L32DluJT/apH4OLKybXv8H6t"
+			"qc+kP7Ih/HsAG1cBwO9/ofdHYsHNm4arQQAQFo1GR+j6oqB2JIVCoVAolP8uZWUoyAeAcv5HyxTz"
+			"KsrQaEhVkMX62hQKhUKhUCiULw/aH0mhUCgUCuWLIucNIu4gOxNq6rDuAKv2H+QKhYgIQ3ISNDTh"
+			"2qvmXygqwu0byM6EoTFcelTNTU5CSQnYHJhb4mYIsrPRuw909ACgrBQRYXjxHHLysO+CdpYf/KNA"
+			"gMcPkJIMXgF09dGtO7Q/nJtXVIR7YUh/DYEARq3g5IrmtyDlB1A7kkKhUCgUypfDnu3Yshb88vcp"
+			"g4Zhx18goZyyMzFtLB7dr8hSVoalTdVfeHAXMyciK6Ni19AYlWtyVTB7MuKioa0Da1uEXgeA1Zsw"
+			"cTpuXcPCmcjOfF+y/9fYugdk3eLHDzH3O6SmvM/lymHmPPy4HGQVoeM+WP1TxQA6QasF1m3DgMEN"
+			"qwlZQMe1KRQKhUKhfCHcuoYNv4JfDtdeOHkJo8YCwLlTOF+5Ku3sSRVGZE8PfP8DWpvi0b0PfiHn"
+			"DaaMRlYGOBx8Mx5TZqKsDCk1Le6T8wah12FpjQ6dYNwaz5MxbQyyM2Fjh6MBWLcNbDYunsWvSwCA"
+			"z8f0sUhNgVV7BN3BwyT8ugH8chzej8sXASAxHt5zUZCPIaNwJwq3n2DkGOTlYtVSNHoRXylC7UgK"
+			"hUKhUChfCEVFmDAVg4Zh/XZ0dcJ874r0u3cAICIMEWEA4O6Fw/5Y8gsu3MKQUR/8gs9B5OUCgPdK"
+			"bNqJlRtwNaLq8DTD3B8RdAfnr6NHb/y9D2RhoA074NITYydj0DAAOHEUaa+QmY6MdABobQqr9tDW"
+			"xeSZSMpEVCq8BgDAk0cgsd7t7GHUCsatsXEnnmbjbhxaNmrdMelC7UgKhUKhUChfCH0HYs0W7DoI"
+			"OXmcOwWfipV68CYLAO5ULIuL4aMrNjgc2H24GsPtm1XLaGjCrG0Nx1JVez8kLSePsJsAoKgI28po"
+			"S+59AEAkwq1r0DeAtg4ABF/AUC8c2ofUFMiLDZe3t63Y+O1nzJqIM8eR/w4NWkNepjR7gRQKhUKh"
+			"UCh15kIA9mzHk0cAwCxvSeL1ZFa6PBoZf/TfiVuknHzFvJlaIBYkQ3YWAJSWws60IkVQGUgoNQVc"
+			"Oew5jO8nIzsTDyPwMAIrvWFhhXFTMGEaWCy074BfN2D9rygtwYUAXAgAm41uzpizCG7udTvzpoDa"
+			"kRQKhUKhUL4QdmzE/9YDQHc3zFkEcyt0E1sBg7H8agsDyfpUgY/A4QKAoiK+m101y94BABydcecJ"
+			"7tzClYsIvY6UZ0iMxy9L8OYNFi0DgMkzMWw0Qi7h2mXcvoGcNwgPxd3bOHL6o/PKmxxqR1IoFAqF"
+			"QvkSKCrCzq0AYG4FnzPgcJD/7oMCLY0qNlKS0eUjC5wZGiE5CfxyvH4Jo1b1OLpBS2RnoqQEsxZ8"
+			"NFiPvAJ6eaKXJwAEncfMCRAK4Xe4wo4EoKGJYaMxbDTKy7B1HfZsh0iE4z7N146k/pEUCoVCoVC+"
+			"BN6+QXkZABi0rBjRJhNfGFx7VmwcOVhRkleI4MAPyrhUlvl7b8VGyjM8evDpoxNTTyTCteCKFJ+/"
+			"MaIfJo5AyCXwy/EyFY/uvZ983fcraGkDAFcOAIqKkJyEiDAUFQGAnDxGfFtRUq4Zd/o1Y2kUCoVC"
+			"oVAodcbAEFotkPsWodfx8w/gyuHS2YosMhXavit69MbNq3h0D326w8wcD+5WzM5mGDsZB/bgTRb+"
+			"2o0H96CigrDQD6JRfozJM+H3L97mYNlCZKYj/x12/Q+lJTA1g6ML3uVhSB+8yYJxa/z4M3T1EXQe"
+			"OdkA8O1EAHj8AGMGQyhEdzdM/R4cNvb+DgBsNkaNl1wdSRraH0mhUCgUCuVLgMvFtr3Q1oFIhCMH"
+			"cWgfzMyh1QIAUpIryvxxqCLOTsozhFyCplbVKN8amjgaULEEzsMI3LqGrk4VDo61o2+AY+fRqQve"
+			"5mClN7auQ1kp+g3CiQtQVYO2LvzOwckVr15gwQyMHYLD+6Gti59WYc4iAOjuhr+Ook1bhN3Cd6Mx"
+			"aRTCQ2FuhQO+cHSWXB1JGtofSaFQKBQK5QvB3Qt3Y5EQBx4PrUxgaAQe7/28aQBq6vjrKDIz8PI5"
+			"1DRgYYXyMmz8HQCUlSvKWFoj6A6SnyI7C61aw9AYRUUVXZJq6gBwKbTmo1taIyAE6Wl49QIcNtpa"
+			"QEPzfW47S/idR14uXjxHEQ96+jAxez+jHIBnP3j2qwg2yRfAyBiGH59X3kygdiSFQqFQKJQvBzn5"
+			"9xEcgYo1CaugbwB9g4pteYUP4jgymLWDWbuKbcbErAstDWuLHK6pBU2t2v7d8HMwHxmoHUmhUCgU"
+			"CoXSrDHRrJ6mWpd/TM0rlLSWD6D+kRQKhUKhUCiUhkDtSAqFQqFQKBRKQ6Dj2hQKhUKhUCjNmtS8"
+			"6mnSHbCuI9SOpFAoFAqF8mXQLEyr/xR0XJtCoVAoFAqF0hBofySFQqFQKJTPGIFAwCssBKCgoKDw"
+			"sZWtP1vKy8oyM9IBGLc2aWotNUDtSAqFQqFQKJ8xCbEx/d2cASxYumzh0mU1lpk3bcrVoEsAwqLj"
+			"1dTVZaqvGvt+356RliaeoqCo2MrExMGpu6V1+yqFL1+8MGviuNambTz79QfQQlt77mJvklVYULB1"
+			"7RqybdOx44hvx5LtxPg430N/A+ji6PTV0GFSPRdqR1IoFAqFQvmMUVRUsrbtAEBXT4+kHNizG4BJ"
+			"mzae/QaQlGJeUUF+PgCRSCRVMRcCzqSnvZaXVxj/3dSPlTl93C8uOqrGrG7dnbf8sc+kTRsm5e6d"
+			"UACOzi7XQy4nJyVxOJxpc+cpKioBiI2OOrj3D1LMtmMnxo68FhxE0ttaWEjotD4KtSMpFAqFQqF8"
+			"xpiZm18KDRNPWf2TNwCvAV8xdqTM+OfPveG3Q9XU1WuxIxnWb/9dW1e3mFeUkZ52/vSpqMhHEWF3"
+			"xg4ZdOXuPWIpArh7+zaAbi4uXDm55KQkgUAQHxPTqYsDgLioKABsNlsoFCbGx/H5fC6XCyAm6gn5"
+			"X0dnVymdJgO1IykUCoVCoTQjysvKkhLiAejq6evq6wPIyc4mPoKKikpm5uZVyqhpqCcnJTHlYyut"
+			"qPz8d7FRTwyNW2lqfbAQoVAofHTvXnxstJq6hmsv9xba2uK5aa9ePoiIyMvNVVVVte3YydzKisnK"
+			"SE97++YNADNzc8bOS3v1Mi83F4C5pdXrV694PB4AoUAQG/VEU0vL0LhVLWfao7cH4/U4bc68Ef29"
+			"HkbcfZn6/MrFi2Q8uiA/Pz4mGkC37i5yXDnff/4GEP04ssKOjIkG0KGT/eOHD8pKS1OePiVqY548"
+			"BtBCW7udpWX9q79+UDuSQqFQKBRK82JoH4+SkuLREyZt/H0XgO0b1x3e/xcAVTW1mJfpAB7evzdq"
+			"QF8AOw8camdhIe4fSbYBhIfe6u/mvOWPvSPHjGN++UbIle0b1z1NSCC7aurqvmcDO3SyB5D/7t3S"
+			"+XMCz5wWV+Lg5LR93/5WJqYA9u3YTsaLL966076DHSmwde1vJ319ANx+EuM9d3ZU5CMAPB6vv5vz"
+			"iG/Hbt2zr46nzOFwevT2eBhxF8CL5ykk8V7YHZFIpGdgYGpmJq8gTxJjnlQYymRw3NHFNT42prSk"
+			"JDY6ytzKqqiIR6zqrt1dWCxWHY/eYGjcHwqFQqFQKM0IOXn5Lo6OAIhNBrGB2sKCAmJjPXn0kKR0"
+			"d3Wr8u9TZs4mG61N20yZOdvc0ko8d86UiWkvX/X08CQdgQX5+ds2rCNZMyeMJUbkoGHD/zj077Tv"
+			"5wK4Hx4+ZvAg0sv4SQYMHmrQ0pCcwpSZs3v09qjXiTPmo7aODtmICLsDwNHZBYChkbFRq9YAoh9H"
+			"AhAKhQmxsQDM2rUzbWMGgPRcJsTECIVCAI4uLvU6esOgdiSFQqFQKJTmBbEOE2JjykpLhUJh7JMo"
+			"APZduwGIjYoC8PjBfQBm5uZk4FuclRs2kQ2r9jYrN2wiQ8AMXgO+uh0Ve9j/TNDtcCUlZVRaq+Gh"
+			"t27fuA7A3avvroP/DBwydPna9TPmLQDw4nnKaT/fusieOH2GqZkZAEVFxZUbNg0eOaou/yUUCtNe"
+			"v/pj29Yzx/0AKCkp9/bqR7LCb4cC6NbdRbxa4mNj+Hz+8+Tk4uIiAG3atjNt2w4AGdCPfsI4R1I7"
+			"kkKhUCgUyn8P117uAPh8flxMdMrTp8XFRTp6el2dugOIfvIYlcafS4+e9f3lrXv2EYdIVTW1ViYm"
+			"AIqLigCEXr9GCowaO54pPHr8RLJx/fLlxp1QzbjY2ZhoqrZpod7dxmrjqpVCoVBNXX3PP/8S47i4"
+			"uIicpqNrxXSZbs7OAIgrJOl9BGBuZW1lYwMgNjoKlb2SqmpqZA67tKH+kRQKhUKhUJoXHew7Kyur"
+			"FBXx4mOiVVTVAJhbWhFrKSEmhsfjPU9OBuDco1djjsLhvreCMjMyyAbpUCSYVG5nZ2U25kAfw6Cl"
+			"IZvNTnv9CgCHw/l1w+ZBw0dotWhBch/du8cvL9fQ1GSG5h1dKgbxY6OjniYmAGihra2to0OiTmZl"
+			"ZLzNyYmPjQbg4NSdw+FIQ3MVaH8khUKhUCiU5gWXy+3avTuAuJjohLhYABbW1sRaiouJToyNIcUc"
+			"XSQW14aZkkKcCwmiym0WWyr2kn/Q5bCY+K+HjwAgEAgeP3zAGJEA7t65DaCrkzO78uimZmZ6BgYA"
+			"4mOiE+NiAVi2twHARC9PiI2Ji46GrAa1Qe1ICoVCoVAozRAnVzcAcdHRZDaJtY1tO0tLDofz6kXq"
+			"owf3AVhYWTPzUWqExyus++FatW5NNpip3ADiKw1Wksv0X+a/e8eUEQgF1X+tqG7zcgjrtv1OJv2c"
+			"9PXZu2Mbk36PTLL5cLoMMRBjo6NSnj4F0N62A4A27dqRBSGvX7lMloh0kpyFXTvUjqRQKBQKhdLs"
+			"6O7WA0BCbExCbDSA9h3sSPBIkUh07pQ/ACe3qjO1GUg47pepqXVfvaZ334qpLf/s/1MgqDAN9/+x"
+			"i2x4DRwEgOksvH3zBoCSkuJ9v28/53/yg0PLyQEQCARpr17W8dBq6uo79x8kw9AbV628cukCAH55"
+			"+YO7dwF07e4sXpiY17FRT5KfPQXQ3s4OAIfDsbCyBnD+9CkAiopKJJKRDKB2JIVCoVAolGaHnX1n"
+			"VTW13Ldvnycnc7lcaxtbADZ2HQGQIIvObh+dZNOxSxcAL56nTBg+ZMb4MXU5nI1dxfrUDyPuDu/r"
+			"uW3Duokjh532OwbAycV1wOAhABycupPCv2/a0M3KvFMbk3W/LFdQUBD/HWZ6+NQxowf2dC0qqlPH"
+			"ZOdujgt/+hmAUCicO2VyXHRUVOSjkpJiZWWVKhYhMSuzMjLKy8pQ2R8JgMSzfPUiFUDnbt3k5OXr"
+			"ctzGQ+1ICoVCoVAozQ4Oh9Ot0snP3MpaXkEBgK1dR5LCYrFIh2WNLF+zjvQd3rwaEnHnNp/Pr8sR"
+			"N+36Y+5ibzV19Uf3723fsO765WAFRcXx3039+4Q/6Sx0dHaZMG068aTMzEhXVVdbs/l/A4cOF/+R"
+			"72bPISZvzJPH8THR4qPktTN74SLS11hUxJsyehSJ+GPftSuX+8GUaAsra2YBHi6Xy0zBaS82O7ub"
+			"rJwjQedrUygUCoVCaZ787XeySsq0OfOmzZlXJbF9B7vUvA9cITt3cwyPTYh98kReQaGdpSWXy/3r"
+			"6LHqv19lVW4Oh/PjzysWeP/0LCkxNydHTV29nYUl8TtkWLP5f3MWLX6enKzVokVbcwsOh1NcXLRi"
+			"7XoAqmpqAFpoa1+4dSc+JrqkuNjM3KLKkow1Hpc5ut/5i8xuclKSvUNX/ZaGVYqxWKxHz1Kr//uk"
+			"GTMnzZhZPV3aUDuSQqFQKBTKl4aiolLnbo4N+Ecul8tMf64RfYOW+gYtmV0lJWUlpQ8KsNlsZtXE"
+			"BmNmbk5WEm/m0HFtCoVCoVAoFEpDoHYkhUKhUCgUCqUhUDuSQqFQKBQKhdIQqB1JoVAoFAqFQmkI"
+			"1I6kUCgUCoVCoTQEakdSKBQKhUKhUBoCtSMpFAqFQqFQKA2B2pEUCoVCoVAolIZA7UgKhUKhUCgU"
+			"SkNgiUSi+v7Pi3d1WnSc8rlz61WGm7FBU6ugUCifB/SJQWkAt15ljLVp29QqKA2nIesittZQkbgO"
+			"SnPkFW1rCoVSZ+gTg9IAXjW1AErjoOPaFAqFQqFQKJSGQO1ICoVCoVAoFEpDoHYkhUKhUCgUCqUh"
+			"UDuSQqFQKBQKhdIQqB1JoVAoFAqFQmkIDZmvXQtCodDb21skEm3atInNrmqkvn79evPmza1bt/7h"
+			"hx8ke9x6cfny5cDAwAEDBnh5eVXPPXDgQFRU1PTp09u3by97bYTPoho/RkJCQkhISF5enpmZ2cCB"
+			"A9XU1JpEhlAoDAoKUlBQ6N27d5MIAPDq1auQkJBBgwa1aNHiP6hBJBKFhoZGREQIBIJOnTp5eHhw"
+			"OBwZaygpKbl48WJCQoKysrKbm5u9vb2MBQDIzs4ODAxMS0vT1dXt37+/sbGx7DV8AURGRubl5VVP"
+			"d3BwUFVVJdu1NPeGDRs2bNhw69atDh06yEixrMjLy4uMjKyerqOjY2trWyWxxgeCpqbmwIEDfXx8"
+			"pCv080EgEAQHBz9+/JjNZtvb23t4eFR5Eaempl6+fDktLU1fX9/d3d3CwoLJ+uqrr6KiolJTU2Wu"
+			"uukQSZoBAwYAuHnzZvWsLVu2AFixYoXED1ovIiIiAPTu3bt6VllZmZaWlpKSUkFBgeyFidMcqvFI"
+			"9NP6/ssvv/zCYrG0tLQ6d+7MYrFatmwZEREhDW21UF5efvjwYWtrawCDBw+W8dEJSUlJ06dPl5OT"
+			"A/Do0aP/oAYej0euYRMTE/KQdXR0fPPmjSw1JCUltWvXDoCdnZ2+vj6AadOmCYVCWWo4e/asmpqa"
+			"nJycg4ODioqKgoLC/v37ZSlAljTgiVF3evbsWeMrLDU1lRSovblXrlzZhDejVLl27VqNNTN58mTx"
+			"YrU8EJrwUSmS8mXTAHJycrp06QLA0tKSdCe5urqKmwRbtmzhcDhqamoODg66uroAFi1axOT27NlT"
+			"Q0OjKYQ3GZK3I48ePQpgzpw51bNcXFwAxMfHS/yg9cXCwoLNZmdmZlZJv3z5MoDRo0c3iSpxmkM1"
+			"1vf29vf3B9CrV6/CwkKRSHT79m0lJSVDQ0OyKxt8fX3NzMwAkPtf9g/H7OzsMWPGcDgcJSUlU1PT"
+			"Jnl1NQcNc+fOBbBkyRLyIt+2bZuMm0MgEHTs2JHNZp89e1YkEpWWlo4cORLAtm3bZKbhxYsXysrK"
+			"LVu2TEpKEolE6enplpaWbDb7/v37MtMgS6RqEKSnp6eIkZycrKenZ29vT3I/2dxfsB1ZXFyc8iFr"
+			"164FEBAQQAp88oFA7Uhx5s+fD2Dfvn1kd8OGDQDWrVtHdh88eADAzc2NWJalpaXDhg0DQC48EbUj"
+			"JQKPx1NRUTEyMqry3f/69WsWi+Xg4CDxIzaAVatWAfjzzz+rpM+YMQPA+fPnm0SVOM2hGut7ezs6"
+			"OrLZ7GfPnjEpy5cvF78hZcCePXs8PT2Dg4Nzc3Ob5OFYWlpqb2+/cuXK7Oxs8jyS/auryTXk5eXJ"
+			"y8u3bduWz+czia6urgASEhJko+HixYsAJk2axKTk5uaqqqoaGhrKrEvS29sbwKFDh5iUK1euAPj2"
+			"229lI0DGyNIguHPnDoDVq1eT3U82t7gdGR0dfeDAgaNHj2ZnZ8tMsCzx8vJSUVEpKioiu598IDCP"
+			"Sh6PFxAQsG/fvlu3bslMbXOzIw8cOODt7c08uzIyMgCMHDmS7G7evBmAr68vU55cikynD2NHCgSC"
+			"Gzdu7Nu3LyAgoLS0VLYnIVMkb0eKRKLx48cDCAsLE0/8/fffZdwZUAtPnz4F0LdvX/FEPp+vq6ur"
+			"o6NTVlbWVMLEafJqrNftnZOTA8DZ2Vk8MSYmBsDQoUMlLe3TNJUdKU5T2ZFNruHUqVMAli1bJp64"
+			"e/duADt27JCNhnnz5gEIDg4WTyR9VI8fP5aNBjs7Ozk5OfH+eKFQqKenp6WlJRsBMkaWBsGcOXMA"
+			"xMTEkN1PNjexI8+cOdOvXz8AioqKAFq0aEG6ir8kMjMz2Ww2Y/dU4WN25Ndff713714tLS1SMwDm"
+			"zZsnE73Nzo6swuPHj8XNROJXxvQ+iipfc3PnziW7xI68fv26lZUVl8vlcrkAHBwcvmBTUirztceO"
+			"HQvgxIkT4oknT55ks9mjR4+WxhHrS9u2bZ2cnEJCQt6+fcsk3rx5Mzs7e9SoUcSDpMlp/tUoTnx8"
+			"PIDOnTuLJ1pbWysrK8fFxTWRKErTQFq8ysXg4ODAZP13NFhaWqqovF8qkMVidenSJTc3NzMzUzYa"
+			"vkgEAoGfnx/jvoY6N/c333xjY2OTnZ3N4/HWrFnz9u3bPXv2yFC4LPDz8xMKhWSwte5cuHBh27Zt"
+			"x48fLyoqevXqlbGx8e7du8nX+H+ZgoKCJUuWiL9z+/Tpw2Kxzp07x5QhTmju7u5MSn5+/rBhwxYu"
+			"XFhYWJifnz9gwID79+8HBQXJWLzMkIod6enpqa+vT/okCFlZWaGhoZ6engYGBtI4YgMYN24cn88X"
+			"vxqI4HHjxjWdqA/4LKqRISsrC0AVYSwWS09PLzs7u4lEUZqGGi8GMvVBZhdDVlYWl8vV1tZuKg15"
+			"eXnl5eXVb1UZ18MXSUhISHZ2tripVMfm3rVr15YtW3R0dNhs9rRp0wAkJSXJSrWM8PX1lZeXHzhw"
+			"YL3+y8LC4u7du56eniwWy8jI6KuvvhIIBCkpKVIS+VkwcOBAY2PjtLQ0f39/Mi0BgJ2d3aFDh0JC"
+			"Qrp37z516tRevXr9+eefq1atGjp0KPOPcnJyN2/enD59uoKCgpKS0oQJE/AlXmkMUrEjORzO6NGj"
+			"nz9/TjxSAZw6dUooFJIONnHi4uICAgICAwMTExOrZBUUFISEhJw5c+bGjRtFRUUSFzlq1Cgul3vy"
+			"5EmyKxQK/f39zczMnJyc6i6jFv2N57OoxiqId70Q1NXV+Xy+tI9LaYZUuRjU1dUByPJiqPFq/A9q"
+			"+PI4duwYgOHDh4sn1qWqSQ8lgQS+yc/Pl55O2ZOamhoWFubl5VXfgGvm5uYaGhrM7hdZOfWlrKxM"
+			"Tk4uKSkpICBAvCoyMjIKCgqysrLevHmTm5tbWlpaUFAgEAiYAkpKSjY2NszuF1+ZEkx8lDkAACAA"
+			"SURBVI4fyTB27NgdO3b4+/uT+fOnT59WUlIS/3x8/fr18OHDk5OTe/XqJRKJQkJC7O3t/f39NTU1"
+			"AezcuXPp0qX29vZmZmaJiYlxcXG7d++WbE+hrq6ul5dXcHBwQUGBmpra3bt309PTV6xYwWKxmDK1"
+			"yKhdv6Ro/tXIQLxACgoKqqS/e/dOQUFBGkekNFtqvBjevXsHQGYXA5fLrfFqlJmGWu4ImWmokWPH"
+			"jhEvFABOTk7EX/AzorS01N/fv1WrVuSpSGhAczcT/yXJ4uvrC0C8b6xhfJGVU18uX75cVla2cePG"
+			"X375pbCwkPiY+fr6ent7T5w48eDBgySo5Pr165ctW6anp7d48eIaf+eLr0xprWfTtWtXCwsLMiab"
+			"m5t79erVwYMHM9FiAXh7excUFKSkpBw/fvzEiRPx8fGKiook7E5SUtK8efN2794dGhp6+PDh8PDw"
+			"devW+fv7l5WVSVbkuHHjysrKAgMDAZCYNeJdfbXLqEW/BPksqpFgaGgIgExtEyczM7MZjsJTpEqN"
+			"FwPxCJTZxUAm6lYZPpalBlVVVTU1tRrvCJlpqJFz585tr+TGjRtNJaPBBAYG5ufnjxgxQjyxyZu7"
+			"mXD06FEOhzNkyJCmFvKFIC8vv2LFis6dO/v7+5Mw+MRSX7duHROZ/Mcff1RRUTly5EhTCm1SpLgu"
+			"4tixYxMSEmJiYs6fP8/n86t0g2VnZ+vr6zMjEXp6eoGBgWR63Zs3bwCQKICE77///vTp0/Ly8pJV"
+			"OHjwYBUVFWJBnj592sHBwdLSksmtXUYt+iVL869GgqWlJZfLffTokXhiXFxcSUlJ9TUVKF82pMWr"
+			"XAwPHz5ksv47GpKSkgoLC5kUkUj06NEjQ0NDLS0t2Wiojo+PT14l69evbyoZDYYMalfpcmsOzd3k"
+			"xMbGRkVF9ezZswkX0PoisbKyElXGJCFfhuRTmSAnJ9eiRYv/8sw56dqRAE6dOuXv76+trV1lEcIJ"
+			"EyZcu3Zt/Pjx1Rd06tKli42NzdixY/fv3y/+CJY4ysrKw4YNu3jxYlhYWHJy8pgxY+ouoxb9kqX5"
+			"VyNBRUWlT58+4eHh4t7E5BNt8ODB0j46pVnRs2dPTU3NY8eOlZeXM4lHjhzhcDj1df9vMKRL5t9/"
+			"/2VScnNzAwMDra2tzc3NZaahvLzcz8+PSbly5UpmZia9IxpMYWHhuXPn9PX1mXkPhObQ3E0O6Sqr"
+			"4jZKqRdFRUW6urpt2rQR93eMi4tjs9lk6ZpWrVoBIKviEV6+fElmuMtebXNBqlGFnJycLCwsFBUV"
+			"Z82aVT03ODiYLHVlaWm5du3a9PR0Jis3N3fJkiU6OjqKioojR468cOGClBReunQJAFkIIS0trUpu"
+			"7TJq0S9Zmqoa6xvW686dO2Q10oSEhPLy8qNHj8rLy9vZ2ZWXl9frdyQCjR/ZtBo2btwIYMKECW/e"
+			"vMnPz1+yZAmA2bNny1JD//79AezYsaOkpOTFixfkG+z48eMyE5CXl2dgYKClpRUcHCwUCsPDw01N"
+			"TVVUVJKTk2WmQZbIIBDg4cOHAcyYMaN6Vu3NXeN6NgB69uwpbc0yw8zMjMVivX79upYytcchZyDV"
+			"de3aNWnorEJzix85ceJEAHPmzHn79m1ubu6KFSsADB8+nOQSm8HKyur27ds8Hu/evXtk8tbevXtJ"
+			"gerr2ZCFK1euXCnjE5EZ0rUjd+3aRazV27dvf6xMSkrKmjVrWrVqRYaYxbPKysrOnj07dOhQFovl"
+			"7u5eXFwscYV8Pp/EhujTp8/HytQuoxb9kqKpqrEBt/fJkyfJRxuhR48eL1++rO+PSARqRzatBqFQ"
+			"uHz5csaJgoRZkXEk3ry8PHFHMVVV1d27d8tSgEgkioqKsrOzYzSYmpreuHFDxhpkhgwMAjIrKCgo"
+			"qHpW7c39xduR4eHhALp37157MWpHfhIejzdu3DjxGbfDhg3Lzc1lChw+fJiYDQQNDY3169czuf9B"
+			"O5IlEonq2nUpTcrLywcPHvzgwYManQxCQ0Pd3Nz++OOPWbNmyV5bXWTUrl9mSLYafWKejbVp2wAN"
+			"kZGRhYWFpqambdq0qe+/U74k3r17Fx0dLRQKraysxD8wZMnr16+TkpIUFRU7duyopKTUJBpiY2Mz"
+			"MzNbtGjRoUMHxj3/y6NhTwzJ0hyam1IvmsNlU52cnJz4+HiRSGRhYaGnp1clVyAQJCYmZmZmamlp"
+			"WVtbS2nWweeCtOL+1Bc5ObnevXsHBQUJhcLqz1kXFxdVVVUS3LgJqUVG7fplRnOoRjk5ua5du0r1"
+			"EJTPBQ0NjSp+bLLHyMjIyMioaTW0b9+eWXmFIlWaQ3NTvgC0tbVreXZxOBxra2tra2tZSmq2NI3F"
+			"IxKJevfu3atXLzIBCsDz58/3798/evRoNpsdFBSkoqJy/PhxkiUUCjdv3lxaWlol0IO0qUVG7fpl"
+			"pvCzqEYKhUKhUChfLE01oP706VM3NzclJSVnZ2dHR0d1dfXvv/+ex+OR3E2bNmloaLRt27ZXr16t"
+			"WrWytbUNCQmRvchaZNSuX2ZItRqbm9sKhUJpztAnBqUB0Mvmc6eJ/SNzcnJSU1PZbLalpWUVXxY+"
+			"n5+SkpKbm6uvr29iYtJUCmuXUYt+WSKlamyebisUCqV5Qp8YlAZAL5vPnSb2j9TW1tbW1q4xi8vl"
+			"Noe4X7XLqEW/LGn+1UihUCgUCuXL44udOUihUCgUCoVCkSrUjqRQKBQKhUKhNARqR1IoFAqFQqFQ"
+			"GgK1IykUCoVCoVAoDaEh87V9Yp5JQwqFQqFQKBQKRZY0cr58c1kXkdIMoeEYKBRK3aFPDEoDoJfN"
+			"5w4d16ZQKBQKhUKhNARqR1IoFAqFQqFQGgK1IykUCoVCoVAoDYHakRQKhUKhUCiUhkDtSAqFQqFQ"
+			"KBRKQ6B2JIVCoVAoFAqlIXAl+3NCodDb21skEm3atInNrmqkvn79evPmza1bt/7hhx8ke9x6cfny"
+			"5cDAwAEDBnh5eVXPPXDgQFRU1PTp09u3by97bfhM6rAWEhISQkJC8vLyzMzMBg4cqKam1iQyhEJh"
+			"UFCQgoJC7969m0QAgFevXoWEhAwaNKhFixb/QQ0ikSg0NDQiIkIgEHTq1MnDw4PD4chYQ0lJycWL"
+			"FxMSEpSVld3c3Ozt7WUsgKE5XAyfNZGRkXl5edXTHRwcVFVVyXZxcfGFCxcSExMVFBS6du3q6urK"
+			"YrFI1oYNGzZs2HDr1q0OHTrITrRMyMvLi4yMrJ6uo6Nja2vL7L548eLSpUvp6enGxsb9+vUzMjJi"
+			"sjQ1NQcOHOjj4yMLuZ8DAoEgODj48ePHbDbb3t7ew8Ojyrs4Pj7+6tWrubm5RkZG/fr1MzAwYLK+"
+			"+uqrqKio1NRUmatuOkSSZsCAAQBu3rxZPWvLli0AVqxYIfGD1ouIiAgAvXv3rp5VVlampaWlpKRU"
+			"UFAge2EMzaQOj0Q/re+//PLLLywWS0tLq3PnziwWq2XLlhEREdLQVgvl5eWHDx+2trYGMHjwYBkf"
+			"nZCUlDR9+nQ5OTkAjx49+g9q4PF45DI2MTGxsLAA4Ojo+ObNG1lqSEpKateuHQA7Ozt9fX0A06ZN"
+			"EwqFstQgauqGkCUNeGLUnZ49e9b4CktNTSUFYmJiTExMOBxOp06dTE1NAbi7uzNP8pUrV36p9X/t"
+			"2rUaa2by5MlMmf3793O5XDU1ta5du6qrqysoKBw7dozJbcJHpUjKl00DyMnJ6dKlCwBLS0vSneTq"
+			"6ipuEixatAiAlpYWqUxlZeWjR48yuT179tTQ0GgK4U2G5O3Io0ePApgzZ071LBcXFwDx8fESP2h9"
+			"sbCwYLPZmZmZVdIvX74MYPTo0U2iiqGZ1GF9b29/f38AvXr1KiwsFIlEt2/fVlJSMjQ0JLuywdfX"
+			"18zMDAC5/2X/cMzOzh4zZgyHw1FSUiIvM9m/upqDhrlz5wJYsmQJsdu2bdsm4+YQCAQdO3Zks9ln"
+			"z54ViUSlpaUjR44EsG3bNplpaA4NIUukahCkp6eniJGcnKynp2dvb88U6Nixo4KCwr1798juhg0b"
+			"ACxatIjsfsF2ZHFxccqHrF27FkBAQAApkJ6erqCgYGVllZeXJxKJ3rx5Y2RkpK6uXlxcTApQO1Kc"
+			"+fPnA9i3bx/ZJRfSunXryO7p06cB9O3bl8fjiUSid+/eOTs7y8vLP3v2jBSgdqQE4PF4KioqRkZG"
+			"Vb77X79+zWKxHBwcJH7EBrBq1SoAf/75Z5X0GTNmADh//nyTqGJoJnVY39vb0dGRzWYzt5NIJFq+"
+			"fLn4DSkD9uzZ4+npGRwcnJub2yQPx9LSUnt7+5UrV2ZnZ5PnkexfXU2uIS8vT15evm3btnw+n0l0"
+			"dXUFkJCQIBsNFy9eBDBp0iQmJTc3V1VV1dDQUGZdkk3eEDJGlgbBnTt3AKxevZrsvn79esSIEczL"
+			"XiQSlZWVycnJ2drakl1xOzI6OvrAgQNHjx7Nzs6WmWBZ4uXlpaKiUlRURHafPXu2YsWKCxcuMAVm"
+			"zpwJICYmhuwyj0oejxcQELBv375bt27JTG1zsyMPHDjg7e3NPLsyMjIAjBw5kuwOGzYMQGxsLFM+"
+			"LCwMAPFGE4nZkQKB4MaNG/v27QsICCgtLZXtScgUyduRIpFo/PjxAMLCwsQTf//9dxl3BtTC06dP"
+			"ySeFeCKfz9fV1dXR0SkrK2sqYQzNoQ7rdXvn5OQAcHZ2Fk+MiYkBMHToUElL+zRNZUeK0xxMhybR"
+			"cOrUKQDLli0TT9y9ezeAHTt2yEbDvHnzAAQHB4snki7Jx48fy0aDOM3hYpA2sjQI5syZI24JVaes"
+			"rExRUdHGxobsEjvyzJkz/fr1A6CoqAigRYsWSUlJspIsIzIzM9lsNmP31MjQoUMBMH4mAL7++uu9"
+			"e/dqaWmRmgEwb948mehtdnZkFR4/fiw+PGhnZycnJycQCJgCAoGAw+Ew7z5iR16/ft3KyorL5XK5"
+			"XAAODg5fsCkplfnaY8eOBXDixAnxxJMnT7LZ7NGjR0vjiPWlbdu2Tk5OISEhb9++ZRJv3ryZnZ09"
+			"atQo4snUtDT/OqxCfHw8gM6dO4snWltbKysrx8XFNZEoStNAWrzKxeDg4MBk/Uc0UKSEQCDw8/Nj"
+			"3NdqxMfHp6SkhDgCMXzzzTc2NjbZ2dk8Hm/NmjVv377ds2eP9PXKFD8/P6FQSLrNauTChQvnzp3r"
+			"27evtra2eOK2bduOHz9eVFT06tUrY2Pj3bt3k6/x/zIFBQVLliwRf+3KycmVl5eXlpYyZdhstrq6"
+			"ekpKCpOSn58/bNiwhQsXFhYW5ufnDxgw4P79+0FBQbJWLyukYkd6enrq6+uTPglCVlZWaGiop6en"
+			"+LSmpmXcuHF8Pv/cuXNMChE8bty4phP1ns+iDsXJysoCUEUbi8XS09PLzs5uIlGUpqHGi4HMdJHZ"
+			"xZCVlcXlcsXflLLXQJESISEh2dnZtZhKV69enT17trq6+tKlS8XTd+3atWXLFh0dHTabPW3aNABJ"
+			"SUlSlytbfH195eXlBw4cWD3rxIkTHTt2HDly5MSJE319fcWzLCws7t696+npyWKxjIyMvvrqK4FA"
+			"IG4b/QcZOHCgsbFxWlqav78/80FCvkUvXbrEFIuNjc3NzS0qKmJS5OTkbt68OX36dAUFBSUlpQkT"
+			"JuBLvNIYpGJHcjic0aNHP3/+/MGDByTl1KlTQqGQ9LGJExcXFxAQEBgYmJiYWCWroKAgJCTkzJkz"
+			"N27cEG8hSTFq1Cgul3vy5EmyKxQK/f39zczMnJyc6i6jFv2NpC51mJ+f/7yStLQ0gUAg/gtlZWVM"
+			"7osXL8S/n6SHiopKlRR1dXU+ny+DQ1OaG1UuBnV1dQCyvBhqvBplrIEiDY4dOwZg+PDhNeaeOHFi"
+			"4MCB8vLyZ86cadOmjXgWMQIIJABTfn6+NJXKmtTU1LCwMC8vrxoDrvH5fBaLVVxcHBoaevv2bfEs"
+			"c3NzDQ0NZveLrJz6Qlxsk5KSAgICmKqYO3eunJzc7NmzL1++nJ+ff+3atcGDBzORpwhKSko2NjbM"
+			"7hdfmdKKQ07MHTKBF8Dp06eVlJTEPx9fv37t5OTUs2dPHx+fQ4cOOTk5eXh4MOHBdu7caWBgsHLl"
+			"ylOnTnl7e7ds2fLIkSOSVairq+vl5RUcHFxQUADg7t276enpY8eOZeKN1S6jdv0S4ZN1ePDgwbZt"
+			"2w4ZMmTIkCGOjo4aGhrjx49PT08nubGxsW3atOnbt++QIUM8PT3V1dU9PDzu3r0rQYXiEC8QUpni"
+			"vHv3TkFBQUoHpTRParwY3r17B0BmFwOXy63xapSlhubJsWPHfq1EvFvlc6G0tNTf379Vq1YkOEsV"
+			"du3aNWrUKBMTk/DwcHd391p+pzn4L0kc0stI3B+r8+2330ZGRsbExAiFwqFDh9YYdZLwRVZOfbl8"
+			"+XJaWtqyZcsOHTr03XffkUQbG5uzZ89yuVwvLy8NDY1BgwbNnz+/RYsWmpqaH/udL74ypWVHdu3a"
+			"1cLCggzL5ubmXr16tYrN7u3tXVBQkJKScvz48RMnTsTHxysqKpKwO0lJSfPmzdu9e3doaOjhw4fD"
+			"w8PXrVvn7+9fVlYmWZHjxo0rKysLDAxEpbkm3ttXu4xa9EuKT9YhADU1tcjIyMjIyJcvXz548CAh"
+			"IcHZ2Zm8LAl+fn6RkZGJiYnp6emtW7d2c3O7f/++BEUyGBoaAiBT28TJzMxsngPxFOlR48WQmZmJ"
+			"aoPdUtUgFAqrDGHLWEPz5Ny5c9sruXHjRlPLqTeBgYH5+fkjRoyonrV///65c+d6eHjcu3fPyspK"
+			"9tqanKNHj3I4nCFDhvyfvTsNaOpoG4d/ZYGwr7IvIiqLCIhipVpEBXFBZLEiBbR635Vqa61dKVbU"
+			"p7bqrbR2w61orZVFEBARZCmiiAtWhVbZKwgKCAET9i3L+2Fez/80wVRpchJhfp/IzCTnYjJJ5szM"
+			"mSOhjL29/ddff83j8U6ePElZYC8pZWXlqKio6dOnp6SkEONEixcvrq+vLy8vv379enNz87vvvvv4"
+			"8WNLS0v5hipHMrwvYmhoaFVVVVlZ2fnz53k8nsi6QzabbWRkREw8GRoaZmZmoqsp29raAADtAoi8"
+			"++67aWlpysrK0o3Qz89PXV0d9SDT0tJcXV1tbW2JXMlhSIhfiiTXoQhbW9vU1NSmpqYjR46I5+rp"
+			"6cXGxtrZ2W3fvl26QRJHZzKZJSUl5MSKior+/n7yPRWwsQC94yKN4c6dO0TWGIlBMcXFxXGf2rNn"
+			"j7zDeWFoUlt8yO3u3bvvvPPO3Llzs7Ky5HUbLfkqLy+/e/euh4fHP94zCXWy8ULh52RnZyd8uicJ"
+			"QqfT7e3t3dzcNDU1y8vLBwcHyUsmxhrZ9iMBIDU1NSUlRV9fX+QmhGvWrCkoKFi9erX40PqMGTMc"
+			"HBxCQ0NjY2O7u7tlF6GamlpgYOCFCxeuX79eW1sbEhLy/GFIiF+KJNehOHNz87lz5168eHHYXAaD"
+			"sWrVqkuXLgkEAqmHqq6uvnDhwhs3bpBXE6NlAH5+flI/HKbIPDw8dHR0EhMTh4aGiMRTp04xGIxh"
+			"l//LAhqS+fXXX4kUDoeTmZlpb28/efJkamLApK67uzsjI8PIyEjkQmwA+OSTTwDgl19+kfqIw8sC"
+			"TWqLLxv98ssvWSzW8ePHiRS0ZcEYH5gfVm9vr4GBwYQJE8jXG1RUVNDpdAMDAwCIj4+3sLD46aef"
+			"iFxU7RKu+hr1ZNiPRHvrnDp1KicnR3wzndDQ0Nzc3IcPH7q4uNjZ2e3evZuYBVNWVi4qKgoJCYmM"
+			"jDQwMAgKCkJbCstCaGhoT0/Pxo0bxffTkRyGhPilSHIdDsvKyqqpqUlCbl9fn3TXcRKioqJoNNqq"
+			"Vauqq6t5PF5CQkJ0dLSTk9NY/oCNTSwWKzIysq6u7q233mpvb+/q6oqIiLh27drbb7+Nprwp8Mor"
+			"ryxZsuTUqVPff//9wMDAw4cPg4ODe3p60D0IsJdUWlpaf3+/v7+/yP2OGxoacnJyrKysLl26dIIE"
+			"3RtsjIiPj6fRaOKT2mii7PPPP7969SqPx/v9998/+ugjBoMhfuUrpqam5uPj8+DBgy1btnA4HC6X"
+			"u3379pKSkoCAAHSVnre3d19f39atW4uKivr7+5OTk6Ojo729vdF9FsYome5O+eOPP6KjXL169Vll"
+			"6urqdu3aZWFhgaaYyVmDg4Pnzp0LCAig0Wjz588nbuIkRTweD20FsnDhwmeVkRyGhPilQkIdHjhw"
+			"QPz+S//5z3+cnZ2FQiGa0RPZ9xgtiOFwOM9z6BFsD3vmzBl00obMnTv34cOHL/oiUoH3IZdvDAKB"
+			"YNu2bcTIENpmheKdeLlcLvk3VUNDIyYmhsoAyBShMcgaBRtKo13Ec3JyRNKftdSP+IYc9r6IAODh"
+			"4SHrmKlx48YNAHj11VeHzb1w4YK5uTlRLUZGRsnJyUSu+Fclqq6CggKZxowo2j7kPT09YWFh5Ctu"
+			"AwMDyT+axcXF5H0Ali5d2traSuSK3xcR3QB9x44dlP0LFKMJhcIX73xK39DQkJ+f3+3bt9FCeBFF"
+			"RUXu7u4HDx7cuHEj9bE9TxiS45eRb7/9dufOnSKDi+7u7rq6uufOnSstLXVxcSkpKZk2bRqRGxUV"
+			"9f3333O5XPKH5Fniyu6HOkx80aiGhoZKS0u7u7utrKxENt3AxpqOjo579+4JBAI7OzvyCQaVGhsb"
+			"a2pqVFRUnJ2dVVVV5RLDGDGybwyMGnw+v7Kyks1m6+npTZkyBW2qoAgUs9m0t7dXVlYKhUIbGxtD"
+			"Q0ORXIFAUFZW1tnZaWVlZWZmJpcIFYeitCQlJaUFCxbk5OQIBAKRCQsAmDNnjoaGBtrcWI4khCE5"
+			"fspUVlZeu3aNGMIU0d/fHx8fv3jx4ufpRI6YkpLSzJkzZff62EtEW1tbfB0bxczMzPAXPYYxGAzy"
+			"poaYZPr6+hK+u+h0uqOjI5XxKDL59HiEQuGCBQvmzZtHXAD14MGD2NjY4OBgOp2ek5Ojrq6elJSE"
+			"sgQCwf79+wcGBobd6EF2JIQhOX4qgyTweLy8vDwfHx9nZ+d169aJF7h7966fn197e/uuXbuoDw/D"
+			"MAzDsNFHPp0eGo32008/CQQCCwuLOXPmuLm5OTs7e3l5oWugFi1atHPnzvDw8EmTJs2fP9/KyurX"
+			"X3/Nzs6m+FxKQhiS46dSR0eHjo6Ojo6OhobGO++8ExQUdOnSJRUVFaKAu7u7jo6Oqqqqt7e3kZHR"
+			"rVu3bGxsKA4SwzAMw7BRSc7rI9vb2+vr6+l0uq2trcjSJR6PV1dXx+FwjIyMxo8fL68IJYchIf5R"
+			"QDGXrWAYppjwNwY2ArjZvOzkvD5SX19fX19/2Cwmk6kI27xJDkNC/BiGYRiGYaOb3K4IwTAMwzAM"
+			"w15quB+JYRiGYRiGjQTuR2IYhmEYhmEjgfuRGIZhGIZh2EiM5HrtuLL7sggFwzAMwzAMo9K/vF5e"
+			"Ue6LiCkgvB0DhmHPD39jYCOAm83LDs9rYxiGYRiGYSOB+5EYhmEYhmHYSOB+JIZhGIZhGDYSuB+J"
+			"YRiGYRiGjQTuR2IYhmEYhmEjgfuRGIZhGIZh2EgwpftyAoEgIiJCKBTu27ePThftpDY2Nu7fv9/S"
+			"0vLDDz+U7nGfX11d3XfffWdjY/POO++I516+fDktLW3BggXLly+nPjaC4lejBFVVVfn5+Vwu19ra"
+			"2sfHR1NTUy5hCASCnJwcFou1YMECuQQAAI8ePcrPz/f19dXT0xuDMQiFwqKiops3b/L5/GnTpnl6"
+			"ejIYDIpjQLq7uzMzMx0dHadMmUL90dlsdmZmZlNTk4GBwZIlS8zNzamPYRQoLS3lcrni6a6urhoa"
+			"GiKJFRUVxcXF06ZNmzZtGkrZu3fv3r17r1y54ujoKPNYqcXlcktLS8XTx40bN3XqVPR3X19fcXGx"
+			"SIF58+ahP3R0dHx8fOLi4mQZ5kuDz+fn5ub+8ccfdDrdxcXF09NT/FcYAAoLC1NTUwEgMjLSyMiI"
+			"nLVs2bK7d+/W19dTFLHcCaVt6dKlAFBYWCieFR0dDQBRUVFSP+jz6+/v19XVVVdX7+3tFc9dtmwZ"
+			"AOTn51MfmAhFqMZT9/560ads376dRqPp6upOnz6dRqOZmJjcvHlTFrFJMDQ0dPLkSXt7ewDw8/Oj"
+			"+OhITU1NeHi4kpISAJSUlIzBGHp6elAbHj9+vI2NDQDMmjWrra2N4jA4HM6XX36pr68PAAcOHKD4"
+			"6EKh8Ny5c5qamkpKSq6ururq6iwWKzY2lvowqDGCb4zn5+HhMexPWH19vUjJoaEhBwcHANixYweR"
+			"uGPHDjl+GGWqoKBg2JpZt24dUeby5csiuXp6ekSuHL8qhTJuNi+qvb19xowZAGBra4tOO1977bWu"
+			"ri7xkkuWLNHR0QGAb775RiTLw8NDW1ubkngVgvT7kfHx8QCwadMm8aw5c+YAQGVlpdQP+kLCw8MB"
+			"4MyZMyLpXV1dLBbL1NSUz+fLJTAyRajGF/14p6SkAMC8efO6u7uFQuHVq1dVVVVNTU3RQ2okJCRY"
+			"W1sDAPoKoP7Lkc1mh4SEMBgMVVVVKysrufx0KUIM7733HgB8+umnAoFAKBQeOHCA+rdj69at2tra"
+			"NBrNzs5OLv3IhoYGNTU1ExOTmpoaoVDY3Nxsa2tLp9Nv3bpFcSTUkGmHoLm5uY6ktrbW0NDQxcVF"
+			"vOS3335Lo9HGTj+yr6+v7u+++uorAEhPTyfKxMbGAsCNGzeIMo8ePSJycT+S8P777wPAkSNH0MO9"
+			"e/cCwO7du0WKtbS0MBiMLVu22NraTp8+XSR3rPUjpb8+0s/PT11dPS0tTfj3O+U0NTVdu3bN1dXV"
+			"1tZW6gd9IaGhoQCARqTJzp8/PzAwEBISMuwgNsUUvxrFoVn4Y8eOqaurA8Ds2bM/+uijpqYmKqdL"
+			"0Hx6bm7u1atXKTsomZaWVkVFxbZt2xoaGvz8/MZmDB0dHUeOHJk4ceLu3bvRF77WYAAAIABJREFU"
+			"L/qWLVtee+219PT06upqysJ4+PDhihUrysrK9uzZQ9lByWJiYnp7e/fs2TNp0iQAMDY2jomJEQgE"
+			"X3/9tVzieakZGxtbkTx+/Li1tTUgIECkWGtr6/bt24OCgiS8VFlZ2fHjxxMSEtra2mQZMkVUVFSs"
+			"/u7y5cvq6uoLFy4kylRVVampqc2aNYsoY2ZmJv5Svb29586dO3r0aFFREYX/gQJxcnKKiIj473//"
+			"ix6uXbsWAEpKSkSKJSYm8vn85cuX+/v737lzp6KiYthXEwgEhYWFR48ePXfu3ODgoCwDlytZdE5X"
+			"r14NANevXycnfv/99yCnqSURAoHA0tJSS0urv7+fnB4YGAiKdMIq92p8odPE9vZ2AJg9ezY5says"
+			"DAACAgKkHdo/43A4INeTbOHTU1v5tii5xIBO0rZu3UpOjImJAYDvvvuOykiQtLQ0uXz5ODk5KSkp"
+			"kcfjBQKBoaGhrq4uxZFQg8qBpU2bNgFAWVmZSPq6desmTpyYm5sLw41Hnj17dvHixQCgoqICAHp6"
+			"emioeDRpaWmh0+krV64kJ/r5+Tk5OT3rKQCwfPnyw4cP6+rqopoBgM2bN8s+WKFQwcYjRfzxxx8w"
+			"3MTgzJkzdXR0BgcHr127BgCRkZHkXDQeeenSJTs7OyaTyWQyAcDV1XVgYIDC2Kkjk4E3NOCXnJxM"
+			"Tjxz5gydTg8ODpbFEV8IjUYLCQnp7OxE3zVIb29vVlbWlClTiHXZcqfg1SiisrISAKZPn05OtLe3"
+			"V1NTe9a5GjZaoXdcpDG4uroSWWNERUWFra0tGp5HaDTajBkzOBxOS0uLHAN72fH5/NOnTxMr2AjF"
+			"xcUnTpzYtm0bWhYsbtWqVQ4ODmw2u6enZ9euXU+ePDl06BAlIVPn9OnTAoEADYsQampqbGxsLl68"
+			"+OWXX+7fvx99XZNlZWUdOHAgKSmpt7f30aNH5ubmMTEx6Gx8zOrq6vr000/Ff3Crq6t///13Hx8f"
+			"JSWlWbNmmZiYxMfHC/8+c9jZ2RkYGPjBBx90d3d3dnYuXbr01q1bOTk51P4HFJFJP9LLy8vIyIg8"
+			"cdza2lpUVOTl5WVsbEwuWVFRkZ6enpmZKT7b1dXVlZ+ff/bs2cuXL/f29ko3wrCwMPj71PaFCxf6"
+			"+/tROhHzg6fYbLbIK3R2dhK5TU1NfD5fuhHCy1CNZK2trQAgEhiNRjM0NBSvPWx0G7YxoEsax05j"
+			"4HK5Q0NDIpUAY68eZCE/P5/NZot0lQQCwaZNm5ycnNasWfOsJ/7444/R0dHjxo2j0+nr168HgJqa"
+			"GpmHS62EhARlZWUfHx8ihc/n19TUXLhwYdWqVXl5ebt27XJwcDh48CD5WTY2NsXFxV5eXjQazczM"
+			"bNmyZXw+v66ujvLwFYWPj4+5uXlTU1NKSgq6JoFw6tQpAEBrKuh0up+fX319/ZUrV8hllJSUCgsL"
+			"w8PDWSyWqqoqapOjr7EhMulHMhiM4ODgBw8e3L59G6WkpqYKBAI0wIY0Nja6ubl5eHjExcWdOHHC"
+			"zc3N09OT2Nbhhx9+MDY23rFjR2pqakREhImJCXrnpMXBwcHZ2Tk9PX1oaAiloGG/kJAQokx4eLiz"
+			"s7O/v//y5cvt7OxMTEyioqKIJQ7Hjx+fOHGiv7+/v7//rFmztLW1V69e3dzcLMUgFb8axZGHXhAt"
+			"LS0ejyfTg2KKSaQxaGlpAcBYawzDfiJg7NWDdCUmJgLAihUryInHjh27devWt99+K2GBOxoUR9BO"
+			"WJ2dnTILUw7q6+uvX7/u7e1N3nCNw+E4ODh4eno2NDRcvny5pqZm4sSJ7733XlVVFVFm8uTJ2tra"
+			"xMNRWTkvZHBwUElJqaamJj09nVwPQqEwLi5OVVUV7UcBAOh8RuS3VVVVFW0agIzu+pTVBSWor4Mu"
+			"4AWAtLQ0VVVV8uljREREV1dXXV1dUlJScnJyZWWliopKXl4eANTU1GzevDkmJqaoqOjkyZM3btzY"
+			"vXt3SkqKdJephoaGcjgctGPCwMBAVlaWu7v7+PHjyWXmz59fWlr6559/trW1nTx58vDhw+TxbU1N"
+			"zdLS0tLS0ocPH96+fbuqqmr27NkdHR3SDRIUuxoJaAlIV1eXSHpHRweLxZLFETGFNWxjQB+NsdMY"
+			"JHwiQK71kJiYuPOp7OxseYUxYgMDAykpKRYWFmh/FoTD4Xz++eeBgYHEnoj/6Flz3y+1hIQEeDpU"
+			"Rhg3blxJSUl6erqqqioAGBkZbdu2TSAQnD59+lmvMyor54Xk5eU1NTVt3br1xIkTxGU3AHD9+vXa"
+			"2lobG5ucnJyzZ8+ePXuWy+Uymczk5OSBgYFnvdrork9Z9SNnzpxpY2OD5mQ5HM7Fixf9/PzIu8Wy"
+			"2WwjIyPiZN3Q0DAzM3PlypUAgK6hQ7u3IO+++25aWpqysrIUIwwJCaHRaCjCvLy8rq4u8jifCBqN"
+			"tnDhwoMHD6alpd28eVO8gK2tbWpqalNT05EjR6QYpOJXI8HU1BQAHj9+LJLe0tIiPrWHjW7DNga0"
+			"InDsNAYNDQ1NTc1hPxEg13rIyMj49inxbQUVX2ZmZmdn5+uvv05O/P7779lsdmdn59q1a9euXYu2"
+			"azl79iy63nbsiI+PZzAY/v7+kou98sorAFBbW0tJUC8rZWXlqKio6dOnp6SkELN8aNyxtrZ27VPr"
+			"169nMplcLjcrK0uu8cqNDDe4CQ0NraqqKisrO3/+PI/HIy89BIA1a9YUFBSsXr1afCP+GTNmODg4"
+			"hIaGxsbGdnd3yyg8MzOzefPmpaWlCQQC1LtC3S8JAgICVFRULl68OGyuubn53Llzn5U7YgpejQRb"
+			"W1smkymyP0JFRUV/fz9xTwVsjEDvuEhjuHPnDpE1RkydOrWmpob86RMKhSUlJaamprq6uvKKKi4u"
+			"jvuUvHZE+jfQpLbIkNvkyZPffPPNYfeyGTvKy8vv3r3r4eEhcvMqoVDY0tJCXsSPFnShIXNMMjs7"
+			"O+HTDUmGhoaSkpK0tLTYbDaX5Pz58wDw66+/yjtY+ZBtPxIAUlNTU1JS9PX1vb29RXJzc3MfPnzo"
+			"4uJiZ2e3e/du4sRdWVm5qKgoJCQkMjLSwMAgKCjowoULsogwLCystbW1sLAQbQbxjzeOYzKZaOHt"
+			"swpYWVlJyB0Zxa9GBG1XduPGDfJSYnTqJq9tFDF58fDw0NHRSUxMJNYfA8CpU6cYDAZ5+f+o5+/v"
+			"PzQ0RJ49/O2331paWvAnYsS6u7szMjKMjIxELn0ICQk5QfLZZ58BgL+//4kTJ+QTqDygSW2RZaMA"
+			"8MEHHxgbG5PXMKDtdZ2dnakMT/H19vYaGBhMmDCB3OeuqKig0+kGBgYAcOHChfb2dh8fH5F1KfPm"
+			"zTMwMMjMzBybV7jLsB85ceJENze3U6dO5eTkBAUFia8PWLhw4aVLl+rq6sLCwg4fPjxp0iTi2mQd"
+			"HZ3//e9/TU1NSUlJPB7Px8dnwYIF/f390o1wxYoVLBZry5YtT548kTCpTSYQCCQs4pacOzKKX42E"
+			"qKgoGo22atWq6upqHo+XkJAQHR3t5OQkclklNuqxWKzIyMi6urq33nqrvb29q6srIiLi2rVrb7/9"
+			"NpryHiPefvttY2PjTz75JC8vTygUFhcXh4eHq6urf/LJJ/IO7WWVlpbW39/v7++vCHeLUDTx8fE0"
+			"Gk18Unvz5s1qamoffPAB2u6nsLBwx44d+vr65OtKMQBQU1Pz8fF58ODBli1bOBwOl8vdvn17SUlJ"
+			"QEAAujwO3VNDvKfOYDACAwMHBwdF9ukbI2T7UQwLC6uurhbZT0eElZXVtm3b7t+/P3fu3I0bN5Kz"
+			"lJSUfH19U1NTCwsLCwoKfv75Z+mGp62t7evr+8cff2hpafn6+v5j+f7+/oaGBktLy2cVqK6ulpA7"
+			"YgpejYRXX301KSnp0aNHtra2SkpKISEhbm5umZmZePZkDPrkk0+2bduWmJg4btw4LS2t6Ojo9evX"
+			"o7sjjh3a2tp5eXkWFhbe3t50Ot3NzQ0AsrKyJkyYIO/QXlbohrH41FRccXFxbW2tm5ub+KmatbX1"
+			"hQsXeDyevb09k8n08PDQ19fPyclB953HyA4ePBgWFhYTE6Onp6erq7tr167AwEB0V8mOjo5z586p"
+			"q6sTV2qToXVxst4RRUHJcxP0v9u/fz+dTh/23tYCgUBDQ2Pnzp1UxuPn5ydyN5SjR48CQHl5uVAo"
+			"PHDggMgNNNHo98GDB6kMUpwUq3FktxkYHBy8efPmxYsXa2trR/B0bDThcrlFRUWFhYWtra3yjkWe"
+			"ysrKLl68WFpaOuwHc9RQ5BuTYHw+/969ewUFBdXV1fKO5W8UsNm0tbUVFRVduXKlpaVF3rG8BOQz"
+			"UCQUCj09PQUCAVrzBwAPHjyIjY0NDg6m0+k5OTmBgYE///wzukeqQCCIjo4eGBgQuUCPSt3d3YmJ"
+			"ie+///7GjRvt7e1Fcnk8XkFBwYYNG5ydndetW0dZVIpZjUpKSjNnzpTpIbCXhba2tsg6trFpypQp"
+			"IndewTCK0el08o6GmAT6+vr4i+v5yacfSaPRfvrpp3Xr1llYWLi4uPD5/IqKitWrV+/btw8AFi1a"
+			"tHPnzvDw8K1bt1pYWNy/f19bWzs7O5v6z0BmZqaOjg4AoIuODxw4EB4eTuR2dHQQuRYWFkFBQZGR"
+			"kcTNSSnwslQjhmEYhmGjEk3495tCUqy9vb2+vp5Op9va2qItUgk8Hq+uro7D4RgZGYlsD46JkFE1"
+			"xpXdD3WYKNVIMQwbtfA3BjYCuNm87OR8AYS+vv6zlvoymczJkydTHM9LClcjhmEYhmHUw1snYBiG"
+			"YRiGYSOB+5EYhmEYhmHYSOB+JIZhGIZhGDYSuB+JYRiGYRiGjQTuR2IYhmEYhmEjMZJ9f+LK7ssi"
+			"FAzDMAzDMIxK/3LfJTnvH4kpMrytF4Zhzw9/Y2AjgJvNyw7Pa2MYhmEYhmEjgfuRGIZhGIZh2Ejg"
+			"fiSGYRiGYRg2ErgfiWEYhmEYho0E7kdiGIZhGIZhI4H7kRiGYRiGYdhIMKX7cgKBICIiQigU7tu3"
+			"j04X7aQ2Njbu37/f0tLyww8/lO5xn19dXd13331nY2PzzjvviOdevnw5LS1twYIFy5cvpz42RPHr"
+			"ULKqqqr8/Hwul2ttbe3j46OpqSmXMAQCQU5ODovFWrBggVwCAIBHjx7l5+f7+vrq6emNwRiEQmFR"
+			"UdHNmzf5fP60adM8PT0ZDAbFMSDd3d2ZmZmOjo5TpkyRSwCgGI3hpVZaWsrlcsXTXV1dNTQ0iIdX"
+			"r169ceMGg8FwcnKaP38+jUZD6Xv37t27d++VK1ccHR0pipgqXC63tLRUPH3cuHFTp04FgAcPHjx4"
+			"8EC8wKRJk8zNzQFAR0fHx8cnLi5OxpG+HPh8fm5u7h9//EGn011cXDw9Pck/xPv3729sbCQeqqmp"
+			"WVtbz50718bGhkhctmzZ3bt36+vrKY1bjoTStnTpUgAoLCwUz4qOjgaAqKgoqR/0+fX39+vq6qqr"
+			"q/f29ornLlu2DADy8/OpD4xMQerw1L2/XvQp27dvp9Fourq606dPp9FoJiYmN2/elEVsEgwNDZ08"
+			"edLe3h4A/Pz8KD46UlNTEx4erqSkBAAlJSVjMIaenh7UjMePH4++YWfNmtXW1kZxGBwO58svv9TX"
+			"1weAAwcOUHx0RBEaAzVG8I3x/Dw8PIb9Cauvr0cFhoaGXn/9dQCws7ObNGkSAHh5eRHf8zt27Bit"
+			"9V9QUDBszaxbtw4VQP+7uF9++QUVkONXpVDGzeZFtbe3z5gxAwBsbW3Raedrr73W1dVFFHB2dkbV"
+			"5efnt3jx4mnTpjGZTAAICgoaHBxEZTw8PLS1teX0H8iB9PuR8fHxALBp0ybxrDlz5gBAZWWl1A/6"
+			"QsLDwwHgzJkzIuldXV0sFsvU1JTP58slMIKC1OGLfrxTUlIAYN68ed3d3UKh8OrVq6qqqqampugh"
+			"NRISEqytrQEAfQVQ/+XIZrNDQkIYDIaqqqqVlZVcfroUIYb33nsPAD799FOBQCAUCg8cOED927F1"
+			"61ZtbW0ajWZnZyeXfqQivBFUkmmHoLm5uY6ktrbW0NDQxcWFKLB7924AOHbsGHr45Zdfkk+5R3E/"
+			"sq+vr+7vvvrqKwBIT09HBTgcjkgBX19fBoPR3t6OCuB+JOH9998HgCNHjqCHe/fuBYDdu3cTBVA/"
+			"kvyUx48fo9/lmJgYlIL7kf9WT0+Purq6mZkZ+v0gNDY20mg0V1dXqR/xRV2+fBkAQkJCRNITEhIA"
+			"4OOPP5ZLVGQKUocv+vGeNWsWnU6/f/8+kbJt2zbyZ5IChw4d8vLyys3N5XA4cvlyHBgYcHFx2bFj"
+			"B5vNRl9J1P90yT0GLperrKw8ceJEHo9HJL722msAUFVVRVkYq1ev/s9//lNeXp6WliaXfqTc3wiK"
+			"UdkhuHbtGgB88cUX6CGfzzc0NJw5cyZRYHBw8OTJkzdu3EAPyf3Ie/fuHTt2LD4+ns1mUxYwlby9"
+			"vZ815yYUCvv6+rS0tBYsWECkEF+VPT096enpR44cuXLlCkWxKlg/8tixYxEREcQX1+PHjwFg5cqV"
+			"RAHxfqRQKMzNzSUPABP9SD6ff/ny5SNHjqSnpw8MDFDyH8iBlNdHAoCamlpgYOCvv/5aXFzs5uZG"
+			"pKekpAiFwtDQUKkf8UW5u7tbWlqeP39+YGCAxWIR6cnJyQCgCBEqfh2Ke/LkSXFx8ezZs9FwIPLG"
+			"G298+eWX2dnZaAyYAhs2bNiwYQMADLuUigLKysp37tyRy6EVJ4aLFy8ODg6uWrWKvCDyjTfeKCoq"
+			"ys7OJi8kkqmTJ0+iP6qqqqg5ogi5vxGjGJq0WbFiBXpYUlLS2tr69ttvEwWUlJRWr14t8qz6+vrI"
+			"yMjs7GwVFZX+/n49Pb3i4mI0CT5qtLa2/vbbbytWrFBVVR22QGZmZmdnJ1F1iFAoPHLkSGRkZF9f"
+			"X39/PwBs3rz5u+++oyJiRfKf//yH/LClpQUAjIyMJD+Lx+MBgJqaGjnx8uXLGzZs+Ouvv1ABV1fX"
+			"q1evKisrSzliBSCT67VRRwd1ywhnzpyh0+nBwcGyOOILodFoISEhnZ2d6BwC6e3tzcrKmjJlyrRp"
+			"0+QYG0HB61BcZWUlAEyfPp2caG9vr6amVlFRIaegMPlA77hIY3B1dSWyMOzf4PP5p0+fJlawAUB5"
+			"eTkA2NjYNDc3x8bGfv311xkZGYODgyJPXLVqlYODA5vN7unp2bVr15MnTw4dOkR19DJ2+vRpgUAQ"
+			"GBj4rALx8fE0Gs3f35+cmJWVdeDAgaSkpN7e3kePHpmbm8fExKBZnTGrq6vr008//cff3Obm5l27"
+			"dikpKa1du5ZI7OzsDAwM/OCDD7q7uzs7O5cuXXrr1q2cnByZBy0P0h+PBAAvLy8jI6PU1NSvv/4a"
+			"pbS2thYVFXl5eRkbG5NLVlRUVFdXM5nMyZMni4xSdHV13bx5s6urS1dXd+bMmSI9/X8pLCxs7969"
+			"qampvr6+KOXChQv9/f1hYWFEmdbW1t7eXvS3urq6gYEB+RU6OzufPHmC/lZWVjYyMpLutajPU4eS"
+			"YxgcHGxqakJ/0+l0IyMj8uCr1LW2tgKAyPtLo9EMDQ3ZbLbsjospoGEbAzqnx40B+/fy8/PZbPZb"
+			"b71FpKBLaG/fvh0eHm5hYdHf39/Q0GBtbZ2dnT158mSi2I8//kg8a/369VFRUTU1NRQHL2sJCQnK"
+			"yso+Pj7D5nZ0dGRlZbm5uZmampLTbWxsrl27pq2tDQBmZmbLli07fPhwXV2drq4uFUErHh8fn6Ki"
+			"ovHjx6ekpKDlj2SoF97X18dms2tqary8vAoLC9GpMqKkpFRYWOjg4IAerlmzJisra/Q1NkQm45EM"
+			"BiM4OPjBgwe3b99GKampqQKBgDwh29jY6Obm5uHhERcXd+LECTc3N09PT2Iu8ocffjA2Nt6xY0dq"
+			"ampERISJicmpU6ekGKGDg4Ozs3N6evrQ0BBKQSN/ISEhRJnw8HBnZ2d/f//ly5fb2dmZmJhERUUR"
+			"J7jHjx+fOHGiv7+/v7//rFmztLW1V69e3dzcLK0In6cOJcdQXl4+YcKERYsW+fv7e3l5aWlpeXp6"
+			"FhcXSyvCYamrq4ukaGlpoTF/bKwRaQxaWlrwdAIIw/6NxMREIE1qAwCaiv35558zMzOrqqrq6+tj"
+			"YmJqa2tFprbJv/RoA6bOzk6KgqZEfX399evXvb29n7XhWnp6en9/v8ikNgBMnjwZdSKRUVk5L2Rw"
+			"cFBJSammpiY9PV28HqysrKysrOzt7R0dHcePH5+RkbFr1y40hY2oqqoSnUgY7fUpq33IUXcHXcAL"
+			"AGlpaaqqquSR9oiIiK6urrq6uqSkpOTk5MrKShUVlby8PACoqanZvHlzTExMUVERWii9e/fulJQU"
+			"8UmKfxkhh8NBOyYMDAxkZWW5u7uPHz+eXGb+/PmlpaV//vlnW1vbyZMnDx8+TB7f1tTULC0tLS0t"
+			"ffjw4e3bt6uqqmbPnt3R0SHFCEFiHT5PDKdPny4tLa2urm5ubra0tHR3d79165a0IiRDex90dXWJ"
+			"pHd0dMh0HBRTQMM2BtQscWOQu8TExJ1PZWdnyzucFzYwMJCSkmJhYYH2ZyH78MMP58+fj/5+5513"
+			"5syZU1xcfP/+/WFfB+3ENMqgq0UDAgKeVQCtK5VQABmVlfNC8vLympqatm7deuLEif/+978iud8+"
+			"9csvv9y7d+/MmTN5eXmenp59fX3Dvtrork9Z9SNnzpxpY2OTmpoKABwO5+LFi35+fuTdYtlstpGR"
+			"ETFiYWhomJmZuXLlSgBoa2sDAPLlGu+++25aWpp0F6iGhITQaDQUYV5eXldXl4TrV2g02sKFCw8e"
+			"PJiWlnbz5k3xAra2tqmpqU1NTUeOHJFWhP9Yhy8Ug56eXmxsrJ2d3fbt26UVIRmaJUFXt5G1tLSI"
+			"zG9io96wjQGtWMeNQe4yMjKIX0G0ecXLBV0mgraKJKCxNFtbW3LizJkzAWDYLbhHq/j4eAaDIbL2"
+			"kYAuwXFxcSH/vGLPoqysHBUVNX369JSUFMkXbvr7+wcHBzc0NFy8eJGy8BSHDO+LGBoaWlVVVVZW"
+			"dv78eR6PR156CABr1qwpKChYvXq1+Eb8M2bMcHBwCA0NjY2N7e7ullF4ZmZm8+bNS0tLEwgEqJOK"
+			"erESBAQEqKioPKuhmJubz507V7rNSHIdvmgMDAZj1apVly5dEggEUgwSsbW1ZTKZJSUl5MSKior+"
+			"/n50TwVs7EDvuEhjQFcu48Ygd3Fxcdyn9uzZI+9wXhia1BYZUZs4cSIAPHz4kJyIli2NnSHw8vLy"
+			"u3fvenh4POueSWfOnOHz+f84GImR2dnZCYXC9vZ2ycXQ+m8pTki+RGTbjwSA1NTUlJQUfX19b29v"
+			"kdzc3NyHDx+6uLjY2dnt3r2bGL1QVlYuKioKCQmJjIw0MDAICgq6cOGCLCIMCwtrbW0tLCw8e/bs"
+			"4sWL//F+ZUwm09zcnLh4RZyVlZWE3BGQXIcjiMHKyqqvr08We+Koq6svXLjwxo0b5KXEaFWrn5+f"
+			"1A+HKTIPDw8dHZ3ExERi/TEAnDp1isFgPGv5P4Y9j+7u7oyMDCMjI5FLHzw8PJSVlc+dO0ek8Pn8"
+			"vLw8JSUlJycnysOUDzSpLb728fkLjHG9vb0GBgYTJkzg8/lEYkVFBZ1OF7nQVkRHR8eZM2cAYPTd"
+			"dfN5yLAfOXHiRDc3t1OnTuXk5AQFBYmvD1i4cOGlS5fq6urCwsIOHz48adIkNIcLADo6Ov/73/+a"
+			"mpqSkpJ4PJ6Pj8+CBQvQSmopWrFiBYvF2rJly5MnT55zU0aBQCB+z+vnzB2Bf6zDEUQIANINkhAV"
+			"FUWj0VatWlVdXc3j8RISEqKjo52cnCTsQIGNSiwWKzIysq6u7q233mpvb+/q6oqIiLh27drbb78t"
+			"cpUohr2QtLS0/v5+f39/kS8xbW3t9evXX7lyJSIigsPhoL0kq6ur169fjy7wGguG3dCH0NDQUFRU"
+			"RN4sCROhpqbm4+Pz4MGDLVu2cDgcLpe7ffv2kpKSgIAAkVZ06dKlS5cuFRQUpKamfvHFF05OTg8e"
+			"PHjrrbfGZj9SJvv+EMLCwjZt2oT+eFYZKyurbdu2RURE+Pn5bdy4kdznUFJS8vX19fX1LSoqcnd3"
+			"//nnnzdu3CjF8LS1tX19fc+cOaOlpUVsACQB2kvC0tLyWQWqq6sl5I7M89Th88dQXV2tpaVFvi5P"
+			"il599dWkpKSNGzcSq5Tmzp0bFxeHrrrAxpRPPvmkq6tr3759aDNwOp2+fv16dHdEDBsxdJnIsKem"
+			"33zzzcDAQHR09L59+wCAwWCEh4ePnSZXXFxcW1v76quvPutUDQ1G4rN6yQ4ePMjn82NiYn788UeU"
+			"EhgYGBsbK1KMuJwLAIyNjWfMmLF///5/XBo3asn3djpk+/fvp9Ppw97bWiAQaGho7Ny5k8p40I3Y"
+			"ySlHjx4FgPLycqFQeODAAZEbaKLR74MHD1IWoeQY0Oo08n3Y+vr6rK2tg4KCnvP1R3a7qsHBwZs3"
+			"b168eLG2tnYET8dGEy6XW1RUVFhY2NraKu9YMJlThBvcPXny5Nq1a9evX3/y5Im8Y8GeiyI0GxFt"
+			"bW1FRUVXrlxpaWmRdywvAfkMFAmFQk9PT4FAgJb9AcCDBw9iY2ODg4PpdHpOTk5gYODPP/8cFBQE"
+			"AAKBIDo6emBgQOQCPSp1d3cnJia+//77GzdutLe3F8nl8XgFBQUbNmxwdnZet26dXCL8xxju3r37"
+			"8ccft7e379q1S6aRKCkpocskMUxbW1t8C18Mkx1dXd1XX31V3lFgLzd9fX38xfX85NOPpNFoP/30"
+			"07p16ywsLFxcXPh8fkVFxerVq9F8xKJFi3bu3BkeHr5161YLC4v79+9ra2tnZ2eTd/WkRmZmpo6O"
+			"DgCgi44PHDhAvk90R0cHkWthYREUFBQZGamiokJlhP8Yg7u7O4PBGBjLC5jEAAAgAElEQVQY0NHR"
+			"Wbhw4a1bt0bZzWQxDMMwDJMXmlAolOPh29vb6+vr6XS6ra2tyE3leTxeXV0dh8MxMjIS2R4co0Zc"
+			"2f1Qh4nyjgLDsJcD/sbARgA3m5ednC+A0NfXR/Pa4tBNtymOB8MwDMMwDHtOMtz3B8MwDMMwDBvF"
+			"cD8SwzAMwzAMGwncj8QwDMMwDMNGAvcjMQzDMAzDsJHA/UgMwzAMwzBsJEay709c2X1ZhIJhGIZh"
+			"GIZR6V/uuyTn/SMxRYa39cIw7PnhbwxsBHCzednheW0MwzAMwzBsJHA/EsMwDMMwDBsJ3I/EMAzD"
+			"MAzDRgL3IzEMwzAMw7CRwP1IDMMwDMMwbCRwPxLDMAzDMAwbCaZ0X+7QoUNVVVWbN2+2trYWz42M"
+			"jOzv79+7dy+LxZLucV9IXl5eZmbm0qVLvb29xXOPHTt29+7d8PDwKVOmUB8bIhAIIiIihELhvn37"
+			"6HTRvn5jY+P+/fstLS0//PBDuYQnWVVVVX5+PpfLtba29vHx0dTUlEsYAoEgJyeHxWItWLBALgEA"
+			"wKNHj/Lz8319ffX09MZsDPJ9I/r7+y9cuFBVVaWmpubu7u7i4kJ9DGw2OzMzs6mpycDAYMmSJebm"
+			"5tTHMAqUlpZyuVzxdFdXVw0NDfR3Z2dnZmZmXV2dqqrqK6+8Mnv2bBqNhrL27t27d+/eK1euODo6"
+			"Uhc0JbhcbmlpqXj6uHHjpk6dSjysrKy8ePEih8MxMzNbvHixsbExkaWjo+Pj4xMXF0dFuAqvoaEh"
+			"Ozu7ubnZ3Nx88eLFZmZmIgUEAkFqaurZs2erq6sHBwctLCyWLVv25ptvqqioEGXGVpUKpWrfvn0A"
+			"8MUXX4hn3bp1CwDc3d2le8QRuHnzJgAsWLBAPGtwcFBXV1dVVbWrq4v6wMiWLl0KAIWFheJZ0dHR"
+			"ABAVFSXrGE7d++tFn7J9+3Yajaarqzt9+nQajWZiYnLz5k1ZxCbB0NDQyZMn7e3tAcDPz4/ioyM1"
+			"NTXh4eFKSkoAUFJSMjZjkPsbUVNTM2nSJABwcnIyMjICgPXr1wsEAipjOHfunKamppKSkqurq7q6"
+			"OovFio2NpTIAKo3gG+P5eXh4DPsTVl9fjwrk5+fr6ekpKSk5OzujgYwFCxZ0dHSg3B07dsjxwyhT"
+			"BQUFw9bMunXriDIfffQRAOjq6s6cOVNLS0tNTS0+Pp7IleNXpVDGzeZFxcbGMplMTU1NVFEsFisx"
+			"MZFcoLGxcdasWQCwcOHC3bt3R0dH+/n5AYCdnV1dXR1RTL5VSjEp9yMfPXpEo9GmTp0qnvX5558D"
+			"wOHDh6V7xJGxsbGh0+ktLS0i6Xl5eQAQHBwsl6jI4uPjAWDTpk3iWXPmzAGAyspKWcfwoh/vlJQU"
+			"AJg3b153d7dQKLx69aqqqqqpqSl6SI2EhAT0E4KGk6n/JLPZ7JCQEAaDoaqqamVlJZefLkWIQe5v"
+			"BJ/Pd3Z2ptPp586dEwqFAwMDK1euBIADBw5QFkNDQ4OampqJiUlNTY1QKGxubra1taXT6bdu3aIs"
+			"BirJtEPQ3NxcR1JbW2toaOji4oJy+/v7DQwMxo0b99df/38M6Hz7ww8/RA9HcT+yr6+v7u+++uor"
+			"AEhPT0cF0tLSAGDRokU9PT1CobCjo2P27NnKysr3799HBXA/EmlubmaxWHZ2dlwuVygUtrW1mZmZ"
+			"aWlp9fX1oQI9PT2Ojo7KyspE3SK//PILOl8dGhpCKbgf+a/Mnz8fAKqrq0XSbW1tlZWV29vbpX7E"
+			"Efi///s/ADh69KhI+ttvvw0A58+fl0tUZD09Perq6mZmZiLDJ42NjTQazdXVlYIYXvTjPWvWLDqd"
+			"Tnw3CYXCbdu2AcCRI0ekHdozHTp0yMvLKzc3l8PhyOWTPDAw4OLismPHDjab/f7778vlp0sRYpD7"
+			"G3HhwgUAWLt2LZHC4XA0NDRMTU0pG5KMiIgAgBMnThApv/32GwC88cYb1ARAMSo7BNeuXSPPff3+"
+			"++8A8PbbbxMF+Hy+iooKMahB7kfeu3fv2LFj8fHxbDabsoCp5O3tra6u3tvbix4GBgYCQHl5OVHg"
+			"+vXrAIBWTwlJnZ6enp709PQjR45cuXKFsmgVpx95//79qKiorKwsImXDhg0AUFZWhh7u2bMHAHbt"
+			"2iX+3GXLlk2aNKm4uBg9lG+VUkz6/chjx44BwJ49e8iJf/75p0J1z//66y90fkZO5PF46Ix2cHBQ"
+			"XoGRrV69GgCuX79OTvz+++8pG1N5oY93e3s7AMyePZucWFZWBgABAQHSDu2fyav7QiavPpxCxSCv"
+			"N2Lz5s0AkJubS05EQ5J//PEHNTE4OTkpKSmRx+MFAoGhoaGuri41AVCMyg7Bpk2byD/waN0UMfqI"
+			"GBgYODo6or9RP/Ls2bOLFy8GALSUTU9PDw0VjyYtLS10On3lypVECmqHfD6fSOHz+QwGg/i6BoDl"
+			"y5cfPnxYV1eXWOS3efNmagJWnH6kuICAAABoa2tDD8ePH6+srEwslpBAvlVKMelfr71ixQoWi5Wc"
+			"nExOPHPmDACEhoZK/XAjM3HiRDc3t/z8/CdPnhCJhYWFbDY7KCgILSmTO1Rd4jVJp9ODg4PlFNQz"
+			"VVZWAsD06dPJifb29mpqahUVFXIKChu7UKsTaZCurq5EFjUx2NraqqurEyk0Gm3GjBkcDqelpYWa"
+			"GEYlPp9/+vRpW1tb4mpIR0dHExOT3NzcgYEBlPLbb7+x2Ww0P0ZYtWqVg4MDm83u6enZtWvXkydP"
+			"Dh06RHX0Mnb69GmBQIDGIBElJaWhoSGiZgCATqdraWnV1dURKVlZWQcOHEhKSurt7X306JG5uXlM"
+			"TAw6CRyzsrKyMjIyFi1apK+vDwANDQ319fUzZszQ0tJ6zqePkSqVfj9SW1vb19f3zp079fX1RGJq"
+			"aqqWlpavry96ODg4+OCphoYGcvtGGhoaiAJdXV1SDxIAwsLCeDxeRkYGOUiUTi7W1dWVn59/9uzZ"
+			"y5cv9/b2irxIRUVFenp6ZmZmdXW11CP08vIyMjJCUSGtra1FRUVeXl7kS+0khyE5filqbW0FAJHA"
+			"aDSaoaEhm82W3XExbFitra1MJhP9ABDQ1TbUNEgulzs0NCTyiaA4htEqPz+fzWaTu0poyZqGhoaj"
+			"o+PatWv9/f2DgoJCQ0N37dpFfuKPP/4YHR09btw4Op2+fv16AKipqaE6ehlLSEhQVlb28fEhUtDp"
+			"U3Z2NpFSXl7O4XDIvwg2NjbFxcVeXl40Gs3MzGzZsmV8Pp/c0RxTkpOTnZ2dV65c+eabbyYkJKDE"
+			"xsZGALCwsHjOFxk7VSqT/SPRQBoagwSAysrKe/furVixghjdLS8vnzBhwqJFi/z9/b28vLS0tDw9"
+			"PYuLi4lXcHJymjNnjr+//9KlS42NjR0dHX/99VfpBhkUFMRkMokgBQJBSkqKtbW1m5sbUeaHH34w"
+			"NjbesWNHampqRESEiYnJqVOnUFZjY6Obm5uHh0dcXNyJEyfc3Nw8PT2H3ZZixBgMRnBw8IMHD27f"
+			"vo1SUlNTBQIBeVhXchgS4pcR8tALoqWlxePxZHpQDBvWsK0RAKhskIoQw+iTmJgIACtWrCAntre3"
+			"czictra29vZ2Lpfb29vb09MjMkiBelQI2gmrs7OTkpApUl9ff/36dW9vb/KGa++9956SktI777yT"
+			"l5fX2dlZUFDg5+dHbJaETJ48WVtbm3g4Kivn+fF4PBqN1tfXV1RUdPXqVZSI2hJ5cx/Jxk6VyqQf"
+			"uWTJEl1dXXT1LgCgi8VExvkA4PTp06WlpdXV1c3NzZaWlu7u7miNC/LJJ5+Ulpai06b169evXbsW"
+			"LQ2UFgMDA29v79zcXDTeWVxc3NzcHBoaSuw3VlNTs3nz5piYmKKiopMnT964cWP37t0pKSmDg4MA"
+			"EBER0dXVVVdXl5SUlJycXFlZqaKigi73liLUZSTXpKqqKvksXEIYkuOXOiaTCQDig8cdHR3y3S4U"
+			"G5uYTOawrREAqGmQEj4RlMUwrMTExJ1PkceoXhYDAwMpKSkWFhYzZswgEuvq6vz9/ZWVlWtrazMy"
+			"Mi5dupSXl5eRkbF27dpnvY6CrF+SLjR4hlb1ERwcHM6dO8dkMr29vdGE4fvvv6+np6ejo/Os1xmV"
+			"lfP83njjjdLS0rKyMoFAEBAQgLbnRJMb6EqAERjFVSqTfiSLxVq5cuWNGzeampoAICUlxdTUdN68"
+			"ec8qr6enFxsba2dnt337dvFcZWXlzZs3b9iwYefOnf39/VKMMywsbHBwMDMzE5721chDfW1tbQBA"
+			"3lD93XffTUtLU1ZWBgA2m21kZEQMNhgaGmZmZqJV/FI0c+ZMGxsbNLXN4XAuXrwoch4pIQzJ8Uud"
+			"qakpADx+/FgkvaWlRXxqD8NkDV2XLTJ9jFYlUtMgNTQ0NDU1h/1EUBbDsDIyMr596vLly/IKY8Qy"
+			"MzM7Oztff/11cmJaWtrAwMBnn31G9I3c3d09PT2zsrLIi+BHvfj4eAaD4e/vL5K+ePHi+vr68vLy"
+			"69evNzc3v/vuu48fP7a0tJRLkC8Le3v7r7/+msfjnTx5EgAmTZrEYrGG3fJ9jJPVfRFDQ0OFQmFa"
+			"WlpDQ8Pt27dDQkLE78tCxmAwVq1adenSJYFAMGyBkJAQDocj3bfQz89PXV0d9SDT0tJcXV1tbW2J"
+			"3BkzZjg4OISGhsbGxnZ3d4s8d82aNQUFBatXr5Z1qwoNDa2qqiorKzt//jyPxxMZ1pUQhuT4pc7W"
+			"1pbJZJaUlJATKyoq+vv7yfdUwDBqoFYn0iDv3LlDZFETQ01NDfnTJxQKS0pKTE1NdXV1qYlBXFxc"
+			"HPcptI/JywVNaosMuaH+OjqbJaClqGjp9lhQXl5+9+5dDw+PYW9eRafT7e3t3dzcNDU1y8vLBwcH"
+			"ybP82LDs7Ozg6WpmVVVVLy+vxsZGtOeUiLi4uGXLlp09e5bqEBWArPqR7u7ulpaWqampaCwtJCTk"
+			"H59iZWXV19f3rCWGaDtlNMApLWpqaoGBgRcuXLh+/Xptba1IkMrKykVFRSEhIZGRkQYGBkFBQWhH"
+			"OiQ0NDQ3N/fhw4cuLi52dna7d+8WH3iQCjREmpqampKSoq+vL3IvRwlhSI5f6tTV1RcuXHjjxg3y"
+			"unW0HBNt949hVEJDMuR11RwOJzMz097efvLkyZTFMDQ0dPr0aSLlt99+a2lpwZ+IEevu7s7IyDAy"
+			"MkK3YyCgqx/QvcoQgUBQXFxMp9NNTEyojlJO0KS2yLJRAIiPj7ewsPjpp59ESpKXSGEA8OWXX7JY"
+			"rOPHjxMpaG8HYvYgMjISADZv3tzX10d+Ymtra0RERF5eHrqB1pgjuy2FPvvsMzqdPnXqVHt7e5Es"
+			"NEggsqcdGjrmcDhCoVBbW1tki8SGhgYASEtLk26QaHkQuu9FU1PTsGUGBwfPnTsXEBBAo9Hmz59P"
+			"bG2P1NXV7dq1y8LCAg1tSjc8xM3NzcbGRkVFZePGjc8qIyEMyfFL8KLbel27do1Op7u4uFRVVQ0N"
+			"DcXHxysrK5O3+KcS3j9SQWKQ4xuxZMkSAPjuu+/6+/sbGhrQOVhSUhJlAXC5XGNjY11d3dzcXIFA"
+			"cOPGDSsrK3V19draWspioBIFGwGinwnyfuNIS0uLtra2hobG6dOnOzo67t+/v2bNGiDdnGzY+9kA"
+			"gIeHh6xjpoy1tTWNRmtsbBRJZ7PZ+vr648aNu3LlSl9fX1JSEovF8vb2JgqIf0JRdRUUFFAQtuLs"
+			"H1lZWamsrGxsbFxUVDQ0NHTz5s1JkyYxGAxys/nf//4HADNnzrx48SKPx+PxeNnZ2ZMnT2YwGKdO"
+			"nSKKybdKKSbDfuS9e/dQV/Wrr74SyRq2H7lt2zYtLS10qwnxfiS6D8Tt27elGySPx0NzHwsXLvzH"
+			"wleuXAGAgwcPimcNDg4uWbLE0NBQuuEhP/74I6rJq1evSi4pOQwJ8Q9rBB/vM2fOGBgYEGcpc+fO"
+			"ffjw4Yu+iFTgfqSCxCDHN4LL5ZIXimloaMTExFAcw927d52cnIgYrKysLl++THEMlKGgQ4B2Ec/J"
+			"yRHP+v3338lVzWQy33zzzc7OTpQ76vuRN27cAIBXX3112Nzi4uIJEyYQlbN06dLW1lYiF/cjCRcu"
+			"XDA3NycqysjIKDk5WaTMuXPnnJ2dAYBOpzMYDACYNWtWUVERucyY6kfShELh8w9eSktpaamLi0tJ"
+			"Scm0adNQSn9/v4ODg6urK5oD0tHR2blz55YtW4inhIaGFhQUPHz4EL1tciEUCrW0tD7++GPUIERE"
+			"R0dHREQMDQ1JXgkqaxLCkBy/uLiy+6EOE180gKGhodLS0u7ubisrK/I3F4bJRWNjY01NjYqKirOz"
+			"s6qqqlxiKC8vb2lp0dPTc3R0lO/3g0yN7BtDuurr6xsaGpSVle3t7Z9zv+gxQiAQlJWVdXZ2WllZ"
+			"mZmZyTuc/0cRmg0Zn8+vrKxks9l6enpTpkxBGy+Ie/To0V9//TU0NDR58mS07m7MGr6CKHb37t2P"
+			"P/64vb1dZM9YpLm5OTo6OiEhAV2JRllUOTk5gYGBP//8c1BQEAAIBILo6OiBgYHXX39dKBR6enqi"
+			"LSfRXgAPHjyIjY0NDg6m8kdCchgS4pdpVEpKSjNnzpTpITDs+ZmZmcn9V3PKlCnEnVcwmRo/fvz4"
+			"8ePlHYUiotPpjo6O8o7iJcBgMBwcHP6xmLm5OXnkciyT55mxu7u7jo6Oqqqqt7e3kZHRrVu3bGxs"
+			"iNzIyEgdHR1NTU1bW9t79+799ttvFN8McNGiRTt37gwPD580adL8+fOtrKx+/fXX7OxsBwcHGo32"
+			"008/CQQCCwuLOXPmuLm5OTs7e3l5kRcyU0ByGBLipzJIDMMwDMNGK/nMa79EeDxeXV0dh8MxMjIS"
+			"P81tb2+vr6+n0+m2trbymjKTHIbk+CVTtOkGDMMUGf7GwEYAN5uXnULMaysyJpMpYZcQfX19kRv4"
+			"yoWEMCTHj2EYhmEYNmKjdsU3hmEYhmEYJlO4H4lhGIZhGIaNBO5HYhiGYRiGYSOB+5EYhmEYhmHY"
+			"SIzkeu24svuyCAXDMAzDMAyj0r+8Xh7v+4M9E96OAcOw54e/MbARwM3mZYfntTEMwzAMw7CRwP1I"
+			"DMMwDMMwbCRwPxLDMAzDMAwbCdyPxDAMwzAMw0YC9yMxDMMwDMOwkcD9SAzDMAzDMGwkmNJ9uUOH"
+			"DlVVVW3evNna2lo8NzIysr+/f+/evSwWS7rHfSF5eXmZmZlLly719vYWzz127Njdu3fDw8OnTJlC"
+			"fWwAIBAIIiIihELhvn376HTRjn5jY+P+/fstLS0//PBDuYT3j6qqqvLz87lcrrW1tY+Pj6amplzC"
+			"EAgEOTk5LBZrwYIFcgkAAB49epSfn+/r66unpzdmY5DvG9Hf33/hwoWqqio1NTV3d3cXFxfqY0Dk"
+			"/ka81EpLS7lcrni6q6urhoYGOaWwsDA1NRUAIiMjjYyMyFl79+7du3fvlStXHB0dZRotlbhcbmlp"
+			"qXj6uHHjpk6dCgB9fX2RkZHkLD09vcmTJ3t5eRkYGBCJy5Ytu3v3bn19vawDVnwNDQ3Z2dnNzc3m"
+			"5uaLFy82MzMjsrKzs7Ozs4mHLBZr3Lhxs2bNmjNnDoPBIL+Ijo6Oj49PXFwcdXHLkVCq9u3bBwBf"
+			"fPGFeNatW7cAwN3dXbpHHIGbN28CwIIFC8SzBgcHdXV1VVVVu7q6qA+MsHTpUgAoLCwUz4qOjgaA"
+			"qKgoCsI4de+vF33K9u3baTSarq7u9OnTaTSaiYnJzZs3ZRGbBENDQydPnrS3twcAPz8/io+O1NTU"
+			"hIeHKykpAUBJScnYjEHub0RNTc2kSZMAwMnJCXUp1q9fLxAIqA9D7o2BGiP4xnhOHh4ew/5+1dfX"
+			"i5RcsmSJjo4OAHzzzTciWTt27Bh9b0FBQcGwNbNu3TpUgMPhAIC+vr6fn5+fn5+np6eNjQ0AKCkp"
+			"7d+/n3gdDw8PbW1tufwLsms2IxAbG8tkMjU1NWfOnKmlpcVisRITE4lc1IReeeUVVJkLFixAffEJ"
+			"EyacO3eO/Dpy/PWhnpT7kY8ePaLRaFOnThXP+vzzzwHg8OHD0j3iyNjY2NDp9JaWFpH0vLw8AAgO"
+			"DpZLVIT4+HgA2LRpk3jWnDlzAKCyspKCMF70452SkgIA8+bN6+7uFgqFV69eVVVVNTU1RQ+pkZCQ"
+			"gMbC0XAy9Z9kNpsdEhLCYDBUVVWtrKzk8rulCDHI/Y3g8/nOzs50Oh19vw8MDKxcuRIADhw4QFkM"
+			"ivBGUEl2HYLm5uY6ktraWkNDQxcXF5FiLS0tDAZjy5Yttra206dPF8kdlf3Ivr6+ur/76quvACA9"
+			"PR0VQP1IDw8P8rNu375taGgIAPfu3UMpuB8pFAqbm5tZLJadnR2XyxUKhW1tbWZmZlpaWn19fagA"
+			"akJpaWnEUwQCQVpa2rhx4+h0+oULF4j0MdWPlPL6SDMzs3nz5t27d6+mpkYk68yZM8rKyuirXO5C"
+			"Q0MFAkF6erpI+pkzZwAgLCxMHkH9P35+furq6qixktObmpquXbvm6upqa2srr9gkQBPxx44dU1dX"
+			"B4DZs2d/9NFHTU1NVI7to/n03Nzcq1evUnZQMi0trYqKim3btjU0NPj5+Y3ZGOT+RuTm5v7xxx9r"
+			"1qzx9fUFAGVl5aNHj2poaKAxGGpiUIQ3YnQwNja2Inn8+HFra2tAQIBIscTERD6fv3z5cn9//zt3"
+			"7lRUVDzrBcvKyo4fP56QkNDW1ibj2GVLRUXF6u8uX76srq6+cOFCCc+aPn36W2+9BQC3b98WyRII"
+			"BIWFhUePHj137tzg4KAMQ1c8vb29n3766TfffKOtrQ0A+vr6vr6+nZ2dtbW1z3oKjUbz9/dHJ6sb"
+			"Nmzg8/nir3nu3LmjR48WFRXJNno5knrP9NixYwCwZ88ecuKff/4JitQ9/+uvvwBg0aJF5EQej2dg"
+			"YDBu3LjBwUF5BUZYvXo1AFy/fp2c+P333wOFAyovdJrY3t4OALNnzyYnlpWVAUBAQIC0Q/tn6Cxc"
+			"vk3u/fffB3mPf8g9Bnm9EZs3bwaA3NxcciI6j/3jjz8oDkaoAG8EBSgbWNq0aRMAlJWViaTPnDlT"
+			"R0dncHDw2rVrABAZGUnORYNJZ8+eXbx4MQCoqKgAgJ6eXk1NDTVhU6ClpYVOp69cuZJIGXY8UigU"
+			"fvrppwCQnJyMHqLxyEuXLtnZ2TGZTCaTCQCurq4DAwOyjllxxiPFoXOVtrY29FB8PJKwZMkSALh4"
+			"8SJ6CADLly8/fPiwrq4uamkAsHnzZupCp5D0r9desWIFi8VKTk4mJ6JxvtDQUKkfbmQmTpzo5uaW"
+			"n5//5MkTIrGwsJDNZgcFBaGVTPKF6kq8Gul0enBwsJyCkqSyshIApk+fTk60t7dXU1OTMCqAYTKC"
+			"Wp1Ig3R1dSWysJcUn88/ffq0ra2tyKWQ1dXVv//+u4+Pj5KS0qxZs0xMTOLj44ViY8+rVq1ycHBg"
+			"s9k9PT27du168uTJoUOHKAxftk6fPi0QCAIDAyUXu3Xr1vHjxy0sLFCXGuns7AwMDPzggw+6u7s7"
+			"OzuXLl1669atnJwcGYesuLKysjIyMhYtWqSvr/+PhdF1hOg6EOLpBw4cSEpK6u3tffTokbm5eUxM"
+			"DOrWjzLS70dqa2v7+vreuXOHfOVXamqqlpYWmmBSEGFhYTweLyMjg0hBV/nJfVIb8fLyMjIyQiEh"
+			"ra2tRUVFXl5exsbGcgzsWVpbWwFAJDYajWZoaMhms+UUFDZ2tba2MplMkR8AdLUNbpAvtfz8fDab"
+			"Ld5VOnXqFACgASQ6ne7n51dfX3/lyhWRYj/++GN0dDRa0LZ+/XoAEF+F9fJKSEhQVlb28fERSb93"
+			"756/v7+/v7+np6etra23t3dQUNC1a9fIV7srKSkVFhaGh4ezWCxVVdU1a9bA6Kqc55ecnOzs7Lxy"
+			"5co333wzISHheZ5iaWkJAI8fPyZSbGxsiouLvby8aDSamZnZsmXL+Hx+XV2drIKWH5nsH4nG0tAY"
+			"JABUVlbeu3dvxYoVxOju4ODgg6caGhoGBgZEXqGhoYEo0NXVJYsgg4KCmEwmEaRAIEhJSbG2tnZz"
+			"cyMX6+rqys/PP3v27OXLl3t7e0VepKKiIj09PTMzs7q6WrrhMRiM4ODgBw8eEOtXUlNTBQIBeUy3"
+			"s7OTqKWmpiaRlRn/WMmygFZGkmlpafF4PAoOjWEihm2NAIAb5EstMTERAFasWEFOFAqFcXFxqqqq"
+			"aLMLAEAdTdS5JENj0gjag6mzs1OmAVOmvr7++vXr3t7e4rutEcsoHR0dnZycVFRUTp48uXv37u7u"
+			"bqKMqqqqg4MD8XCUVc4L4fF4NBqtr6+vqKjoOVd4KysrAwD5V3jy5MlonSUyiutTyvtHIkuWLNHV"
+			"1U1JSfnoo48AIC0tDf4+zldeXu7i4mJjY6Oqqtrb21tfX//aa6/t3r171qxZqICTk5O6urqBgcHg"
+			"4GB9fb21tfWnn36KlgxKi4GBgbe3d25ubldXl6amZnFxcXNzc1RUFI1GI8r88MMPn332mYuLi7W1"
+			"dXV1dUVFRUxMDPpHGhsbV6xYUVtbO2/ePKFQmJ+f7+LikpKSgrackIrQ0NDvvvsuJSVlxowZAJCW"
+			"lqaqqko+Cz9+/PhHH32E9kJrb2/ncDgBAQH79u0zMTGB56hk6ULracQ7/R0dHfLdLhQbm5hM5rCt"
+			"EQDGeINMTExEq1AAwM3NjTyzqfgGBgZSUlIsLCzQtyLh+vXrtbW1zs7OxDzs0NAQk8lMTk7+4Ycf"
+			"nvWOK8ISJilCI2filx8BwKRJk7799lviIY/H2759+549e9ra2pKSkoZ9tVFWOS/kjTfeeOONNyoq"
+			"Kvz8/AICAn7//fdp06ZJfgqa5ZCwX/Iork+ZjEeyWKyVK1feuHGjqakJAFJSUkxNTefNmydS7PTp"
+			"06WlpdXV1c3NzZaWlu7u7uS1BZ988klpaWl5eTmHw1m/fv3atf2jEsIAACAASURBVGvRVSZSFBYW"
+			"Njg4mJmZiYKEv6/grKmp2bx5c0xMTFFR0cmTJ2/cuLF79+6UlBR0CVtERERXV1ddXV1SUlJycnJl"
+			"ZaWKigraNkhaZs6caWNjg6a2ORzOxYsX/fz8RDbd1dTULC0tLS0tffjw4e3bt6uqqmbPno1+LBHJ"
+			"lSxFpqam8PdRfaSlpUUxJ+Kx0c3U1FQgEIhMYbe0tIDY6ouxJiMj49unLl++LO9wXkxmZmZnZ+fr"
+			"r78uko7GHWtra9c+tX79eiaTyeVys7Ky5BGpHMTHxzMYDH9//38syWQyv/rqK0tLyzNnzshoxm8U"
+			"sLe3//rrr3k83smTJ/+xMNoNHm2XO9bI6r6IoaGhQqEwLS2toaHh9u3bISEh4rdm+f/au/Owpo61"
+			"AeATAoSAshZRRIqUEhCV4lZcUoEKRZFGpCoN2OpTpNr6oFcetaiot1oXQPnwitUW7L0ugGiICyCI"
+			"LFq0YEWggGwtCCIoiGEzBAjJ98c8zZMmGDAmOQHf318yc07yOjlJJjNz3hExNjaOjY21s7PbvXu3"
+			"dK22tnZwcPD69ev37t3L4/EUGCROr4N7kGw2WyKfDs4HIb4xz7fffstms/HwdWtrq5mZmWjibNy4"
+			"campqQrPauTv719VVVVeXp6SksLn82Wv3aTRaMnJyU1NTadOnZKuld3Ib45Go2lqahYVFYkXVlRU"
+			"8Hg8vK0CAKqErzqJC/LBgweiqrfW+fPn2/928OBBosN5PXhSW2LIrb+/PykpSV9fv7W1tV1MSkoK"
+			"Qujs2bPExKpaDx8+LC0tXbhw4TA3TMKL14VCIfQjZbCzs0PDWFH98uXLixcvamlpEbh9GoGU1Y+k"
+			"0+mWlpbJycl4OI3JZMo+nkwmr1q1Kjc3VyAQDHoAk8nkcDiDbgAlN11d3eXLl1+/fh3PiUgEOXPm"
+			"TAcHB39//9jYWPFFJNgXX3yRk5OzevVqxYYkAY+PJicns1gsExOTQTdyFGdhYfHRRx9lZ2cPWjtk"
+			"I78JnLEsPz9ffF02HiSAzHlA9fCojHgfgsPhpKam2tvbv//++8TFBeTX3d197do1MzMzvB2DyPXr"
+			"19va2ry8vCTmr11cXExNTVNTU0flTbIS8KS2xLJRGYqKih48eGBqaiqxe+TbbP/+/RQK5fTp06IS"
+			"nNtB9gxGf39/YGBga2trYGDg2znXoax+JIlEYjKZubm5cXFx9vb2w9nW1srKqqenZ9BNVHEtQghP"
+			"lCuQv7//y5cvN2zYIJ1PR1tbOy8vj8lkhoaGmpqarly58vr16+In3rhx4/Hjx05OTnZ2dgcOHJCe"
+			"0n1zOD/RuXPnMjIyhpmQyMrKSkYryW7kN4RXl65ataq6uprP5yckJERGRk6fPn3IJBQAKNycOXMW"
+			"L1587ty5Y8eO9fb2Pn782M/P7+XLl//+97+JDg3Iic1m83i8ZcuWScxu4Z0OpLtQZDJ5+fLlfX19"
+			"EgnURqX4+HicE3vQ2vb29tzc3Nzc3MzMzAsXLgQHB9PpdIRQZGSkxMbQbzM8o7hz5847d+7w+fzf"
+			"f/89JCSETCZLpCwsKyvDjZmenh4ZGeno6JiYmOjm5hYREUFQ4ARTVj8SIRQQECAQCMrKyoaZSQcP"
+			"kr1q+lt2rdxwep2SkpKPP/4Y354iztDQ8PDhw01NTUlJSXw+38vLy83NTTS37u7unpubW1dXFxAQ"
+			"cPLkSRsbG/E0PYoSEBBQXV3N4/GG34wyWklJzYjNnTs3KSmpsbGRRqNpaWkxmUxnZ+fU1FR8Cw4A"
+			"KpaQkLBs2bJNmzbp6OhYWlrevXs3JiZGTbbUAnLAG8ZK/C7t6Oi4evWqnp6e6E5tcfjllr5re5Qp"
+			"KCiora11dnbG69SllZSUuLq6urq6enh4BAQEpKSk+Pr63r17Fyf3ARiNRrty5YqmpuaCBQu0tLTm"
+			"zJnT1dWVmJgocZNNWFgYbswlS5aEh4dbW1snJCRkZmZKJ4h4WxCS/RwvWpLY2mHXrl36+voCgUAo"
+			"FBoYGEjs2nLz5k2EUGFhoUoD/SeciuzEiRPSVX19fYsXL8bLTVQmKipKekfUBQsWeHt7C4fRyEOS"
+			"b5uBvr6+e/fuZWdn19bWynE6AIrV2NiYk5Pz22+/cblcomMZ5dR5YxKgttTtsuHz+WVlZTk5OSUl"
+			"Jf39/USHMwKoy0ARj8eLj4/39PQUT7sj7vTp0xMmTHB0dFRxYOLmz58/ZswYnHBbAl5gm5GRIXs4"
+			"UNkqKyvv3r17/PjxQWuHbGSF0NLSmj17tvIeH4DXMnHixIkTJxIdBQBgZCCTyeJ5NMGQCOvxiCst"
+			"LWUwGG1tbfv27ZOubW5uDgkJSUhIOHr0qCpXcmRkZOjp6YlyawkEgoiIiN7e3s8++0woFLq5ubm4"
+			"uOBNpRFCjx49io2N9fPzI6oTyefzMzMzvby8HB0d165dK32A7EYGAAAAAHhdRPYj6XS6oaEhlUr1"
+			"8PAwMzO7f/++ra2tqDY0NNTQ0HDs2LE0Gq2srOzmzZsq3lf6k08+2bt3b1BQkI2Njaurq5WV1dmz"
+			"Z9PT0x0cHEgk0s8//ywQCCZNmjR//nxnZ2dHR8dFixb9/PPPqowQIdTR0WFoaGhoaDhmzJhvvvlm"
+			"5cqVubm5on2D0FCNDAAAAAAgN5JQaht7II7P59fV1XE4HDMzs3fffVeitq2trb6+XkNDg0ajUalU"
+			"QiJUnvPlf/k7vEd0FACAkQE+MYAc4LIZ6dRlfaTa0tTUlJFtzsTExMTERJXxAAAAAACoCbVYHwkA"
+			"AAAAAEYc6EcCAAAAAAB5QD8SAAAAAADIA/qRAAAAAABAHvLcr32+/C9lhAIAAAAAAFTpDe+Xh7w/"
+			"4JUgHQMAYPjgEwPIAS6bkQ7mtQEAAAAAgDygHwkAAAAAAOQB/UgAAAAAACAP6EcCAAAAAAB5QD8S"
+			"AAAAAADIA/qRAAAAAABAHpqKfbgff/yxqqoqODjY2tpaujY0NJTH4x06dIhCoSj2eYevrq4uOjra"
+			"1tb2m2++ka69desWm812c3P79NNPVR+biEAg2L59u1AoDA8P19CQ7Os/efIkIiLC0tJyy5YthIQn"
+			"W1VVVVZWVnt7u7W1tZeX19ixYwkJQyAQZGRkUCgUNzc3QgJACDU2NmZlZXl7exsbG7+1MajDC9Hd"
+			"3Z2amjpt2rQpU6ao/tlbW1tTU1ObmppMTU0XL15sYWGh+hhGtPb29uLiYunyd955Z+rUqeIl+fn5"
+			"8fHx9+/f53K5RkZGLi4uX3/99fjx40UHGBoaenl5nT9/XulBq0pxcXF7e7t0+axZs8aMGYMQSk9P"
+			"T09PF5VTKJR33nnnww8/nD9/PplMFpXn5eUtXbr04MGDGzZsUEHY6mxgYODGjRslJSUaGhpOTk4f"
+			"f/yx+LewRHuKs7Gx2bhxI0Jo6dKlpaWl9fX1KoqYcEKFCg8PRwh9//330lX3799HCNHpdMU+4+vi"
+			"8XhGRkZ6enpcLle6dunSpQihrKws1QcmYcmSJQih27dvS1dFRkYihMLCwpQdw7myP1/3lN27d5NI"
+			"JCMjoxkzZpBIpAkTJty7d08ZscnQ399/5swZe3t7hBCDwVDxs2M1NTVBQUFaWloIoaKiorczBnV4"
+			"ITgczv79+01MTBBCUVFRqg/g6tWrY8eO1dLSmjVrlp6eHoVCiY2NVX0YqiHHJ8Zw5OTkDPrltXbt"
+			"WtExvb29X331FULIwcFh165dUVFRX3/9NZVK1dfXz8jIEB1G4KWoJAsXLhy0cerr6/EBe/bsQQjN"
+			"mTOHwWAwGAw3NzdTU1OE0OTJk69evSp6HNzIhLxHlHTZyKetrW3mzJkIIRqNhn92LliwoKurS3SA"
+			"RHuK27lzJz5m4cKFBgYGBP0PCKDgfmRjYyOJRJo6dap01c6dOxFCJ0+eVOwzyiEoKAghdOnSJYny"
+			"rq4uCoVibm4+MDBASGDi4uPjEUIbN26Urpo/fz5CqLKyUtkxvO7bm8ViIYRcXFy6u7uFQuGdO3eo"
+			"VKq5uTn+UzUSEhLwWDj+CFD9d0ZrayuTySSTyVQq1crKipA+nDrEQPgLIRQKd+zYYWBgQCKR7Ozs"
+			"CPmObGho0NXVnTBhQk1NjVAobG5uptFoGhoa9+/fV3EkqqGkDkFPT0/dP/3www8IoStXroiOwZ3I"
+			"HTt2iH96l5SUGBgY6Orq1tXV4ZLR149sbm4Wb5na2tpx48Y5OTmJDsD9HjabLSoRCARsNvudd97R"
+			"0NC4fv06LoR+JLZp0yaE0KlTp/Cfhw4dQggdOHBAdIB0e0p72/qRCl4fOXHiRBcXl7KyspqaGomq"
+			"S5cuaWtrr1ixQrHPKAd/f3+EUHJyskR5SkpKb28vk8mUnkpWPQaDoaenhy9W8fKmpqa7d+/OmjWL"
+			"RqMRFdur4Fn4uLg4PT09hNC8efNCQkKamppUOYuE59Nv3Lhx584dlT2pOH19/YqKil27djU0NDAY"
+			"jLc2BsJfCITQ48ePfX19y8vLDx48SEgAMTExXC734MGDNjY2CKHx48fHxMQIBIIjR44QEs8IpaOj"
+			"Y/VPt27d0tPTc3d3xwfk5+fHxcUtWrRo//794p/e06dPDw0NNTY2TktLk3hMLpd79erVn376KS8v"
+			"T3X/EyUYP368eMs8ffq0paXFx8dHxikkEmnZsmV4MHL9+vUDAwMSBzx9+jQhISEuLq66ulqZsauj"
+			"6dOnb9++Hf8sQQitWbMGIVRUVCTfowkEgtu3b//0009Xr17t6+tTVJBqR+E907i4OITQwYMHxQv/"
+			"+OMPpDY/BAUCgaWlpb6+Po/HEy9fvnw5Im4WUtrq1asRQr/99pt44bFjx5CqfjW+1s/EtrY2hNC8"
+			"efPEC8vLyxFCPj4+ig5taBwOh/BLDv+0JfaKIjwGdXgh2Gy2yt414qZPn66lpSU+Hi8QCMaNG2dk"
+			"ZKTiSFRDNQNLz54909DQWLFihajkyy+/RAilp6cPeS5C6NNPPz158qSRkZGOjg7+EgwODlZmvCqF"
+			"1+eVl5eLSmSMny1evBghlJ2dLfx7PPKHH37YtGkTnspACGloaFy8eFHZMavVeKSEkpIS9M+JweGP"
+			"R+bm5trZ2WlqampqaiKEZs2a1dvbq/yQCaD4gTdfX18KhXLx4kXxwkuXLqG/BwIJRyKRmExmZ2fn"
+			"jRs3RIVcLjctLW3KlCkffPABgbGJw80l3ZIaGhp+fn4EBfVKlZWVCKEZM2aIF9rb2+vq6lZUVBAU"
+			"FABEqqiooNFoeHgeI5FIM2fO5HA4z549IzCwEe3ChQsCgQD/7Mdu375NJpPpdPpwTk9LS4uKikpK"
+			"SuJyuY2NjRYWFjExMfjXzkg3MDBw4cIF0cK+IeFb3/CtC9iePXtqamrKysq4XG5OTo5QKCRqLF8d"
+			"dHV1bdu2Tb4v3M7OzuXLl//rX//q7u7u7OxcsmTJ/fv3MzIylBEn4RTfjzQwMPD29n7w4IH4zUrJ"
+			"ycn6+vre3t4Kfzr5BAQEoH9ObV+/fp3H4+FyNbFo0SIzMzPxIFtaWvLy8hYtWiR+B6KaaGlpQQhJ"
+			"BEYikcaNG9fa2kpQUAAQpr29vb+/X/qtamZmhhCCN4XcEhIStLW1vby8RCVPnjwxMTHR1dUdzum2"
+			"trYFBQWLFi0ikUgTJ05cunTpwMBAXV2d0uJVnaysrNbWVvEetmyWlpYIoadPn4pK/Pz8UlJS8Hpi"
+			"FxcXGo0mvUTtLeHl5WVhYdHU1MRisfA9CeKOHTu25p+4XK74AVpaWrdv3w4KCqJQKFQq9YsvvkAI"
+			"jdbGVMpCQDyQhscgEUKVlZVlZWW+vr6ieYS+vr5Hf2toaOjt7ZV4hIaGBtEBXV1dCo/QwcHB0dHx"
+			"ypUr/f39uAQP+zGZTNExLS0tohikP/Q7OztFtU1NTdJLTN4cmUz28/N79OhRYWEhLklOThYIBNLD"
+			"uhUVFVeuXElNTZVeztLV1ZWVlXX58uVbt25JXOjKID70gunr6/P5fGU/LwDqadB3BEII3hTyqa+v"
+			"/+233zw8PMQTivX19Ym+XIb0/vvvGxgYiP7E+bA6OzsVGychEhMTEUK+vr7DPF5bWxshJP7lNXPm"
+			"TBKJJPrT2NhYGd+/I0JfX5+WllZNTc2VK1fkuDyoVKqDg4Poz9F0mUlTcP5IbPHixUZGRiwWKyQk"
+			"BCGEFyeJD/U9fPjQycnJ1taWSqVyudz6+voFCxYcOHDgww8/xAdMnz5dT0/P1NS0r6+vvr7e2tp6"
+			"27ZteL2govj7+2/bti0nJ8fDw6O3tzctLY1Op7/77ruiA4KCgnJyciZPniwQCJ48eaKtrR0YGBgW"
+			"Fobfe6dPnw4JCZk2bRpCqK2tjcPh+Pj4hIeHT5gwQbFBRkdHs1gsnImAzWZTqVTxn5tPnjzx9fWt"
+			"ra11cXERCoVZWVlOTk4sFsvQ0BAh9J///Oe7775zcnKytraurq6uqKiIiYlR0pgrXgIi/aHT0dFB"
+			"YLpQAIgi4x2BECLwTZGYmIhXoSCEnJ2dPT09iYpEDgkJCQghiftIjI2N8fpsOeDEWKNAb28vi8Wa"
+			"NGkS/rIYDjw+IiPF76hpHDlkZmb29fUdPnx49+7d3d3dEgvMgoODly1bNvxHG90tqZTxSAqFsmLF"
+			"ivz8/KamJoQQi8UyNzd3cXGROOzChQvFxcXV1dXNzc2WlpZ0Ol18ocbWrVuLi4sfPnzI4XDWrVu3"
+			"Zs0afIuJojCZTBKJhGeNMzMzu7q6pMf5XF1di4uL//jjj+fPn585c+bkyZPi6yTGjh1bXFxcXFz8"
+			"+PHjwsLCqqqqefPm4S8JRZk9e7atrS0OksPhZGdnMxgMnF0W2759e1dXV11dXVJS0sWLFysrK3V0"
+			"dDIzMxFCNTU1wcHBMTExeXl5Z86cyc/PP3DgAIvFUtJdY+bm5uifUyTYs2fP1HAWHgBlGzNmzNix"
+			"Ywd9RyCpFSCqdO3atf/7261bt4gKQz7x8fFkMlniK3zq1KkvX778888/iYpKHaSmpnZ2dn722WfD"
+			"PwVnd8cZXoE0bW3tsLCwGTNmsFisQZO9A0xZCW78/f2FQiGbzW5oaCgsLJSdTMfY2Dg2NtbOzm73"
+			"7t3Stdra2sHBwevXr9+7dy+Px1NUhDhFEZvNxsm0ZOckIpFI7u7uJ06cYLPZ9+7dkz6ARqMlJyc3"
+			"NTWdOnVKURFi/v7+VVVV5eXlKSkpfD5fYjSxtbXVzMxMNHc2bty41NRU/B95/vw5Qkh8Y6Fvv/0W"
+			"/08VGyFGo9E0NTUl8iNUVFTweDyJPScAeEtMnTq1pqamu7tbVCIUCouKiszNzY2MjIiK6vz58+1/"
+			"G1l3UTx8+LC0tHThwoUSmzPhlfdJSUnSp1RVVbm4uOAsgKMbntSWnfFH3MuXLy9evKilpUXgRlMj"
+			"gp2dnfDvhCRgUMrqR9LpdEtLy+TkZDyWJr7ucFBkMnnVqlW5ubkCgWDQA5hMJofDGXR3LLkFBAS0"
+			"tLTcvn378uXLnp6eQ24c5+Pjo6Ojk52dPWithYXFRx999KpauYmyXbJYLBMTEw8PD/HaL774Iicn"
+			"Z/Xq1dItM3PmTAcHB39//9jYWPFvMiXB6dzy8/PFlxKfO3cOIURUCkMAiLVs2bL+/v4LFy6ISm7e"
+			"vPns2TN4R8gHT2pLr/8LCgoyMTE5fPiwxJDkwMDA5s2bb926hTc0GsW6u7uvXbtmZmYmfUfIoPr7"
+			"+wMDA1tbWwMDA2G+SITL5Zqamk6ePFl8zWhFRYWGhgbeBAgMSln9SJxbJzc3Ny4uzt7e3snJachT"
+			"rKysenp6XjV6jLflwBPlioJTFG3evPnFixfDyUmkqamJb+B61QFWVlaKjRAh9N577zk7O587dy4j"
+			"I2PlypUSyyz8/f1v3Ljx+PFjJycnOzu7AwcOiObRtLW18/LymExmaGioqanpypUrr1+/rtjYJISF"
+			"hZFIpFWrVlVXV/P5/ISEhMjIyOnTpw///kEARhO8ufPWrVszMzOFQmFBQUFQUJCent7WrVuJDm1E"
+			"io+Pxzm0Jcr19fUvXrw4MDBAp9PPnTv38uVLhFBZWZmXl1d6evqGDRsCAwOJiFd12Gw2j8dbtmzZ"
+			"q+b9ysrKcnNzc3Nz09PTIyMjHR0dExMT3dzcIiIiVByqOtPV1fXy8nr06NHmzZs5HE57e/vu3buL"
+			"iop8fHzw7XEidXV1xVJKS0uJipxYSty4JSAgQCAQlJWVDfPGDjwS+aq3gexa+eAURSUlJcPPSSQQ"
+			"CGTEILtWbgEBAdXV1a9KS+Tu7p6bm1tXVxcQEHDy5EkbGxtRqiBDQ8PDhw83NTUlJSXx+XwvLy83"
+			"NzcFrg2QMHfu3KSkpMbGRhqNpqWlxWQynZ2dU1NT8Q0HALxtDAwMMjMzJ02a5OHhoaGh4ezsjBBK"
+			"S0ubPHky0aGNPAUFBbW1tc7OzngptgRXV9eCgoIZM2Z8+eWXY8aMoVAo06ZNq6ysjI2NPXHihPg9"
+			"yKMS3kdXxi/2sLAwV1dXV1fXJUuWhIeHW1tbJyQkZGZmSucTeMudOHEiICAgJibG2NjYyMho3759"
+			"y5cvj42NlThsy5YtTlKGmcF0FCIk+zleRSexx8auXbv09fUFAoFQKDQwMJDYfOLmzZsIocLCQpUF"
+			"iXdeFy/p6enR1NQ8cuSIUCiMioqS3kBzwYIF3t7eKotQWl9f3+LFi8eNGzdo7a+//ooQOnHixDAf"
+			"Tb5tBvr6+u7du5ednV1bWyvH6QCMPuXl5dnZ2cXFxeK7P48+6rAxCYfDuXPnTnp6eklJyehu7VFD"
+			"HS4bCc+fP8/Ly/v111+fPXtGdCwjgLoMFPF4vPj4eE9Pz1f9cDx9+vSECRMcHR1VHJi4s2fP8vl8"
+			"vJeUtMrKyrt37x4/flzFUYnDi6YzMjIGHRmdP3/+mDFjcMJwpcYwe/ZspT4FACPLlClThrnFCHhD"
+			"hoaG8+bNIzoKMLKZmJgMc6UpQEqd1x6+0tJSBoPR1ta2b98+6drm5uaQkJCEhISjR4+SyWTVh4cQ"
+			"6u7ujo2N3bRp04YNG6SzJPD5/MzMTC8vL0dHx7Vr16osKqFQ6Obm5uLiIrqV7NGjR7GxsX5+fhoa"
+			"GhkZGXp6eqJ7GAUCQURERG9v72slhgAAAAAAeBUixyPpdDqZTO7t7TU0NHR3d79//76NjY2oNjQ0"
+			"dO/evQMDAyQSae7cuTdv3lR9eoLU1FSc0Bsnr4mKigoKChLVdnR0iGonTZq0cuXK0NDQ4W+r8OZI"
+			"JNLPP/+8du3aSZMmOTk5DQwMVFRUrF69Ojw8HCH0ySef7N27NygoaMeOHZMmTfrrr78MDAzS09PF"
+			"k+wDAAAAAMiNJBQKiY4BvKm2trb6+noNDQ0ajUalUsWr+Hx+XV0dh8MxMzMT361nOM6X/+Xv8J5C"
+			"IwUAjFrwiQHkAJfNSKcu6yPBmzAxMXlVgjRNTc33339fxfEAAAAA4G2gFusjAQAAAADAiAP9SAAA"
+			"AAAAIA/oRwIAAAAAAHlAPxIAAAAAAMhDnvu1z5f/pYxQAAAAAACAKr3h/fKQ9we8EqRjAAAMH3xi"
+			"ADnAZTPSwbw2AAAAAACQB/QjAQAAAACAPKAfCQAAAAAA5AH9SAAAAAAAIA/oRwIAAAAAAHlAPxIA"
+			"AAAAAMhDU7EP9+OPP1ZVVQUHB1tbW0vXhoaG8ni8Q4cOUSgUxT7v8NXV1UVHR9va2n7zzTfStbdu"
+			"3WKz2W5ubp9++qnqY8MEAsH27duFQmF4eLiGhmRH/8mTJxEREZaWllu2bCEkvCFVVVVlZWW1t7db"
+			"W1t7eXmNHTuWkDAEAkFGRgaFQnFzcyMkAIRQY2NjVlaWt7e3sbHxWxuDOrwQ3d3dqamp06ZNmzJl"
+			"ClExEP5CjGjFxcXt7e3S5bNmzRozZgxCKD09PT09fdBzbWxsNm7ciBA6dOjQoUOHfv3112nTpik1"
+			"WhUbsnHu3bsXHx8/6LlfffXVtGnTRmvLyK2hoSE9Pb25udnCwsLT03PixImiqhcvXnz//feDnrVw"
+			"4UIfH5+8vLylS5cePHhww4YNqoqXYAruR3Z3d0dHR5uYmISFhUlUFRYWHjp0iE6nE9iJRAiZm5uf"
+			"OXOmr69v7dq1VCpVojYyMjIlJYXATiRCSEND4+HDh2lpaQwGg06nS9QmJiZGR0dLN6+a2LNnz759"
+			"+wwNDSdPnlxUVDR+/PgrV67Mnj1blTHw+fyEhISDBw9WVFQwGAxCui9//vlnRETEL7/80t/fX1RU"
+			"REjXgfAY1OGFaG9vj4mJiYqKamtri4qKIqQfSfgLMQps3rz51q1b0uX19fW4q5Sfnx8dHT1nzpwJ"
+			"EyZIHIMPQAjxeLyOjo6BgQFlR6tiQzbOw4cPo6Ojp06d+t57kmkauVwuGr0tI5+4uLj169dTqVQ7"
+			"O7uqqqpvv/32f//736pVq3BtZ2dndHT0+PHjP/zwQ4kTcS+cz+d3dHT09vaqOm4CCRWqsbGRRCJN"
+			"nTpVumrnzp0IoZMnTyr2GeUQFBSEELp06ZJEeVdXF4VCMTc3HxgYICQwEfzbcePGjdJV8+fPRwhV"
+			"VlaqIIxzZX++1vEsFgsh5OLi0t3dLRQK79y5Q6VSzc3N8Z+qkZCQgMfCcY+BwWCo7Kmx1tZWJpNJ"
+			"JpOpVKqVlRVCqKio6C2MgfAXQigU7tixw8DAgEQi2dnZIYSioqJUHIA6vBCq9LqfGMPX3NxcJ6a2"
+			"tnbcuHFOTk6iA/bs2YMQYrPZMh4EHzP6XoIhG+eXX36Rff0T2zLKu2zk0NzcTKFQ7Ozs2tvbhULh"
+			"8+fPJ06cqK+v39PTgw+oq6uT/YGWk5NDyKcNgRS8PnLixIkuLi5lZWU1NTUSVZcuXdLW1l6xYoVi"
+			"n1EO/v7+CKHk5GSJ8pSUlN7eXiaTKT2brGIMBkNPTw9/JoqXNzU13b17d9asWTQajajYZMAT8XFx"
+			"cXp6egihefPmhYSENDU1nT9/XmUx4Pn0Gzdu3LlzR2VPKk5fX7+iomLXrl0NDQ0MBuOtjYHwFwIh"
+			"9PjxY19f3/Ly8oMHDxISgDq8EKPD+PHjrcQ8ffq0paXFjyo0aAAACnBJREFUx8dH7gcsLy8/ffp0"
+			"QkLC8+fPFRgnIRTbOKOpZeTA5XK3bdt29OhRAwMDhJCJiYm3t3dnZ2dtba0cj/b06dOEhIS4uLjq"
+			"6mpFR6pGFDyvjRAKCAjIyclhsVjfffedqLC0tLSqqorBYKjDnA6dTre0tMS9RvFJ9osXL6K/e5nE"
+			"0tXVXb58+dmzZwsKCpydnUXlLBZLKBSqQ4TSXrx4UVBQMG/ePPGlsZ9//vn+/fvT09PxGLAKrF+/"
+			"fv369QihQRcMqYC2tvaDBw8IeWq1ioHwFwIhdObMGfyPqqoqQgJQhxdiVMIzNr6+vnKcW19fHxoa"
+			"mp6erqOjw+PxjI2NCwoKbGxsFB0jYeRunFHfMsNhbW0tsfzx2bNnCCEzM7PXehwul7t58+bjx49r"
+			"a2v39PRoaGhcuHDhs88+U2SsakPxA2++vr4UCgX3yUQuXbqE1KOLhhAikUhMJrOzs/PGjRuiQi6X"
+			"m5aWNmXKlA8++IDA2ERwW0k3o4aGhp+fH0FByVJZWYkQmjFjhnihvb29rq5uRUUFQUEBAEabgYGB"
+			"Cxcu0Gg0+Va7rlq1ysHBobW19eXLl/v27Xvx4sWPP/6o8CCJ8iaNM7pbRj5paWnXrl375JNPTExM"
+			"XuvEPXv21NTUlJWVcbncnJwcoVBI1KyICih+PNLAwMDb2/vSpUv19fXvvvsuLkxOTtbX1/f29lb4"
+			"08knICDg0KFDycnJopCuX7/O4/ECAgKIDUxk0aJFZmZmycnJR44cwSUtLS15eXmLFi0aP348sbEN"
+			"qqWlBSEkERuJRBo3blxraytBQQEARpusrKzW1tbAwEDpqmPHjl2+fFm85MSJE7q6uuIlx48fF527"
+			"bt26sLAw6VVYI5eMxomPjy8uLhb9aWlpKTHwNrpb5nVdvHhx//79f/7555dffhkRESFR++DBgzVr"
+			"1oiXSFxpfn5+Z86cIZFICCEXFxcajTaKG1MpCwHxWBoeg0QIVVZWlpWV+fr66ujo4JK+vr5Hf2to"
+			"aJC+s6mhoUF0QFdXl8IjdHBwcHR0vHLlSn9/Py7BI39MJlN0TEtLiygG6Z5QZ2enqLapqUnhd7qR"
+			"yWQ/P79Hjx4VFhbikuTkZIFAID6mKzuGIRtZGfDKSHH6+vp8Pl8FTw0AeBskJiYieSe1EUKzZs0S"
+			"/Ruvs+rs7FRIYOrgTRpndLfM6+Lz+SQSqaenJy8vT45F3jNnzsSdSMzY2FgZPRk1ofjxSITQ4sWL"
+			"jYyMWCxWSEgIQojNZiOExIf6Hj586OTkZGtrS6VSuVxufX39ggULDhw4ILqRfvr06Xp6eqampn19"
+			"ffX19dbW1tu2bVu9erUCg/T399+2bVtOTo6Hh0dvb29aWhqdThcNoCKEgoKCcnJyJk+eLBAInjx5"
+			"oq2tHRgYGBYWpq2tjRA6ffp0SEgIvs+/ra2Nw+H4+PiEh4dLZ514kwijo6NZLNbMmTMRQmw2m0ql"
+			"Ll++XHSA7BiGbGTF0tTURAhJv1U6OjqIzfQEABCXmJiIV6EghJydnT09PYmN57X09vayWKxJkybh"
+			"T0UJwcHBy5YtG/6jaWlpKS404sluHCaTuXnz5mE+1ChrGTl8/vnnn3/+Oc5Z5uPj8/vvv4uveZsx"
+			"Y8Z///vf4T/a6G5PpYxHUiiUFStW5OfnNzU1IYRYLJa5ubmLi4vEYRcuXCguLq6urm5ubra0tKTT"
+			"6ffv3xfVbt26tbi4+OHDhxwOZ926dWvWrDl27JgCg2QymSQSCd+1nZmZ2dXVJb1809XVtbi4+I8/"
+			"/nj+/PmZM2dOnjwpvjZx7NixxcXFxcXFjx8/LiwsrKqqmjdvXkdHh6IinD17tq2tLY6Qw+FkZ2cz"
+			"GAxRLrRhxiC7kRXI3NwcIfT06VOJ8mfPnqnnRDwAb6dr1679398GzTuozlJTUzs7O0fr/QpvCBpH"
+			"4ezt7Y8cOcLn80U37QFpykpw4+/vLxQK2Wx2Q0NDYWGh7GQ6xsbGsbGxdnZ2u3fvlq7V1tYODg5e"
+			"v3793r17eTyeoiLEKYrYbLZAIGCz2bJzEpFIJHd39xMnTrDZ7Hv37kkfQKPRkpOTm5qaTp06pagI"
+			"EUL+/v5VVVXl5eUpKSl8Pl/28k3ZMchu5DdHo9E0NTWLiorECysqKng83tSpU5XxjAAAOZw/f779"
+			"byNu7T+et32TjD+jGDSOMuDss7DKXwZl9SNxbp3k5GQ8nCa+7nBQZDJ51apVubm5AoFg0AOYTCaH"
+			"wxFfJvzmAgICWlpabt++ffnyZU9PzyFzEvn4+Ojo6GRnZw9aa2Fh8dFHH72qVj6iVJcsFsvExMTD"
+			"w0P28bJjGLKR34Senp67u3t+fr74auJz584hhCBzHgDgzXV3d1+7ds3MzAxvxwDEQeMoxP79+ykU"
+			"yunTp0UlON8IzKrJoKx+JM6tk5ubGxcXZ29v7+TkNOQpVlZWPT09r8o2h3eDwBPlioJTFG3evPnF"
+			"ixfDyUmkqalpYWEhIwYrKyvFRvjee+85OzufO3cuIyNj5cqVw1ljITsG2Y38hsLCwkgk0qpVq6qr"
+			"q/GeeJGRkdOnTxdf0wkAAPJhs9k8Hm/ZsmWvmt2qq6srllJaWqriOAkxZOOA4cDTkjt37rxz5w6f"
+			"z//9999DQkLIZLKaZC1UT0q5zwbDuXXKysp++OGH4RyPB8le9R6QXSsfUYqi4eckEggEMmKQXSuf"
+			"gICAjRs3on/eqCTDkBEiRTejyNy5c5OSkjZs2CDabuejjz46f/48vgUHAADeBM6wLeN36ZYtW6QL"
+			"DQwMCEyGrzJDNg4YDhqNduXKlXXr1i1YsACXmJmZJSYmqkliaTVFyG6MeBWdxG6eu3bt0tfXFwgE"
+			"QqHQwMBAYnvKmzdvIoQKCwtVFiSDwZDYQ7Onp0dTU/PIkSNCoTAqKsrAwEDilAULFnh7e6ssQtkx"
+			"DNnIQ5Jv29O+vr579+5lZ2fX1tbKcToAYIRSq42SwUihhpcNn88vKyvLyckpKSnp7+8nOhx1py4D"
+			"RTweLz4+3tPTUzzlkrjTp09PmDDB0dFRxYGJO3v2LJ/PX7x48aC1lZWVd+/ePX78uIqjGn4MQzay"
+			"Qmhpac2ePVt5jw8AAAAoD5lMdnBwIDqKEUMtFlKUlpYyGIy2trZ9+/ZJ1zY3N4eEhCQkJBw9epRM"
+			"Jqs+PIRQd3d3bGzspk2bNmzYYG9vL1HL5/MzMzO9vLwcHR3Xrl1LSIRDxiC7kQEAAAAAXheR45F0"
+			"Op1MJvf29hoaGrq7u9+/f198S/jQ0NC9e/cODAyQSKS5c+fevHnTzc1NxRGmpqYaGhoihHDymqio"
+			"qKCgIFFtR0eHqHbSpEkrV64MDQ0V7dmjGkPGILuRAQAAAADkRhIKhUTHANTU+fK//B3eIzoKAMDI"
+			"AJ8YQA5w2Yx0ajGvDQAAAAAARhzoRwIAAAAAAHlAPxIAAAAAAMgD+pEAAAAAAEAe0I8EAAAAAADy"
+			"kOd+bdK/wpURCgAAAAAAUCVh1LY3OR3y/gAAAAAAAHnAvDYAAAAAAJAH9CMBAAAAAIA8oB8JAAAA"
+			"AADkAf1IAAAAAAAgD+hHAgAAAAAAeUA/EgAAAAAAyOP/AarkJHs4cLVkAAAAAElFTkSuQmCC"
+		)
+	)
+	(image
+		(at 255.27 175.26)
+		(scale 0.2225)
+		(uuid "d6b589bf-79d6-4a14-adc5-455bad5b8447")
+		(data "iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz"
+			"AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h"
+			"aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73"
+			"+/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA"
+			"xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y"
+			"Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h"
+			"xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO"
+			"GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful"
+			"fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv"
+			"4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ"
+			"EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R"
+			"Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM"
+			"vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H"
+			"cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0"
+			"6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT"
+			"O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA"
+			"4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86"
+			"sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+"
+			"oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/"
+			"55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0"
+			"qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+"
+			"KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn"
+			"Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4"
+			"mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii"
+			"P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr"
+			"voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6"
+			"bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO"
+			"h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da"
+			"4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y"
+			"YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC"
+			"0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP"
+			"SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb"
+			"WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw"
+			"v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay"
+			"PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX"
+			"Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh"
+			"oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD"
+			"7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da"
+			"43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l"
+			"zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl"
+			"pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS"
+			"H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV"
+			"ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY"
+			"MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2"
+			"NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx"
+			"fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl"
+			"tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew"
+			"iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj"
+			"jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI"
+			"cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo"
+			"XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R"
+			"9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv"
+			"8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV"
+			"RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY"
+			"l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf"
+			"YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN"
+			"EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU"
+			"sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z"
+			"7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs"
+			"OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs"
+			"qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7"
+			"G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6"
+			"wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7"
+			"zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln"
+			"Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX"
+			"apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk"
+			"lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw"
+			"TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb"
+			"54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID"
+			"qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd"
+			"P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l"
+			"UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD"
+			"zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH"
+			"Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1"
+			"QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/"
+			"ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX"
+			"08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC"
+			"KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ"
+			"SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu"
+			"h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp"
+			"VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf"
+			"G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK"
+			"dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO"
+			"uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2"
+			"DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn"
+			"byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc"
+			"dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N"
+			"iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP"
+			"NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4"
+			"wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8"
+			"K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s"
+			"xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS"
+			"Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC"
+			"Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5"
+			"m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm"
+			"aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj"
+			"gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn"
+			"p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL"
+			"ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx"
+			"u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+"
+			"FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa"
+			"ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h"
+			"1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj"
+			"DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy"
+			"+Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj"
+			"wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj"
+			"7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ"
+			"lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN"
+			"2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY"
+			"CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi"
+			"mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E"
+			"uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x"
+			"j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD"
+			"45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO"
+			"4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni"
+			"buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY"
+			"HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH"
+			"NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ"
+			"azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N"
+			"SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP"
+			"hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe"
+			"nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4"
+			"b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN"
+			"xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S"
+			"pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq"
+			"3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB"
+			"Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL"
+			"4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw"
+			"qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX"
+			"9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n"
+			"frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/"
+			"eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK"
+			"TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u"
+			"RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9"
+			"DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j"
+			"2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx"
+			"BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy"
+			"91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7"
+			"jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw"
+			"pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ"
+			"cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M"
+			"xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23"
+			"7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8"
+			"D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw"
+			"YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu"
+			"QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs"
+			"uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA"
+			"PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6"
+			"yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN"
+			"xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq"
+			"JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT"
+			"+HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg"
+			"hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K"
+			"hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt"
+			"g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z"
+			"5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf"
+			"u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO"
+			"Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG"
+			"gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK"
+			"hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x"
+			"moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56"
+			"KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp"
+			"ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz"
+			"eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO"
+			"0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA"
+			"BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ"
+			"2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB"
+			"4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF"
+			"6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI"
+			"gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv"
+			"OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt"
+			"8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI"
+			"bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM"
+			"500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4"
+			"CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V"
+			"aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5"
+			"yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF"
+			"zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss"
+			"tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q"
+			"r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj"
+			"xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h"
+			"6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y"
+			"9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE"
+			"XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh"
+			"oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk"
+			"Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4"
+			"ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW"
+			"zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr"
+			"wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV"
+			"BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7"
+			"LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr"
+			"owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX"
+			"hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j"
+			"1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF"
+			"5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw"
+			"a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6"
+			"Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN"
+			"+SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds"
+			"lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ"
+			"i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu"
+			"fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy"
+			"r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28"
+			"dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az"
+			"70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk"
+			"EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL"
+			"p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf"
+			"nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA"
+			"ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c"
+			"q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu"
+			"Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR"
+			"TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53"
+			"en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA"
+			"x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ"
+			"t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+"
+			"R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf"
+			"5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH"
+			"e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG"
+			"po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh"
+			"6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln"
+			"9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU"
+			"xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ"
+			"rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W"
+			"lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb"
+			"afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs"
+			"FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR"
+			"OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC"
+			"P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp"
+			"EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh"
+			"6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK"
+			"GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ"
+			"hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s"
+			"amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+"
+			"fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij"
+			"TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv"
+			"I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf"
+			"kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ"
+			"BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD"
+			"9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn"
+			"jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8"
+			"I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI"
+			"8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs"
+			"Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN"
+			"MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5"
+			"2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU"
+			"2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss"
+			"ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m"
+			"sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq"
+			"LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT"
+			"tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9"
+			"oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p"
+			"zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu"
+			"WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy"
+			"diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX"
+			"ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY"
+			"5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau"
+			"Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7"
+			"oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG"
+			"xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q"
+			"zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik"
+			"sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN"
+			"ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc"
+			"MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E"
+			"YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3"
+			"bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz"
+			"DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC"
+			"TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES"
+			"3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K"
+			"Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd"
+			"b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5"
+			"99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys"
+			"7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa"
+			"Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e"
+			"8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1"
+			"vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK"
+			"VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4"
+			"ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD"
+			"CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4"
+			"qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr"
+			"1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe"
+			"GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK"
+			"yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj"
+			"po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO"
+			"Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF"
+			"tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D"
+			"mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM"
+			"eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN"
+			"veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu"
+			"5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL"
+			"Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t"
+			"rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl"
+			"sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx"
+			"mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG"
+			"PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk"
+			"Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk"
+			"caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO"
+			"jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS"
+			"gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E"
+			"OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+"
+			"p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO"
+			"cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM"
+			"S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc"
+			"vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3"
+			"boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn"
+			"DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD"
+			"90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw"
+			"0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT"
+			"5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI"
+			"7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP"
+			"QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw"
+			"oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E"
+			"mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/"
+			"N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm"
+			"vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC"
+			"+OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp"
+			"gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz"
+			"gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni"
+			"R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3"
+			"j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo"
+			"BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl"
+			"IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4"
+			"jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA"
+			"Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS"
+			"AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz"
+			"6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H"
+			"qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp"
+			"cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa"
+			"M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv"
+			"4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M"
+			"IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD"
+			"Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r"
+			"un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr"
+			"2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/"
+			"kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF"
+			"7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8"
+			"YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk"
+			"zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp"
+			"8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF"
+			"o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt"
+			"Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA"
+			"hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx"
+			"LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk"
+			"iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2"
+			"HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5"
+			"K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo"
+			"XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/"
+			"D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j"
+			"MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c"
+			"O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB"
+			"fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X"
+			"/V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI"
+			"a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe"
+			"L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37"
+			"zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY"
+			"BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg=="
+		)
+	)
+	(label "Vcc_LCD"
+		(at 232.41 40.64 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "2debe4d7-da40-40c0-bf97-52f3075d0907")
+	)
+	(hierarchical_label "SCL"
+		(shape input)
+		(at 20.32 74.93 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "6e396f1d-9e79-4394-a431-e9f406774c1e")
+	)
+	(hierarchical_label "SDA"
+		(shape bidirectional)
+		(at 20.32 86.36 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "b5826874-d3d3-4104-8afa-556db95ba566")
+	)
+	(hierarchical_label "3V3Raw"
+		(shape input)
+		(at 21.59 53.34 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d8118b62-1e88-4a04-95f5-44238e19a6eb")
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 107.95 63.5 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b90f41")
+		(property "Reference" "R303"
+			(at 110.49 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 111.76 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 109.728 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 107.95 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 107.95 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 107.95 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 107.95 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 107.95 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 107.95 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 107.95 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 107.95 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 107.95 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 107.95 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ac80ab56-5966-42fd-8369-c78267a9cecf")
+		)
+		(pin "2"
+			(uuid "f77e5b49-e840-4f0f-b02d-7e5b701a8438")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R303")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 116.84 63.5 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b90f4c")
+		(property "Reference" "R304"
+			(at 119.38 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1K"
+			(at 120.65 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 118.618 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 116.84 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 1kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 116.84 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 116.84 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269704"
+			(at 116.84 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 116.84 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06031K1%N"
+			(at 116.84 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 116.84 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 116.84 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 116.84 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 116.84 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a33b1bb5-f8ec-4eb2-8719-3f7b58cc74ef")
+		)
+		(pin "2"
+			(uuid "4dd13ec6-8697-4126-810a-05113277d82a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R304")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 97.79 63.5 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b90f99")
+		(property "Reference" "R302"
+			(at 100.33 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 101.6 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 99.568 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 97.79 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 97.79 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 97.79 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 97.79 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 97.79 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 97.79 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 97.79 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 97.79 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 97.79 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 97.79 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c8cbc077-2e6d-42c3-bd35-cca03431cd4e")
+		)
+		(pin "2"
+			(uuid "b0c85ca2-aa4a-47bd-b480-e6055d0006e2")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R302")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 88.9 63.5 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b90fa4")
+		(property "Reference" "R301"
+			(at 91.44 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 92.71 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 90.678 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 88.9 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 88.9 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 88.9 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 88.9 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 88.9 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 88.9 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 88.9 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 88.9 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 88.9 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 88.9 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "2583853e-c3c0-47a8-97a8-88e94b158567")
+		)
+		(pin "2"
+			(uuid "7612200f-b4d9-4faa-a157-5ff616d37c6c")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R301")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 189.23 40.64 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b90fbb")
+		(property "Reference" "R310"
+			(at 187.96 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1R0"
+			(at 189.23 38.1 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 189.23 38.862 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 189.23 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 189.23 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 189.23 40.64 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 189.23 40.64 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 189.23 40.64 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 189.23 40.64 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 189.23 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 189.23 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 189.23 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 189.23 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "de16c208-6a9d-400a-a938-ccc9384e4bfa")
+		)
+		(pin "2"
+			(uuid "ec791030-4432-4ead-a414-ec9517e2fce2")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R310")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Polarized")
+		(at 215.9 44.45 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b90fc5")
+		(property "Reference" "C302"
+			(at 218.8972 43.2816 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "47uF 16V"
+			(at 218.8972 45.593 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4"
+			(at 216.8652 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 215.9 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS"
+			(at 215.9 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 215.9 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2895272"
+			(at 215.9 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "KNSCHA"
+			(at 215.9 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RVT47UF16V67RV0019"
+			(at 215.9 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 215.9 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.038"
+			(at 215.9 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 215.9 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 215.9 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d66ccd4c-3439-4d30-8ee7-00cb7cb44814")
+		)
+		(pin "2"
+			(uuid "fee8cc62-52a8-4972-bc95-218641457912")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "C302")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 203.2 44.45 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b90fd0")
+		(property "Reference" "C301"
+			(at 206.121 43.2816 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 206.121 45.593 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 204.1652 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 203.2 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 203.2 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 203.2 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 203.2 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 203.2 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 203.2 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 203.2 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 203.2 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 203.2 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 203.2 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "fb7737a1-400a-40d4-9794-11eea5e3924c")
+		)
+		(pin "2"
+			(uuid "062f2ae7-eefd-4e7c-8628-3046b6667476")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "C301")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 203.2 100.33 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b90fe7")
+		(property "Reference" "R311"
+			(at 208.28 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 207.01 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 204.978 100.33 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 203.2 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 203.2 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 203.2 100.33 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 203.2 100.33 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 203.2 100.33 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 203.2 100.33 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 203.2 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 203.2 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 203.2 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 203.2 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "afc0a8e1-a01c-45c4-a473-052897a82ed2")
+		)
+		(pin "2"
+			(uuid "473eaaac-17c4-4f16-b752-5125697e461b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R311")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Transistor_FET:BSS138")
+		(at 218.44 104.14 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b90ff3")
+		(property "Reference" "Q301"
+			(at 223.6216 102.9716 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "BSS138"
+			(at 223.6216 105.283 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 223.52 106.045 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF"
+			(at 218.44 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "N-Channel Enhancement Mode Field Effect Transistor"
+			(at 218.44 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 218.44 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C400505"
+			(at 218.44 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd"
+			(at 218.44 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "BSS138"
+			(at 218.44 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 218.44 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0196"
+			(at 218.44 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 218.44 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 218.44 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "292fd703-5baa-4e53-8749-f2097c29e572")
+		)
+		(pin "2"
+			(uuid "b002b100-3c23-485c-ac3e-7ca3886ba277")
+		)
+		(pin "3"
+			(uuid "6b250f59-6fe8-4085-a5a9-9986396245b6")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "Q301")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 180.34 40.64 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b90ffa")
+		(property "Reference" "#PWR0303"
+			(at 180.34 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+5V"
+			(at 180.721 36.2458 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 180.34 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "30f7d6da-4fba-4e5f-a235-79e2a5ba7a1f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#PWR0303")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 116.84 95.25 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062c6d2fc")
+		(property "Reference" "R305"
+			(at 119.38 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1R0"
+			(at 120.65 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 115.062 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 116.84 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 116.84 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 116.84 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 116.84 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 116.84 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 116.84 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 116.84 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 116.84 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 116.84 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 116.84 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "17fe85d4-088c-4a53-8541-0049f0cea481")
+		)
+		(pin "2"
+			(uuid "6963339a-a2f8-41dd-b9e5-986217b643a6")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R305")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 125.73 95.25 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062c73c08")
+		(property "Reference" "R307"
+			(at 128.27 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1R0"
+			(at 129.54 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 123.952 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 125.73 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 125.73 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 125.73 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 125.73 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 125.73 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 125.73 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 125.73 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 125.73 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 125.73 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 125.73 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e299cc96-bc7d-414b-b284-5b1e8520a67f")
+		)
+		(pin "2"
+			(uuid "f3ce02b3-dabd-4cb3-adb7-7bd223bfedb9")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R307")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 133.35 95.25 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062c74117")
+		(property "Reference" "R309"
+			(at 135.89 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1R0"
+			(at 137.16 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 131.572 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 133.35 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 133.35 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 133.35 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 133.35 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 133.35 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 133.35 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 133.35 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 133.35 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 133.35 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 133.35 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "64d98481-e4d1-479c-a046-284c4f3a5431")
+		)
+		(pin "2"
+			(uuid "91ddce6d-9a15-42d2-add4-e4b090914cc7")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R309")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 139.7 106.68 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062c8b28f")
+		(property "Reference" "TP402"
+			(at 143.51 107.95 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "nINT"
+			(at 144.78 113.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 134.62 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 134.62 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 139.7 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 139.7 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 139.7 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 139.7 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 139.7 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 139.7 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 139.7 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 139.7 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 139.7 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "55d2946e-de11-4bd3-b26c-19770c8ae74f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "TP402")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 167.64 49.53 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062e5ea08")
+		(property "Reference" "#FLG0301"
+			(at 167.64 47.625 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 167.64 45.1358 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 167.64 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 167.64 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 167.64 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7a51edfd-de8e-4eb3-adf5-0e0e3af2922d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#FLG0301")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 226.06 59.69 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062e746dd")
+		(property "Reference" "R306"
+			(at 228.6 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 229.87 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 227.838 59.69 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 226.06 59.69 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "DNI"
+			(at 226.06 59.69 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DNI"
+			(at 226.06 59.69 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "DNI"
+			(at 226.06 59.69 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 226.06 59.69 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "DNI"
+			(at 226.06 59.69 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 226.06 59.69 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 226.06 59.69 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 226.06 59.69 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 226.06 59.69 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "790105eb-7c6d-4e8e-b4ed-ecaee3754b2f")
+		)
+		(pin "2"
+			(uuid "e6d231e8-56fb-424b-808b-a6ff775221f1")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R306")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 198.12 59.69 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062e7d140")
+		(property "Reference" "#FLG0302"
+			(at 200.025 59.69 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 201.3712 59.69 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 198.12 59.69 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 198.12 59.69 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 198.12 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "84f3c470-17c8-4878-9f7d-ce446d93b9fa")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#FLG0302")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 226.06 72.39 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062e82d99")
+		(property "Reference" "R308"
+			(at 228.6 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 229.87 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 227.838 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 226.06 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "DNI"
+			(at 226.06 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DNI"
+			(at 226.06 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "DNI"
+			(at 226.06 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 226.06 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "DNI"
+			(at 226.06 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 226.06 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 226.06 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 226.06 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 226.06 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f773a457-a462-418a-856e-a3385939ef14")
+		)
+		(pin "2"
+			(uuid "46bef5dd-0b35-4d18-b6a7-490faec63cff")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R308")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Nut_4-40_0.1875")
+		(at 20.955 191.135 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "014f6fe9-5a14-4755-b8d7-f8f5ef503162")
+		(property "Reference" "MF403"
+			(at 26.67 189.8649 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Nut_4-40_0.1875"
+			(at 26.67 192.4049 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 20.955 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf"
+			(at 20.955 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "#4-40 Hex Nut 0.187\" (4.75mm) 3/16\" Steel"
+			(at 20.955 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DigiKey"
+			(at 20.955 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "36-4694-ND"
+			(at 20.955 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "$0.10000"
+			(at 20.955 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 20.955 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 20.955 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 20.955 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "4694"
+			(at 20.955 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Keystone Electronics"
+			(at 20.955 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF403")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 78.74 63.5 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "01787b6e-0ac1-4323-a778-5eba53025ce4")
+		(property "Reference" "R410"
+			(at 81.28 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 82.55 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 80.518 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 78.74 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 78.74 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 78.74 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 78.74 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 78.74 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 78.74 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 78.74 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 78.74 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 78.74 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 78.74 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "29767ad6-c82a-44d2-81fb-18e6e6727b3f")
+		)
+		(pin "2"
+			(uuid "7f28e3de-d9a1-43eb-be9b-53fce523d6d8")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R410")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Transistor_FET:BSS138")
+		(at 53.34 72.39 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "09258e51-72b0-44dc-be50-3af085ca3b27")
+		(property "Reference" "Q401"
+			(at 55.88 71.12 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "BSS138"
+			(at 49.53 78.74 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 51.435 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF"
+			(at 53.34 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "N-Channel Enhancement Mode Field Effect Transistor"
+			(at 53.34 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 53.34 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C400505"
+			(at 53.34 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd"
+			(at 53.34 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "BSS138"
+			(at 53.34 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 53.34 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0196"
+			(at 53.34 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 53.34 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 53.34 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "49a39b5f-2c1a-45a2-808c-1be3591faae1")
+		)
+		(pin "2"
+			(uuid "35f9c926-c92d-4bdf-9c26-3ef4ad3a2b38")
+		)
+		(pin "3"
+			(uuid "94f64d75-e799-4e45-a018-c9a9b04edd54")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "Q401")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Spacer_0.0182x0.125_inch")
+		(at 92.71 181.61 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0bbbda63-c97c-4607-af22-6c234905b972")
+		(property "Reference" "MF408"
+			(at 99.06 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Spacer_0.0182x0.125 inch"
+			(at 99.06 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 92.71 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+			(at 92.71 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Off-White Nylon Unthreaded Spacer, 0.1875\" OD, 1/8\" Long, for Number 4 Screw Size"
+			(at 92.71 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "94639A702"
+			(at 92.71 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "McMaster-Carr"
+			(at 92.71 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.1145"
+			(at 92.71 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 92.71 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 92.71 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 92.71 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "94639A702"
+			(at 92.71 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "McMaster-Carr"
+			(at 92.71 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF408")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 226.06 77.47 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0ed72387-e6a5-417d-b992-3772bbdd9957")
+		(property "Reference" "#PWR0406"
+			(at 226.06 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 226.06 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 226.06 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 226.06 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 226.06 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "fa3e7eb5-54df-4572-a7ce-9e5b83299f5c")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#PWR0406")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 69.85 63.5 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1359ea37-be74-47fc-a927-75aa27b82a04")
+		(property "Reference" "R409"
+			(at 72.39 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 71.628 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 69.85 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 69.85 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 69.85 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 69.85 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 69.85 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 69.85 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 69.85 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 69.85 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 69.85 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 69.85 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f2132d97-6eaf-4441-bfa3-e8feeba7a2c2")
+		)
+		(pin "2"
+			(uuid "909493e3-2cca-46e0-9ef4-e446976d857e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R409")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 203.2 49.53 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "217a5803-3f18-4063-ab30-799091d6baff")
+		(property "Reference" "#PWR0410"
+			(at 203.2 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 203.2 54.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 203.2 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 203.2 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 203.2 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "158b63c3-41bd-464d-80bd-5bc7ad711ece")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#PWR0410")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 185.42 100.33 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "24afa58f-c8eb-47f2-aa08-6b895c802ded")
+		(property "Reference" "#PWR0402"
+			(at 185.42 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 185.42 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 185.42 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 185.42 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 185.42 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e6ff38f2-8e87-477c-9174-ba8c12dbac55")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#PWR0402")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:LCD_20x4_Character-GPAD_SCH_LIB")
+		(at 185.42 77.47 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2ab4402c-7d6e-4745-b7e2-2505e19e98be")
+		(property "Reference" "U302"
+			(at 162.56 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "LCD_20x4_Character-GPAD_SCH_LIB"
+			(at 158.75 58.42 0)
+			(effects
+				(font
+					(size 1 1)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:LCD_2004A"
+			(at 185.42 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 187.96 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "2004 LCD Display Module Character 20x4 Blacklight Gray Yellow Blue"
+			(at 185.42 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "eBay   Aliexpress"
+			(at 157.988 94.996 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "403534100457 "
+			(at 182.88 97.536 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2" "Amazon  / Aliexpress"
+			(at 156.972 100.584 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2 PN" "https://www.amazon.com/GeeekPi-Interface-Adapter-Backlight-Raspberry/dp/B07QLRD3TM/ref=sr_1_2 /  https://www.aliexpress.com/item/3256803213374992.html"
+			(at 205.486 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Assembly Type" ""
+			(at 185.42 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "4.99"
+			(at 185.42 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "https://www.ebay.com/itm/403534100457"
+			(at 185.42 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 185.42 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 185.42 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 185.42 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 185.42 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6799f5af-dda7-4072-9f74-25049e2a66ed")
+		)
+		(pin "10"
+			(uuid "f7dee6fb-df4d-414d-b6a2-9a2c5272937e")
+		)
+		(pin "11"
+			(uuid "c1d010ad-7e0b-4ca8-bc89-b932ad9e69f7")
+		)
+		(pin "12"
+			(uuid "00d40a8f-3756-48e6-a893-33b7903eec31")
+		)
+		(pin "13"
+			(uuid "e86f44a6-c915-42ea-8731-0802990f017a")
+		)
+		(pin "14"
+			(uuid "e00c1ebf-60fa-448c-a601-6fc7c78e4649")
+		)
+		(pin "15"
+			(uuid "122194bf-d0d7-4837-807d-a315db79cee3")
+		)
+		(pin "16"
+			(uuid "b292c015-a9b6-4eac-80ee-90f82c6274b0")
+		)
+		(pin "17"
+			(uuid "5e8ef7f2-dd44-415b-9052-e6783d350fed")
+		)
+		(pin "18"
+			(uuid "95baef0e-dbb1-4d7b-bead-7eafcaa37290")
+		)
+		(pin "19"
+			(uuid "8375e995-0cf5-463f-be81-46027732fb0f")
+		)
+		(pin "2"
+			(uuid "454a7a70-b195-490c-9d94-af41a95efeae")
+		)
+		(pin "20"
+			(uuid "edfcbad2-288e-41a2-80e3-d61ef8162b22")
+		)
+		(pin "3"
+			(uuid "b5318fbb-4bf0-4330-95f1-1b4b92986d4b")
+		)
+		(pin "4"
+			(uuid "e57840d8-ec70-4537-b18b-8c2b6ce1159d")
+		)
+		(pin "5"
+			(uuid "4d8da57f-8ee4-4d44-b990-64fe7394351c")
+		)
+		(pin "6"
+			(uuid "9edd2fd7-0276-48b4-94f9-5abb9a682561")
+		)
+		(pin "7"
+			(uuid "2c9a51e3-5671-486a-b33b-14d7f7eff9fa")
+		)
+		(pin "8"
+			(uuid "bb387c69-f974-4605-bb1a-c50d220651bf")
+		)
+		(pin "9"
+			(uuid "dfd2bb7f-b83b-4198-ae74-10cb2ed4efa3")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "U302")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Spacer_0.0182x0.125_inch")
+		(at 129.54 181.61 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2bc9d111-b8bc-4e61-b9fe-a5c44a2f224c")
+		(property "Reference" "MF411"
+			(at 135.89 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Spacer_0.0182x0.125 inch"
+			(at 135.89 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 129.54 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+			(at 129.54 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Off-White Nylon Unthreaded Spacer, 0.1875\" OD, 1/8\" Long, for Number 4 Screw Size"
+			(at 129.54 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "94639A702"
+			(at 129.54 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "McMaster-Carr"
+			(at 129.54 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.1145"
+			(at 129.54 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 129.54 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 129.54 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 129.54 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "94639A702"
+			(at 129.54 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "McMaster-Carr"
+			(at 129.54 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF411")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 208.28 106.68 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2ce94dde-528e-4af6-b4b5-b03655a3503e")
+		(property "Reference" "R312"
+			(at 207.01 104.14 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 208.28 110.49 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 208.28 104.902 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 208.28 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 208.28 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 208.28 106.68 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 208.28 106.68 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 208.28 106.68 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 208.28 106.68 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 208.28 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 208.28 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 208.28 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 208.28 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6dc617e0-32e8-4cea-94e0-9920112d1297")
+		)
+		(pin "2"
+			(uuid "3c8dd449-f5c1-4f8b-a151-a38f197056da")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R312")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Nut_4-40_0.1875")
+		(at 128.27 191.77 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "321f509c-c1d5-4d92-a011-88911bf1dfbe")
+		(property "Reference" "MF412"
+			(at 133.985 190.4999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Nut_4-40_0.1875"
+			(at 133.985 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 128.27 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf"
+			(at 128.27 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "#4-40 Hex Nut 0.187\" (4.75mm) 3/16\" Steel"
+			(at 128.27 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DigiKey"
+			(at 128.27 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "36-4694-ND"
+			(at 128.27 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "$0.10000"
+			(at 128.27 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 128.27 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 128.27 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 128.27 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "4694"
+			(at 128.27 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Keystone Electronics"
+			(at 128.27 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF412")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Nut_4-40_0.1875")
+		(at 92.71 192.405 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "52ea4c17-8c70-404a-bd81-759de8e6e1dc")
+		(property "Reference" "MF409"
+			(at 99.06 191.1349 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Nut_4-40_0.1875"
+			(at 99.06 193.6749 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 92.71 192.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf"
+			(at 92.71 192.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "#4-40 Hex Nut 0.187\" (4.75mm) 3/16\" Steel"
+			(at 92.71 192.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DigiKey"
+			(at 92.71 192.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "36-4694-ND"
+			(at 92.71 192.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "$0.10000"
+			(at 92.71 192.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 92.71 192.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 92.71 192.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 92.71 192.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "4694"
+			(at 92.71 192.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Keystone Electronics"
+			(at 92.71 192.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF409")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 31.75 63.5 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5941a990-7191-4ced-8da7-296ee1595fc0")
+		(property "Reference" "R405"
+			(at 34.29 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 35.56 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 33.528 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 31.75 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 31.75 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 31.75 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 31.75 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 31.75 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 31.75 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 31.75 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 31.75 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 31.75 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 31.75 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "53a93d32-1486-4cd3-adfe-dbd9b6bdcce5")
+		)
+		(pin "2"
+			(uuid "ba3f4dbe-d7ec-4fa3-b209-f763c550b19f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R405")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Screw_4-40_0.375_Phillips")
+		(at 58.42 171.45 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5f619803-b5b9-4c9f-8b28-2286ea24524c")
+		(property "Reference" "MF404"
+			(at 62.23 170.1799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Screw_4-40_0.375_Phillips"
+			(at 62.23 172.7199 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+			(at 58.42 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Zinc-Plated Steel Pan Head Phillips Screw, 4-40 Thread, 3/8\" Long"
+			(at 58.42 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "McMaster-Carr"
+			(at 58.42 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "90272A108"
+			(at 58.42 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0182"
+			(at 58.42 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 58.42 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 58.42 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 58.42 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "90272A108"
+			(at 58.42 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "McMaster-Carr"
+			(at 58.42 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF404")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Spacer_0.0182x0.125_inch")
+		(at 58.42 180.34 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "60bc9650-1c6c-4288-8d5d-7a31cca2ad06")
+		(property "Reference" "MF405"
+			(at 64.77 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Spacer_0.0182x0.125 inch"
+			(at 64.77 181.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+			(at 58.42 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Off-White Nylon Unthreaded Spacer, 0.1875\" OD, 1/8\" Long, for Number 4 Screw Size"
+			(at 58.42 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "94639A702"
+			(at 58.42 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "McMaster-Carr"
+			(at 58.42 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.1145"
+			(at 58.42 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 58.42 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 58.42 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 58.42 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "94639A702"
+			(at 58.42 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "McMaster-Carr"
+			(at 58.42 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF405")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 40.64 63.5 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6300a1e0-02b5-41f7-8f02-43b23eed6a01")
+		(property "Reference" "R406"
+			(at 43.18 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 44.45 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 42.418 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 40.64 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 40.64 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 40.64 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 40.64 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 40.64 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 40.64 63.5 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 40.64 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 40.64 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 40.64 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 40.64 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c98c79ea-d35a-4689-9ea0-5dfb9e62ba7e")
+		)
+		(pin "2"
+			(uuid "0ea940a1-aac9-442f-8278-289a2dee7c84")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R406")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x16")
+		(at 252.73 81.28 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "64bef9a2-6017-4149-bf8d-80701c5a4983")
+		(property "Reference" "U303"
+			(at 255.27 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x16"
+			(at 255.27 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x16_P2.54mm_Vertical"
+			(at 252.73 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 252.73 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Plugin,P=2.54mm Pin Headers ROHS"
+			(at 252.73 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 252.73 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C22465876"
+			(at 252.73 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "PZ254V-11-16P"
+			(at 252.73 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "XFCN"
+			(at 252.73 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.09"
+			(at 252.73 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 252.73 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 252.73 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 252.73 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d6cae7c1-e48c-4f21-8ac5-a128661de828")
+		)
+		(pin "10"
+			(uuid "b359546b-6c4f-4d1f-a4b4-aa5a814c1013")
+		)
+		(pin "11"
+			(uuid "c61a0f9b-ace9-4519-bdb8-dee917b1bd3d")
+		)
+		(pin "12"
+			(uuid "df174ab6-58e8-4a61-b638-08db28e5cc51")
+		)
+		(pin "13"
+			(uuid "8d9ca9a2-15dd-461a-a87c-ab32c9267c29")
+		)
+		(pin "14"
+			(uuid "8bbc0226-7920-474d-b6f9-2eb4bef01a13")
+		)
+		(pin "15"
+			(uuid "51031b1e-0fdb-45e4-94b4-6f3858d13b47")
+		)
+		(pin "16"
+			(uuid "e9bea479-ef21-4aa6-ad88-0b20e18972a8")
+		)
+		(pin "2"
+			(uuid "52266cac-25c6-43b6-a683-463bd3cffabf")
+		)
+		(pin "3"
+			(uuid "c2fbcf4c-3976-4de4-8432-b3676c5d8efc")
+		)
+		(pin "4"
+			(uuid "670e5078-9ac8-4af8-a97d-b0e88a034cd9")
+		)
+		(pin "5"
+			(uuid "dbb1a71b-cdd5-4da3-9704-26bb0549d88c")
+		)
+		(pin "6"
+			(uuid "3642cfbc-01c6-4bda-89b0-4fc225be22b7")
+		)
+		(pin "7"
+			(uuid "628dfcf0-6b56-46c3-8be9-9addd45fc29d")
+		)
+		(pin "8"
+			(uuid "afe132a1-4dbe-42b3-9c05-39e03dd49e96")
+		)
+		(pin "9"
+			(uuid "0d7c75cf-03c6-4657-955c-15eccf6c65be")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "U303")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 156.21 105.41 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "664ce4fd-edb5-466e-a148-03aa5edcd405")
+		(property "Reference" "#PWR0403"
+			(at 156.21 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 156.21 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 156.21 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 156.21 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 156.21 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "2f2877ab-7567-43da-9887-a2dba42fd5fa")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#PWR0403")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 209.55 74.93 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "67faf9d0-d33d-47ff-8f6d-b0932c4ac42d")
+		(property "Reference" "#PWR0407"
+			(at 209.55 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 209.55 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 209.55 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 209.55 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 209.55 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "9820b8c7-569c-4886-9639-6714de86dd30")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#PWR0407")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Screw_4-40_0.375_Phillips")
+		(at 92.71 171.45 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "756a2495-fd18-4be4-9093-457c5824c477")
+		(property "Reference" "MF407"
+			(at 96.52 170.1799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Screw_4-40_0.375_Phillips"
+			(at 96.52 172.7199 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 92.71 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+			(at 92.71 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Zinc-Plated Steel Pan Head Phillips Screw, 4-40 Thread, 3/8\" Long"
+			(at 92.71 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "McMaster-Carr"
+			(at 92.71 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "90272A108"
+			(at 92.71 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0182"
+			(at 92.71 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 92.71 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 92.71 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 92.71 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "90272A108"
+			(at 92.71 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "McMaster-Carr"
+			(at 92.71 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF407")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Screw_4-40_0.375_Phillips")
+		(at 127 171.45 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7b9a9c27-6413-41e9-91d9-b1c74b2c007e")
+		(property "Reference" "MF410"
+			(at 130.81 170.1799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Screw_4-40_0.375_Phillips"
+			(at 130.81 172.7199 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 127 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+			(at 127 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Zinc-Plated Steel Pan Head Phillips Screw, 4-40 Thread, 3/8\" Long"
+			(at 127 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "McMaster-Carr"
+			(at 127 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "90272A108"
+			(at 127 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0182"
+			(at 127 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 127 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 127 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 127 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "90272A108"
+			(at 127 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "McMaster-Carr"
+			(at 127 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF410")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 220.98 111.76 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "95bde4a0-d658-4db6-8cb6-1d6ce03efa0d")
+		(property "Reference" "#PWR0405"
+			(at 220.98 118.11 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 220.98 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 220.98 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "1069604d-daba-4157-9dd0-d70afe7a4522")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#PWR0405")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Nut_4-40_0.1875")
+		(at 57.785 191.135 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "99fac1dd-4999-406f-a43f-0df717311a06")
+		(property "Reference" "MF406"
+			(at 63.5 189.8649 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Nut_4-40_0.1875"
+			(at 63.5 192.4049 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 57.785 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.keyelco.com/userAssets/file/M65p135.pdf"
+			(at 57.785 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "#4-40 Hex Nut 0.187\" (4.75mm) 3/16\" Steel"
+			(at 57.785 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DigiKey"
+			(at 57.785 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "36-4694-ND"
+			(at 57.785 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "$0.10000"
+			(at 57.785 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 57.785 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 57.785 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 57.785 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "4694"
+			(at 57.785 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Keystone Electronics"
+			(at 57.785 191.135 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF406")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 214.63 60.96 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9ca882a4-64f8-4304-8de0-abda32ac092e")
+		(property "Reference" "TP405"
+			(at 210.82 54.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Vcontrast"
+			(at 210.82 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 219.71 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 219.71 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Red"
+			(at 214.63 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 214.63 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 214.63 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 214.63 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 214.63 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 214.63 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 214.63 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 214.63 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 214.63 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "20b27a6e-77b1-4db6-a2e5-91c88d5fa6cf")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "TP405")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 50.8 82.55 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "ba359b61-1929-414c-80f1-518864807323")
+		(property "Reference" "R407"
+			(at 46.99 80.01 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 50.8 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 50.8 80.772 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 50.8 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 50.8 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 50.8 82.55 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 50.8 82.55 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 50.8 82.55 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 50.8 82.55 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 50.8 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 50.8 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 50.8 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 50.8 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6a0397bd-eb19-443a-846b-9e62b4dd2457")
+		)
+		(pin "2"
+			(uuid "66d433d9-7e7e-4145-bf8f-a044cf42f52f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R407")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 62.23 93.98 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "c34b2ad2-aef4-47c7-8727-d9ca831d0e95")
+		(property "Reference" "R408"
+			(at 58.42 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 62.23 96.52 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 62.23 92.202 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 62.23 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 62.23 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 62.23 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 62.23 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 62.23 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 62.23 93.98 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 62.23 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 62.23 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 62.23 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 62.23 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "840b5961-cc6e-4837-ba75-3f04b64e38a0")
+		)
+		(pin "2"
+			(uuid "3cc5147d-f0aa-4cee-8907-d2a0cb57ac7b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "R408")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Transistor_FET:BSS138")
+		(at 63.5 83.82 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ce51c2da-3d7d-48f4-84c8-2c3a8d973e40")
+		(property "Reference" "Q402"
+			(at 66.04 82.55 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "BSS138"
+			(at 59.69 90.17 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 61.595 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF"
+			(at 63.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "N-Channel Enhancement Mode Field Effect Transistor"
+			(at 63.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 63.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C400505"
+			(at 63.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd"
+			(at 63.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "BSS138"
+			(at 63.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 63.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0196"
+			(at 63.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 63.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 63.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "db5c2538-a17b-4f2b-bf76-56fdf95ccdfc")
+		)
+		(pin "2"
+			(uuid "af8a60d2-c03f-4dc2-a602-fe7cc816cb38")
+		)
+		(pin "3"
+			(uuid "85b02ee7-acd5-4a3b-989e-6c4d27dafbaa")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "Q402")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 134.62 67.31 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d2692076-1e83-478d-b26b-489e383e9933")
+		(property "Reference" "TP404"
+			(at 134.62 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "SDA"
+			(at 135.89 63.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 139.7 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 139.7 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 134.62 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 134.62 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 134.62 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 134.62 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 134.62 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 134.62 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 134.62 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 134.62 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 134.62 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "baeafecb-bacd-4924-816e-e282c3e8caf0")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "TP404")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 215.9 49.53 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d609d9ff-e246-4f7a-87c2-bf60bf19a787")
+		(property "Reference" "#PWR0409"
+			(at 215.9 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 215.9 54.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 215.9 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 215.9 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "b6ec202e-f45c-4b1f-9b87-68ea76fe4dad")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#PWR0409")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 223.52 35.56 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "dab85703-edaf-43d3-9499-41b59d9a43e0")
+		(property "Reference" "TP401"
+			(at 224.79 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Vcc_LCD"
+			(at 224.79 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 228.6 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 228.6 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Red"
+			(at 223.52 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 223.52 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 223.52 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 223.52 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 223.52 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 223.52 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 223.52 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 223.52 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 223.52 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "69f7ea91-da66-4f35-8c5d-b4bd16b7525a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "TP401")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:PCF8574AT_3_518")
+		(at 156.21 85.09 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e051ebe0-83f1-4aa8-b0c7-b7b5af8758eb")
+		(property "Reference" "U301"
+			(at 149.86 63.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "PCF8574AT_3_518"
+			(at 137.16 66.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_SO:SOIC-16W_7.5x10.3mm_P1.27mm"
+			(at 156.21 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811151526_NXP-Semicon-PCF8574AT-3-518_C86832.pdf"
+			(at 156.21 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "8 100kHz I2C SOIC-16-300mil I/O Expanders ROHS"
+			(at 156.21 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 156.21 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "1.87"
+			(at 156.21 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 156.21 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C86832"
+			(at 156.21 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "PCF8574AT_3_518"
+			(at 156.21 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 156.21 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 156.21 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NXP Semicon"
+			(at 156.21 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "3a5ad194-12eb-4a59-9b31-e28e59238a97")
+		)
+		(pin "10"
+			(uuid "389b8006-63b1-49ce-810a-48e9aa2d663d")
+		)
+		(pin "11"
+			(uuid "d4b7136d-93fd-4677-bf29-226bbffa08ae")
+		)
+		(pin "12"
+			(uuid "998ee018-9af7-40e2-a05e-af08d7338766")
+		)
+		(pin "13"
+			(uuid "019e7b79-122e-4c86-8dd8-7ef120edbedd")
+		)
+		(pin "14"
+			(uuid "51811ac5-c91c-43b0-873d-5a7aa0a35f20")
+		)
+		(pin "15"
+			(uuid "3739fd5a-cfa5-49b0-8f7a-194c909a27c0")
+		)
+		(pin "16"
+			(uuid "b16c5b84-315b-4ae0-ab13-c124f155fd49")
+		)
+		(pin "2"
+			(uuid "d630269b-14ed-4b22-ba47-3ae8d2c15ecf")
+		)
+		(pin "3"
+			(uuid "6e0502b5-df10-487b-be98-d439e28716cf")
+		)
+		(pin "4"
+			(uuid "341e903e-89d3-4e18-90ee-2d961eb2a242")
+		)
+		(pin "5"
+			(uuid "c741e8b2-16af-41df-843b-7ed311de60e7")
+		)
+		(pin "6"
+			(uuid "c8cc664c-0f70-4d46-a80e-ee1967252084")
+		)
+		(pin "7"
+			(uuid "e911a7a8-b550-4a4e-859e-c273ccf177c9")
+		)
+		(pin "8"
+			(uuid "e437afbd-8282-456e-a65a-3dffef62b39c")
+		)
+		(pin "9"
+			(uuid "a661a92b-14df-464e-8226-58604d711499")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "U301")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:POT_0.375_10K")
+		(at 209.55 68.58 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e6b2915e-b2de-400e-841f-313969e9ee14")
+		(property "Reference" "RV301"
+			(at 212.09 67.183 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "POT 0.375 10K"
+			(at 212.09 69.723 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:Potentiometer_Bourns_3386P_Vertical"
+			(at 209.55 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.bourns.com/docs/Product-Datasheets/3386.pdf"
+			(at 209.55 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "±10% ±100ppm/℃ 10kΩ Plugin Variable Resistors/Potentiometers ROHS"
+			(at 209.55 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C116281"
+			(at 209.55 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 209.55 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "3386P-1-103LF"
+			(at 209.55 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Assembly Type" ""
+			(at 207.01 67.4371 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Distributor 2" "Digi-Key"
+			(at 209.55 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2 PN" "3386P-103LF-ND"
+			(at 205.74 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Cost" "0.6963"
+			(at 201.93 69.85 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "BOURNS"
+			(at 209.55 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 209.55 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 209.55 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 209.55 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d020a011-230d-44ae-a806-9feff29695dd")
+		)
+		(pin "2"
+			(uuid "0a464c3c-7a04-4abf-8126-95d001d2d2ef")
+		)
+		(pin "3"
+			(uuid "60d54a8d-ee11-4071-8c23-4be852275389")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "RV301")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 129.54 104.14 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "edf21dec-b4ce-48a6-9b5b-615ecacb5660")
+		(property "Reference" "#PWR0404"
+			(at 129.54 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 129.54 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 129.54 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 129.54 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 129.54 104.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "849a44a4-3285-42d3-803d-586f0ee2c1cc")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#PWR0404")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 199.39 76.2 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f1806f52-48be-4d9c-b4f7-ab880f2c0c08")
+		(property "Reference" "#PWR0408"
+			(at 199.39 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 199.39 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 199.39 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 199.39 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 199.39 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "bea2b4c8-42a1-4f53-b79a-b32385c40cf3")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "#PWR0408")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Spacer_0.0182x0.125_inch")
+		(at 21.59 180.34 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f199673c-0736-4cc4-bbb0-55abbef49738")
+		(property "Reference" "MF402"
+			(at 27.94 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Spacer_0.0182x0.125 inch"
+			(at 27.94 181.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 21.59 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+			(at 21.59 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Off-White Nylon Unthreaded Spacer, 0.1875\" OD, 1/8\" Long, for Number 4 Screw Size"
+			(at 21.59 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "94639A702"
+			(at 21.59 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "McMaster-Carr"
+			(at 21.59 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.1145"
+			(at 21.59 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 21.59 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 21.59 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 21.59 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "94639A702"
+			(at 21.59 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "McMaster-Carr"
+			(at 21.59 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF402")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 129.54 71.12 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f4bf92a9-c0cf-47f9-a140-30daad06e0b8")
+		(property "Reference" "TP403"
+			(at 124.46 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "SCL"
+			(at 124.46 67.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 134.62 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 134.62 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 129.54 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 129.54 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 129.54 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 129.54 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 129.54 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 129.54 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 129.54 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 129.54 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 129.54 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "385d1835-f4d0-4125-bce2-4f32000fd09e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "TP403")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Screw_4-40_0.375_Phillips")
+		(at 21.59 171.45 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fbcd2f6c-e85f-48ea-bb94-218dde6e448f")
+		(property "Reference" "MF401"
+			(at 25.4 170.1799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Screw_4-40_0.375_Phillips"
+			(at 25.4 172.7199 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 21.59 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.mcmaster.com/catalog/128/3306"
+			(at 21.59 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Zinc-Plated Steel Pan Head Phillips Screw, 4-40 Thread, 3/8\" Long"
+			(at 21.59 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "McMaster-Carr"
+			(at 21.59 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "90272A108"
+			(at 21.59 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0182"
+			(at 21.59 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 21.59 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 21.59 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 21.59 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "90272A108"
+			(at 21.59 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "McMaster-Carr"
+			(at 21.59 171.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
+					(reference "MF401")
+					(unit 1)
+				)
+			)
+		)
+	)
 )

--- a/PWA_REV2/PWA_REV2.kicad_pro
+++ b/PWA_REV2/PWA_REV2.kicad_pro
@@ -789,7 +789,7 @@
       {
         "filename": "PWA_REV2.kicad_sch",
         "name": "PWA_REV2",
-        "uuid": "00000000-0000-0000-0000-000000000000"
+        "uuid": "412a327d-1ee3-473e-bc00-1545004b7edf"
       }
     ],
     "used_designators": ""
@@ -797,7 +797,7 @@
   "sheets": [
     [
       "412a327d-1ee3-473e-bc00-1545004b7edf",
-      ""
+      "PWA_REV2"
     ],
     [
       "00000000-0000-0000-0000-000062bc4e7e",

--- a/PWA_REV2/PWA_REV2.kicad_sch
+++ b/PWA_REV2/PWA_REV2.kicad_sch
@@ -1,9567 +1,24517 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid 412a327d-1ee3-473e-bc00-1545004b7edf)
-
-  (paper "A4")
-
-  (title_block
-    (title "KRAKE_PCB")
-    (date "2025-07-18")
-    (rev "2.0")
-    (company "PublicInvention")
-    (comment 1 "GNU Affero General Public License v3.0")
-    (comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
-    (comment 3 "https://github.com/PubInv/krake")
-    (comment 4 "Inherited from the GPAD")
-  )
-
-  (lib_symbols
-    (symbol "Connector:TestPoint" (pin_numbers hide) (pin_names (offset 0.762) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "TP" (at 0 6.858 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "TestPoint" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "test point tp" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "test point" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "Pin* Test*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "TestPoint_0_1"
-        (circle (center 0 3.302) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "TestPoint_1_1"
-        (pin passive line (at 0 0 90) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Connector_Generic:Conn_01x10" (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "J" (at 0 12.7 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "Conn_01x10" (at 0 -15.24 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "connector" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Generic connector, single row, 01x10, script generated (kicad-library-utils/schlib/autogen/connector/)" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "Connector*:*_1x??_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Conn_01x10_1_1"
-        (rectangle (start -1.27 -12.573) (end 0 -12.827)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -10.033) (end 0 -10.287)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -7.493) (end 0 -7.747)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -4.953) (end 0 -5.207)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -2.413) (end 0 -2.667)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 0.127) (end 0 -0.127)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 2.667) (end 0 2.413)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 5.207) (end 0 4.953)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 7.747) (end 0 7.493)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 10.287) (end 0 10.033)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 11.43) (end 1.27 -13.97)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-        (pin passive line (at -5.08 10.16 0) (length 3.81)
-          (name "Pin_1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -12.7 0) (length 3.81)
-          (name "Pin_10" (effects (font (size 1.27 1.27))))
-          (number "10" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 7.62 0) (length 3.81)
-          (name "Pin_2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 5.08 0) (length 3.81)
-          (name "Pin_3" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 2.54 0) (length 3.81)
-          (name "Pin_4" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 0 0) (length 3.81)
-          (name "Pin_5" (effects (font (size 1.27 1.27))))
-          (number "5" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -2.54 0) (length 3.81)
-          (name "Pin_6" (effects (font (size 1.27 1.27))))
-          (number "6" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -5.08 0) (length 3.81)
-          (name "Pin_7" (effects (font (size 1.27 1.27))))
-          (number "7" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -7.62 0) (length 3.81)
-          (name "Pin_8" (effects (font (size 1.27 1.27))))
-          (number "8" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -10.16 0) (length 3.81)
-          (name "Pin_9" (effects (font (size 1.27 1.27))))
-          (number "9" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Connector_Generic:Conn_01x14" (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "J" (at 0 17.78 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "Conn_01x14" (at 0 -20.32 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "connector" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Generic connector, single row, 01x14, script generated (kicad-library-utils/schlib/autogen/connector/)" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "Connector*:*_1x??_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Conn_01x14_1_1"
-        (rectangle (start -1.27 -17.653) (end 0 -17.907)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -15.113) (end 0 -15.367)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -12.573) (end 0 -12.827)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -10.033) (end 0 -10.287)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -7.493) (end 0 -7.747)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -4.953) (end 0 -5.207)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 -2.413) (end 0 -2.667)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 0.127) (end 0 -0.127)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 2.667) (end 0 2.413)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 5.207) (end 0 4.953)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 7.747) (end 0 7.493)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 10.287) (end 0 10.033)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 12.827) (end 0 12.573)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 15.367) (end 0 15.113)
-          (stroke (width 0.1524) (type default))
-          (fill (type none))
-        )
-        (rectangle (start -1.27 16.51) (end 1.27 -19.05)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-        (pin passive line (at -5.08 15.24 0) (length 3.81)
-          (name "Pin_1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -7.62 0) (length 3.81)
-          (name "Pin_10" (effects (font (size 1.27 1.27))))
-          (number "10" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -10.16 0) (length 3.81)
-          (name "Pin_11" (effects (font (size 1.27 1.27))))
-          (number "11" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -12.7 0) (length 3.81)
-          (name "Pin_12" (effects (font (size 1.27 1.27))))
-          (number "12" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -15.24 0) (length 3.81)
-          (name "Pin_13" (effects (font (size 1.27 1.27))))
-          (number "13" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -17.78 0) (length 3.81)
-          (name "Pin_14" (effects (font (size 1.27 1.27))))
-          (number "14" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 12.7 0) (length 3.81)
-          (name "Pin_2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 10.16 0) (length 3.81)
-          (name "Pin_3" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 7.62 0) (length 3.81)
-          (name "Pin_4" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 5.08 0) (length 3.81)
-          (name "Pin_5" (effects (font (size 1.27 1.27))))
-          (number "5" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 2.54 0) (length 3.81)
-          (name "Pin_6" (effects (font (size 1.27 1.27))))
-          (number "6" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 0 0) (length 3.81)
-          (name "Pin_7" (effects (font (size 1.27 1.27))))
-          (number "7" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -2.54 0) (length 3.81)
-          (name "Pin_8" (effects (font (size 1.27 1.27))))
-          (number "8" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -5.08 0) (length 3.81)
-          (name "Pin_9" (effects (font (size 1.27 1.27))))
-          (number "9" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:C" (pin_numbers hide) (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C" (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Unpolarized capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "C_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_0_1"
-        (polyline
-          (pts
-            (xy -2.032 -0.762)
-            (xy 2.032 -0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.032 0.762)
-            (xy 2.032 0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "C_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:C_Polarized" (pin_numbers hide) (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C_Polarized" (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Polarized capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "CP_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_Polarized_0_1"
-        (rectangle (start -2.286 0.508) (end 2.286 1.016)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.778 2.286)
-            (xy -0.762 2.286)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 2.794)
-            (xy -1.27 1.778)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 2.286 -0.508) (end -2.286 -1.016)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "C_Polarized_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:D_Schottky" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at 0 2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "D_Schottky" (at 0 -2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "diode Schottky" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Schottky diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "D_Schottky_0_1"
-        (polyline
-          (pts
-            (xy 1.27 0)
-            (xy -1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 1.27)
-            (xy 1.27 -1.27)
-            (xy -1.27 0)
-            (xy 1.27 1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.905 0.635)
-            (xy -1.905 1.27)
-            (xy -1.27 1.27)
-            (xy -1.27 -1.27)
-            (xy -0.635 -1.27)
-            (xy -0.635 -0.635)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "D_Schottky_1_1"
-        (pin passive line (at -3.81 0 0) (length 2.54)
-          (name "K" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 3.81 0 180) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:LED" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at 0 2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "LED" (at 0 -2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "LED diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Light emitting diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "LED_0_1"
-        (polyline
-          (pts
-            (xy -1.27 -1.27)
-            (xy -1.27 1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 0)
-            (xy 1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 -1.27)
-            (xy 1.27 1.27)
-            (xy -1.27 0)
-            (xy 1.27 -1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.048 -0.762)
-            (xy -4.572 -2.286)
-            (xy -3.81 -2.286)
-            (xy -4.572 -2.286)
-            (xy -4.572 -1.524)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.778 -0.762)
-            (xy -3.302 -2.286)
-            (xy -2.54 -2.286)
-            (xy -3.302 -2.286)
-            (xy -3.302 -1.524)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "LED_1_1"
-        (pin passive line (at -3.81 0 0) (length 2.54)
-          (name "K" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 3.81 0 180) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:Polyfuse_Small" (pin_numbers hide) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "F" (at -1.905 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "Polyfuse_Small" (at 1.905 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 1.27 -5.08 0)
-        (effects (font (size 1.27 1.27)) (justify left) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "resettable fuse PTC PPTC polyfuse polyswitch" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Resettable fuse, polymeric positive temperature coefficient, small symbol" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "*polyfuse* *PTC*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Polyfuse_Small_0_1"
-        (rectangle (start -0.508 1.27) (end 0.508 -1.27)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.54)
-            (xy 0 -2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.016 1.27)
-            (xy -1.016 0.762)
-            (xy 1.016 -0.762)
-            (xy 1.016 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "Polyfuse_Small_1_1"
-        (pin passive line (at 0 2.54 270) (length 0.635)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -2.54 90) (length 0.635)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:R" (pin_numbers hide) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "R" (at 2.032 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "R" (at 0 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at -1.778 0 90)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "R res resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "R_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "R_0_1"
-        (rectangle (start -1.016 -2.54) (end 1.016 2.54)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "R_1_1"
-        (pin passive line (at 0 3.81 270) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GND_1" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "GND_1" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"GND\" , ground" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "GND_1_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 -1.27)
-            (xy 1.27 -1.27)
-            (xy 0 -2.54)
-            (xy -1.27 -1.27)
-            (xy 0 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "GND_1_1_1"
-        (pin power_in line (at 0 0 270) (length 0) hide
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:22-23-2021" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
-      (property "Reference" "J" (at -2.54 1.27 0)
-        (effects (font (size 1.27 1.27)) (justify right))
-      )
-      (property "Value" "22-23-2021" (at 1.27 -3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "Connector_Molex:Molex_KK-254_AE-6410-02A_1x02_P2.54mm_Vertical" (at 5.08 5.08 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Datasheet" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf" (at 5.08 7.62 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Digi-Key_PN" "WM4200-ND" (at 5.08 10.16 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "MPN" "22-23-2021" (at 5.08 12.7 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Category" "Connectors, Interconnects" (at 5.08 15.24 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Family" "Rectangular Connectors - Headers, Male Pins" (at 5.08 17.78 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Datasheet_Link" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf" (at 5.08 20.32 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Detail_Page" "/product-detail/en/molex/22-23-2021/WM4200-ND/26667" (at 5.08 22.86 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Description" "CONN HEADER VERT 2POS 2.54MM" (at 5.08 25.4 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Manufacturer" "Molex" (at 5.08 27.94 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Status" "Active" (at 5.08 30.48 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Assembly Type" "HAND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "WM4200-ND KK 6373" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "CONN HEADER VERT 2POS 2.54MM" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "22-23-2021_1_1"
-        (rectangle (start -1.27 0) (end 3.81 -2.54)
-          (stroke (width 0) (type default))
-          (fill (type background))
-        )
-        (rectangle (start -0.254 -1.143) (end 0.254 -1.651)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start 2.286 -1.143) (end 2.794 -1.651)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (pin passive line (at 0 2.54 270) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 2.54 270) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:Barrel_Jack_Switch_SMT" (pin_names hide) (in_bom yes) (on_board yes)
-      (property "Reference" "J" (at 0 5.334 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "Barrel_Jack_Switch_SMT" (at 1.27 -6.35 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:BarrelJack_CLIFF_FC681465S_SMT_Horizontal" (at 1.27 -1.016 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://tensility.s3.amazonaws.com/uploads/pdffiles/54-00164.pdf" (at 1.27 -1.016 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "JLCPCB" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "C319134" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer" "XKB Connectivity / Tensility International Corp" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN" "DC-005-5A-2.0-SMT / 54-00164" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Description" "Power Barrel Connector Jack 2.10mm ID (0.083\"), 5.50mm OD (0.217\") Surface Mount, Right Angle" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 2" "Digikey" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 2 PN" "839-54-00164CT-ND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "0.205" (at 0 0 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "ki_keywords" "DC power barrel jack connector" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "DC Barrel Jack with an internal switch and a mounting pin" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "BarrelJack*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Barrel_Jack_Switch_SMT_0_1"
-        (rectangle (start -5.08 3.81) (end 5.08 -3.81)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-        (arc (start -3.302 3.175) (mid -3.9343 2.54) (end -3.302 1.905)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (arc (start -3.302 3.175) (mid -3.9343 2.54) (end -3.302 1.905)
-          (stroke (width 0.254) (type default))
-          (fill (type outline))
-        )
-        (polyline
-          (pts
-            (xy 1.27 -2.286)
-            (xy 1.905 -1.651)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 5.08 2.54)
-            (xy 3.81 2.54)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 5.08 5.08)
-            (xy 4.318 5.08)
-            (xy 4.318 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 5.08 0)
-            (xy 1.27 0)
-            (xy 1.27 -2.286)
-            (xy 0.635 -1.651)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.81 -2.54)
-            (xy -2.54 -2.54)
-            (xy -1.27 -1.27)
-            (xy 0 -2.54)
-            (xy 2.54 -2.54)
-            (xy 5.08 -2.54)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 3.683 3.175) (end -3.302 1.905)
-          (stroke (width 0.254) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "Barrel_Jack_Switch_SMT_1_1"
-        (pin passive line (at 7.62 2.54 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 7.62 -2.54 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 7.62 0 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 7.62 5.08 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:ESP32-WROOM-32D-PINORDER" (in_bom yes) (on_board yes)
-      (property "Reference" "U?" (at -4.3941 31.75 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "ESP32-WROOM-32D" (at -4.3941 29.21 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "RF_Module:ESP32-WROOM-32D" (at 12.7 -25.4 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32d_esp32-wroom-32u_datasheet_en.pdf" (at 17.78 -7.62 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "3.42" (at -6.35 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "JLCPCB" (at -6.35 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "C473012" (at -6.35 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN" "ESP32-WROOM-32D-N4" (at -6.35 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer" "Espressif Systems" (at -6.35 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "RF Radio BT ESP ESP32 Espressif onboard PCB antenna" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "RF Module, ESP32-D0WD SoC, Wi-Fi 802.11b/g/n, Bluetooth, BLE, 32-bit, 2.7-3.6V, onboard antenna, SMD" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "ESP32?WROOM?32D*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "ESP32-WROOM-32D-PINORDER_0_1"
-        (rectangle (start -19.05 26.67) (end 19.05 -24.13)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-      )
-      (symbol "ESP32-WROOM-32D-PINORDER_1_1"
-        (pin power_in line (at -21.59 20.32 0) (length 2.54)
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -21.59 -2.54 0) (length 2.54)
-          (name "GPIO25" (effects (font (size 1.27 1.27))))
-          (number "10" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -21.59 -5.08 0) (length 2.54)
-          (name "GPIO26" (effects (font (size 1.27 1.27))))
-          (number "11" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -21.59 -7.62 0) (length 2.54)
-          (name "GPIO27" (effects (font (size 1.27 1.27))))
-          (number "12" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -21.59 -10.16 0) (length 2.54)
-          (name "GPIO14" (effects (font (size 1.27 1.27))))
-          (number "13" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -21.59 -12.7 0) (length 2.54)
-          (name "GPIO12" (effects (font (size 1.27 1.27))))
-          (number "14" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at -11.43 -26.67 90) (length 2.54)
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "15" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -8.89 -26.67 90) (length 2.54)
-          (name "GPIO13" (effects (font (size 1.27 1.27))))
-          (number "16" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -6.35 -26.67 90) (length 2.54)
-          (name "SHD/SD2/GPIO9" (effects (font (size 1.27 1.27))))
-          (number "17" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -3.81 -26.67 90) (length 2.54)
-          (name "SWP/SD3/GPIO10" (effects (font (size 1.27 1.27))))
-          (number "18" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -1.27 -26.67 90) (length 2.54)
-          (name "SCS/CMD/GPIO11/U1RTS" (effects (font (size 1.27 1.27))))
-          (number "19" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at -21.59 17.78 0) (length 2.54)
-          (name "VDD" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 1.27 -26.67 90) (length 2.54)
-          (name "SCK/CLK/GPIO6/U1CTS" (effects (font (size 1.27 1.27))))
-          (number "20" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 3.81 -26.67 90) (length 2.54)
-          (name "SDO/SD0/GPIO7" (effects (font (size 1.27 1.27))))
-          (number "21" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 6.35 -26.67 90) (length 2.54)
-          (name "SDI/SD1/GPIO8" (effects (font (size 1.27 1.27))))
-          (number "22" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 8.89 -26.67 90) (length 2.54)
-          (name "GPIO15/U1RXD" (effects (font (size 1.27 1.27))))
-          (number "23" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 11.43 -26.67 90) (length 2.54)
-          (name "GPIO2/U1TXD" (effects (font (size 1.27 1.27))))
-          (number "24" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 -12.7 180) (length 2.54)
-          (name "GPIO0" (effects (font (size 1.27 1.27))))
-          (number "25" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 -10.16 180) (length 2.54)
-          (name "GPIO4" (effects (font (size 1.27 1.27))))
-          (number "26" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 -7.62 180) (length 2.54)
-          (name "RX2/GPIO16" (effects (font (size 1.27 1.27))))
-          (number "27" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 -5.08 180) (length 2.54)
-          (name "TX2/GPIO17" (effects (font (size 1.27 1.27))))
-          (number "28" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 -2.54 180) (length 2.54)
-          (name "GPIO5" (effects (font (size 1.27 1.27))))
-          (number "29" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -21.59 15.24 0) (length 2.54)
-          (name "EN" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 0 180) (length 2.54)
-          (name "GPIO18" (effects (font (size 1.27 1.27))))
-          (number "30" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 2.54 180) (length 2.54)
-          (name "GPIO19" (effects (font (size 1.27 1.27))))
-          (number "31" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 21.59 5.08 180) (length 2.54)
-          (name "DO_NOT_CONNECT" (effects (font (size 1.27 1.27))))
-          (number "32" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 7.62 180) (length 2.54)
-          (name "GPIO21" (effects (font (size 1.27 1.27))))
-          (number "33" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 10.16 180) (length 2.54)
-          (name "RXD0/GPIO3" (effects (font (size 1.27 1.27))))
-          (number "34" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 12.7 180) (length 2.54)
-          (name "TXD0/GPIO1" (effects (font (size 1.27 1.27))))
-          (number "35" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 15.24 180) (length 2.54)
-          (name "GPIO22" (effects (font (size 1.27 1.27))))
-          (number "36" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 21.59 17.78 180) (length 2.54)
-          (name "GPIO23" (effects (font (size 1.27 1.27))))
-          (number "37" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 21.59 20.32 180) (length 2.54)
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "38" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 21.59 22.86 180) (length 2.54)
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "39" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -21.59 12.7 0) (length 2.54)
-          (name "GPIO36_VP" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -21.59 10.16 0) (length 2.54)
-          (name "GPIO39_VN" (effects (font (size 1.27 1.27))))
-          (number "5" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -21.59 7.62 0) (length 2.54)
-          (name "GPIO34" (effects (font (size 1.27 1.27))))
-          (number "6" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -21.59 5.08 0) (length 2.54)
-          (name "GPIO35" (effects (font (size 1.27 1.27))))
-          (number "7" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -21.59 2.54 0) (length 2.54)
-          (name "GPIO32" (effects (font (size 1.27 1.27))))
-          (number "8" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -21.59 0 0) (length 2.54)
-          (name "GPIO33" (effects (font (size 1.27 1.27))))
-          (number "9" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:IEC_power_polarity_symbols_barrel_jack_Center_positive" (in_bom no) (on_board no)
-      (property "Reference" "#SYM" (at 0 6.985 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "IEC_power_polarity_symbols_barrel_jack_Center_positive" (at -0.1524 -7.3152 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:Symbol_Barrel_Polarity_Center_Positive" (at -0.4318 -5.3594 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 -2.54 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Enable" "0" (at 0 -2.54 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "polarity" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "IEC power polarity symbols barrel jack" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "IEC_power_polarity_symbols_barrel_jack_Center_positive_0_1"
-        (circle (center -8.89 0) (radius 1.27)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 8.89 0) (radius 1.27)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "IEC_power_polarity_symbols_barrel_jack_Center_positive_1_1"
-        (arc (start -1.524 -1.0433) (mid 0 -1.8469) (end 1.524 -1.0433)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (arc (start -1.0433 1.524) (mid -1.8469 0) (end -1.0433 -1.524)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -8.382 0)
-            (xy -9.398 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -7.62 0)
-            (xy -1.905 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.762 0)
-            (xy 7.62 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 8.89 -0.508)
-            (xy 8.89 0.508)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 9.398 0)
-            (xy 8.382 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 0 0) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (arc (start 1.524 1.0433) (mid 0 1.8469) (end -1.524 1.0433)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE" (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at -3.81 2.54 0)
-        (effects (font (size 1.524 1.524)))
-      )
-      (property "Value" "LED_T1.75_CLEAR_WHITE" (at -1.27 -3.81 0)
-        (effects (font (size 1.524 1.524)))
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial" (at 5.08 5.08 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 5.08 7.62 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Digi-Key_PN" "160-1772-ND" (at 5.08 10.16 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "MPN" "LTW-2R3D7" (at 5.08 12.7 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Category" "Optoelectronics" (at 5.08 15.24 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Family" "LED Indication - Discrete" (at 5.08 17.78 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 5.08 20.32 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121" (at 5.08 22.86 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Description" "LED WHITE CLEAR T-1 3/4 T/H" (at 5.08 25.4 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Manufacturer" "Lite-On Inc." (at 5.08 27.94 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Status" "Active" (at 5.08 30.48 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "ki_keywords" "160-1772-ND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "LED WHITE CLEAR T-1 3/4 T/H" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "LED_T1.75_CLEAR_WHITE_0_1"
-        (polyline
-          (pts
-            (xy 0 1.27)
-            (xy 0 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 3.81)
-            (xy -1.27 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 3.175)
-            (xy 0 1.905)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -0.635 3.81)
-            (xy 0 3.81)
-            (xy 0 3.175)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.635 3.175)
-            (xy 1.27 3.175)
-            (xy 1.27 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.54 1.27)
-            (xy -2.54 -1.27)
-            (xy 0 0)
-            (xy -2.54 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "LED_T1.75_CLEAR_WHITE_1_1"
-        (pin passive line (at -5.08 0 0) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 0 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:MountingHole_Pad_3.5mm" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "H103" (at 2.54 1.2446 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "MountingHole_Pad_3.5mm" (at 0 -1.27 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:MountingHole_3.5mm_Pad_Via" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "0" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "AssemblyType" "NA" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Description" "MountingHole_Pad_3.5mm" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "NA" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "NA" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN" "NA" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer" "NA" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "mounting hole" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Mounting Hole with connection" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "MountingHole*Pad*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "MountingHole_Pad_3.5mm_0_1"
-        (circle (center 0 1.27) (radius 1.27)
-          (stroke (width 1.27) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "MountingHole_Pad_3.5mm_1_1"
-        (pin input line (at 0 -2.54 90) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:RotaryEncoder_Switch_MP" (pin_names (offset 0.254) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "SW" (at 2.54 6.35 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "RotaryEncoder_Switch" (at 11.43 -6.35 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at -3.81 4.064 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 6.604 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "rotary switch encoder switch push button" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Rotary encoder, dual channel, incremental quadrate outputs, with switch" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "RotaryEncoder*Switch*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "RotaryEncoder_Switch_MP_0_1"
-        (rectangle (start -5.08 5.08) (end 5.08 -5.08)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-        (circle (center -3.81 0) (radius 0.254)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (circle (center -0.381 0) (radius 1.905)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (arc (start -0.381 2.667) (mid -3.0988 -0.0635) (end -0.381 -2.794)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -0.635 -1.778)
-            (xy -0.635 1.778)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -0.381 -1.778)
-            (xy -0.381 1.778)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -0.127 1.778)
-            (xy -0.127 -1.778)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.81 0)
-            (xy 3.429 0)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.81 1.016)
-            (xy 3.81 -1.016)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -5.08 -2.54)
-            (xy -3.81 -2.54)
-            (xy -3.81 -2.032)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -5.08 2.54)
-            (xy -3.81 2.54)
-            (xy -3.81 2.032)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.254 -3.048)
-            (xy -0.508 -2.794)
-            (xy 0.127 -2.413)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.254 2.921)
-            (xy -0.508 2.667)
-            (xy 0.127 2.286)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 5.08 -2.54)
-            (xy 4.318 -2.54)
-            (xy 4.318 -1.016)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 5.08 2.54)
-            (xy 4.318 2.54)
-            (xy 4.318 1.016)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -5.08 0)
-            (xy -3.81 0)
-            (xy -3.81 -1.016)
-            (xy -3.302 -2.032)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -4.318 0)
-            (xy -3.81 0)
-            (xy -3.81 1.016)
-            (xy -3.302 2.032)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 4.318 -1.016) (radius 0.127)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (circle (center 4.318 1.016) (radius 0.127)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "RotaryEncoder_Switch_MP_1_1"
-        (pin passive line (at -7.62 2.54 0) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "A" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 -2.54 0) (length 2.54)
-          (name "B" (effects (font (size 1.27 1.27))))
-          (number "B" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 0 0) (length 2.54)
-          (name "C" (effects (font (size 1.27 1.27))))
-          (number "C" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 0 -7.62 90) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "MP1" (effects (font (size 0.762 0.762))))
-        )
-        (pin power_in line (at 0 7.62 270) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "MP2" (effects (font (size 0.762 0.762))))
-        )
-        (pin passive line (at 7.62 2.54 180) (length 2.54)
-          (name "S1" (effects (font (size 1.27 1.27))))
-          (number "S1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 7.62 -2.54 180) (length 2.54)
-          (name "S2" (effects (font (size 1.27 1.27))))
-          (number "S2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:SWITCH_TACTILE_SPST-NO_0.05A_24V" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
-      (property "Reference" "S101" (at 0 5.08 0)
-        (effects (font (size 1.524 1.524)))
-      )
-      (property "Value" "SWITCH_TACTILE_SPST-NO_0.05A_24V" (at -11.43 -4.445 0)
-        (effects (font (size 1.524 1.524)))
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:Switch_Tactile_THT_6x6mm" (at 5.08 5.08 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Datasheet" "https://www.te.com/commerce/DocumentDelivery/DDEController?Action=srchrtrv&DocNm=1825910&DocType=Customer+Drawing&DocLang=English" (at 5.08 7.62 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Distributor 1 PN" "C13828" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "JLCPCB" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 2" "Digikey" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 2 PN" "450-1804-ND" (at 5.08 10.16 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Manufacturer" "TE Connectivity ALCOSWITCH Switches" (at 5.08 27.94 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "MPN" "TE Connectivity 1825910-7,   Dongguan Guangzhu Industrial C13828" (at 5.08 12.7 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Category" "Switches" (at 5.08 15.24 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Family" "Tactile Switches" (at 5.08 17.78 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Datasheet_Link" "https://www.te.com/commerce/DocumentDelivery/DDEController?Action=srchrtrv&DocNm=1825910&DocType=Customer+Drawing&DocLang=English" (at 5.08 20.32 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Detail_Page" "/product-detail/en/te-connectivity-alcoswitch-switches/1825910-7/450-1804-ND/1731414" (at 5.08 22.86 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Description" "±10% ±100ppm/℃ 10kΩ Plugin Variable Resistors/Potentiometers ROHS" (at 5.08 25.4 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Status" "Active" (at 5.08 30.48 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Assembly Type" "" (at -139.7 -68.58 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "AssemblyType" "HAND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Cost" "0.0315" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "450-1804-ND FSMJ" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "SWITCH TACTILE SPST-NO 0.05A 24V" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "SWITCH_TACTILE_SPST-NO_0.05A_24V_0_1"
-        (circle (center -1.524 0) (radius 0.254)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.54 2.54)
-            (xy -2.54 -2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.778 0)
-            (xy -2.54 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.778 1.27)
-            (xy 1.778 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 -2.54)
-            (xy 2.54 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 0)
-            (xy 1.778 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 1.524 0) (radius 0.254)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "SWITCH_TACTILE_SPST-NO_0.05A_24V_1_1"
-        (polyline
-          (pts
-            (xy -1.016 2.794)
-            (xy 0.889 2.794)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.794)
-            (xy 0 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (pin passive line (at -5.08 2.54 0) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -5.08 -2.54 0) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 5.08 2.54 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 5.08 -2.54 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:ToolingHole_Pad_1.152mm" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "T" (at -1.27 3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "ToolingHole_Pad_1.152mm" (at 0 2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "ToolingHole_1.152mm_Pad_Via" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "Tooling hole" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Tooling Hole " (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "MountingHole*Pad*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "ToolingHole_Pad_1.152mm_1_1"
-        (circle (center 0 0) (radius 1.27)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff" (in_bom yes) (on_board yes)
-      (property "Reference" "MF" (at 0 0 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff" (at 0 0 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "U_Box_V104_General_Alarm_Device_LED_Standoff_0_1"
-        (circle (center -2.54 0) (radius 1.27)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 0 0) (radius 4.0161)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 2.54 0) (radius 1.27)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-    (symbol "Graphic:Logo_Open_Hardware_Small" (in_bom no) (on_board no)
-      (property "Reference" "#SYM" (at 0 6.985 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "Logo_Open_Hardware_Small" (at 0 -5.715 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Enable" "0" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "Logo" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Open Hardware logo, small" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Logo_Open_Hardware_Small_0_1"
-        (polyline
-          (pts
-            (xy 3.3528 -4.3434)
-            (xy 3.302 -4.318)
-            (xy 3.175 -4.2418)
-            (xy 2.9972 -4.1148)
-            (xy 2.7686 -3.9624)
-            (xy 2.54 -3.81)
-            (xy 2.3622 -3.7084)
-            (xy 2.2352 -3.6068)
-            (xy 2.1844 -3.5814)
-            (xy 2.159 -3.6068)
-            (xy 2.0574 -3.6576)
-            (xy 1.905 -3.7338)
-            (xy 1.8034 -3.7846)
-            (xy 1.6764 -3.8354)
-            (xy 1.6002 -3.8354)
-            (xy 1.6002 -3.8354)
-            (xy 1.5494 -3.7338)
-            (xy 1.4732 -3.5306)
-            (xy 1.3462 -3.302)
-            (xy 1.2446 -3.0226)
-            (xy 1.1176 -2.7178)
-            (xy 0.9652 -2.413)
-            (xy 0.8636 -2.1082)
-            (xy 0.7366 -1.8288)
-            (xy 0.6604 -1.6256)
-            (xy 0.6096 -1.4732)
-            (xy 0.5842 -1.397)
-            (xy 0.5842 -1.397)
-            (xy 0.6604 -1.3208)
-            (xy 0.7874 -1.2446)
-            (xy 1.0414 -1.016)
-            (xy 1.2954 -0.6858)
-            (xy 1.4478 -0.3302)
-            (xy 1.524 0.0762)
-            (xy 1.4732 0.4572)
-            (xy 1.3208 0.8128)
-            (xy 1.0668 1.143)
-            (xy 0.762 1.3716)
-            (xy 0.4064 1.524)
-            (xy 0 1.5748)
-            (xy -0.381 1.5494)
-            (xy -0.7366 1.397)
-            (xy -1.0668 1.143)
-            (xy -1.2192 0.9906)
-            (xy -1.397 0.6604)
-            (xy -1.524 0.3048)
-            (xy -1.524 0.2286)
-            (xy -1.4986 -0.1778)
-            (xy -1.397 -0.5334)
-            (xy -1.1938 -0.8636)
-            (xy -0.9144 -1.143)
-            (xy -0.8636 -1.1684)
-            (xy -0.7366 -1.27)
-            (xy -0.635 -1.3462)
-            (xy -0.5842 -1.397)
-            (xy -1.0668 -2.5908)
-            (xy -1.143 -2.794)
-            (xy -1.2954 -3.1242)
-            (xy -1.397 -3.4036)
-            (xy -1.4986 -3.6322)
-            (xy -1.5748 -3.7846)
-            (xy -1.6002 -3.8354)
-            (xy -1.6002 -3.8354)
-            (xy -1.651 -3.8354)
-            (xy -1.7272 -3.81)
-            (xy -1.905 -3.7338)
-            (xy -2.0066 -3.683)
-            (xy -2.1336 -3.6068)
-            (xy -2.2098 -3.5814)
-            (xy -2.2606 -3.6068)
-            (xy -2.3622 -3.683)
-            (xy -2.54 -3.81)
-            (xy -2.7686 -3.9624)
-            (xy -2.9718 -4.0894)
-            (xy -3.1496 -4.2164)
-            (xy -3.302 -4.318)
-            (xy -3.3528 -4.3434)
-            (xy -3.3782 -4.3434)
-            (xy -3.429 -4.318)
-            (xy -3.5306 -4.2164)
-            (xy -3.7084 -4.064)
-            (xy -3.937 -3.8354)
-            (xy -3.9624 -3.81)
-            (xy -4.1656 -3.6068)
-            (xy -4.318 -3.4544)
-            (xy -4.4196 -3.3274)
-            (xy -4.445 -3.2766)
-            (xy -4.445 -3.2766)
-            (xy -4.4196 -3.2258)
-            (xy -4.318 -3.0734)
-            (xy -4.2164 -2.8956)
-            (xy -4.064 -2.667)
-            (xy -3.6576 -2.0828)
-            (xy -3.8862 -1.5494)
-            (xy -3.937 -1.3716)
-            (xy -4.0386 -1.1684)
-            (xy -4.0894 -1.0414)
-            (xy -4.1148 -0.9652)
-            (xy -4.191 -0.9398)
-            (xy -4.318 -0.9144)
-            (xy -4.5466 -0.8636)
-            (xy -4.8006 -0.8128)
-            (xy -5.0546 -0.7874)
-            (xy -5.2578 -0.7366)
-            (xy -5.4356 -0.7112)
-            (xy -5.5118 -0.6858)
-            (xy -5.5118 -0.6858)
-            (xy -5.5372 -0.635)
-            (xy -5.5372 -0.5588)
-            (xy -5.5372 -0.4318)
-            (xy -5.5626 -0.2286)
-            (xy -5.5626 0.0762)
-            (xy -5.5626 0.127)
-            (xy -5.5372 0.4064)
-            (xy -5.5372 0.635)
-            (xy -5.5372 0.762)
-            (xy -5.5372 0.8382)
-            (xy -5.5372 0.8382)
-            (xy -5.461 0.8382)
-            (xy -5.3086 0.889)
-            (xy -5.08 0.9144)
-            (xy -4.826 0.9652)
-            (xy -4.8006 0.9906)
-            (xy -4.5466 1.0414)
-            (xy -4.318 1.0668)
-            (xy -4.1656 1.1176)
-            (xy -4.0894 1.143)
-            (xy -4.0894 1.143)
-            (xy -4.0386 1.2446)
-            (xy -3.9624 1.4224)
-            (xy -3.8608 1.6256)
-            (xy -3.7846 1.8288)
-            (xy -3.7084 2.0066)
-            (xy -3.6576 2.159)
-            (xy -3.6322 2.2098)
-            (xy -3.6322 2.2098)
-            (xy -3.683 2.286)
-            (xy -3.7592 2.413)
-            (xy -3.8862 2.5908)
-            (xy -4.064 2.8194)
-            (xy -4.064 2.8448)
-            (xy -4.2164 3.0734)
-            (xy -4.3434 3.2512)
-            (xy -4.4196 3.3782)
-            (xy -4.445 3.4544)
-            (xy -4.445 3.4544)
-            (xy -4.3942 3.5052)
-            (xy -4.2926 3.6322)
-            (xy -4.1148 3.81)
-            (xy -3.937 4.0132)
-            (xy -3.8608 4.064)
-            (xy -3.6576 4.2926)
-            (xy -3.5052 4.4196)
-            (xy -3.4036 4.4958)
-            (xy -3.3528 4.5212)
-            (xy -3.3528 4.5212)
-            (xy -3.302 4.4704)
-            (xy -3.1496 4.3688)
-            (xy -2.9718 4.2418)
-            (xy -2.7432 4.0894)
-            (xy -2.7178 4.0894)
-            (xy -2.4892 3.937)
-            (xy -2.3114 3.81)
-            (xy -2.1844 3.7084)
-            (xy -2.1336 3.683)
-            (xy -2.1082 3.683)
-            (xy -2.032 3.7084)
-            (xy -1.8542 3.7592)
-            (xy -1.6764 3.8354)
-            (xy -1.4732 3.937)
-            (xy -1.27 4.0132)
-            (xy -1.143 4.064)
-            (xy -1.0668 4.1148)
-            (xy -1.0668 4.1148)
-            (xy -1.0414 4.191)
-            (xy -1.016 4.3434)
-            (xy -0.9652 4.572)
-            (xy -0.9144 4.8514)
-            (xy -0.889 4.9022)
-            (xy -0.8382 5.1562)
-            (xy -0.8128 5.3848)
-            (xy -0.7874 5.5372)
-            (xy -0.762 5.588)
-            (xy -0.7112 5.6134)
-            (xy -0.5842 5.6134)
-            (xy -0.4064 5.6134)
-            (xy -0.1524 5.6134)
-            (xy 0.0762 5.6134)
-            (xy 0.3302 5.6134)
-            (xy 0.5334 5.6134)
-            (xy 0.6858 5.588)
-            (xy 0.7366 5.588)
-            (xy 0.7366 5.588)
-            (xy 0.762 5.5118)
-            (xy 0.8128 5.334)
-            (xy 0.8382 5.1054)
-            (xy 0.9144 4.826)
-            (xy 0.9144 4.7752)
-            (xy 0.9652 4.5212)
-            (xy 1.016 4.2926)
-            (xy 1.0414 4.1402)
-            (xy 1.0668 4.0894)
-            (xy 1.0668 4.0894)
-            (xy 1.1938 4.0386)
-            (xy 1.3716 3.9624)
-            (xy 1.5748 3.8608)
-            (xy 2.0828 3.6576)
-            (xy 2.7178 4.0894)
-            (xy 2.7686 4.1402)
-            (xy 2.9972 4.2926)
-            (xy 3.175 4.4196)
-            (xy 3.302 4.4958)
-            (xy 3.3782 4.5212)
-            (xy 3.3782 4.5212)
-            (xy 3.429 4.4704)
-            (xy 3.556 4.3434)
-            (xy 3.7338 4.191)
-            (xy 3.9116 3.9878)
-            (xy 4.064 3.8354)
-            (xy 4.2418 3.6576)
-            (xy 4.3434 3.556)
-            (xy 4.4196 3.4798)
-            (xy 4.4196 3.429)
-            (xy 4.4196 3.4036)
-            (xy 4.3942 3.3274)
-            (xy 4.2926 3.2004)
-            (xy 4.1656 2.9972)
-            (xy 4.0132 2.794)
-            (xy 3.8862 2.5908)
-            (xy 3.7592 2.3876)
-            (xy 3.6576 2.2352)
-            (xy 3.6322 2.159)
-            (xy 3.6322 2.1336)
-            (xy 3.683 2.0066)
-            (xy 3.7592 1.8288)
-            (xy 3.8608 1.6002)
-            (xy 4.064 1.1176)
-            (xy 4.3942 1.0414)
-            (xy 4.5974 1.016)
-            (xy 4.8768 0.9652)
-            (xy 5.1308 0.9144)
-            (xy 5.5372 0.8382)
-            (xy 5.5626 -0.6604)
-            (xy 5.4864 -0.6858)
-            (xy 5.4356 -0.6858)
-            (xy 5.2832 -0.7366)
-            (xy 5.0546 -0.762)
-            (xy 4.8006 -0.8128)
-            (xy 4.5974 -0.8636)
-            (xy 4.3688 -0.9144)
-            (xy 4.2164 -0.9398)
-            (xy 4.1402 -0.9398)
-            (xy 4.1148 -0.9652)
-            (xy 4.064 -1.0668)
-            (xy 3.9878 -1.2446)
-            (xy 3.9116 -1.4478)
-            (xy 3.81 -1.651)
-            (xy 3.7338 -1.8542)
-            (xy 3.683 -2.0066)
-            (xy 3.6576 -2.0828)
-            (xy 3.683 -2.1336)
-            (xy 3.7846 -2.2606)
-            (xy 3.8862 -2.4638)
-            (xy 4.0386 -2.667)
-            (xy 4.191 -2.8956)
-            (xy 4.318 -3.0734)
-            (xy 4.3942 -3.2004)
-            (xy 4.445 -3.2766)
-            (xy 4.4196 -3.3274)
-            (xy 4.3434 -3.429)
-            (xy 4.1656 -3.5814)
-            (xy 3.937 -3.8354)
-            (xy 3.8862 -3.8608)
-            (xy 3.683 -4.064)
-            (xy 3.5306 -4.2164)
-            (xy 3.4036 -4.318)
-            (xy 3.3528 -4.3434)
-          )
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-      )
-    )
-    (symbol "Regulator_Linear:AMS1117-3.3" (in_bom yes) (on_board yes)
-      (property "Reference" "U" (at -3.81 3.175 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "AMS1117-3.3" (at 0 3.175 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "http://www.advanced-monolithic.com/pdf/ds1117.pdf" (at 2.54 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "linear regulator ldo fixed positive" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "1A Low Dropout regulator, positive, 3.3V fixed output, SOT-223" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "SOT?223*TabPin2*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "AMS1117-3.3_0_1"
-        (rectangle (start -5.08 -5.08) (end 5.08 1.905)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-      )
-      (symbol "AMS1117-3.3_1_1"
-        (pin power_in line (at 0 -7.62 90) (length 2.54)
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_out line (at 7.62 0 180) (length 2.54)
-          (name "VO" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at -7.62 0 0) (length 2.54)
-          (name "VI" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Regulator_Linear:LM7805_TO220" (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "U" (at -3.81 3.175 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "LM7805_TO220" (at 0 3.175 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "Package_TO_SOT_THT:TO-220-3_Vertical" (at 0 5.715 0)
-        (effects (font (size 1.27 1.27) italic) hide)
-      )
-      (property "Datasheet" "https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF" (at 0 -1.27 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "Voltage Regulator 1A Positive" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Positive 1A 35V Linear Regulator, Fixed Output 5V, TO-220" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "TO?220*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "LM7805_TO220_0_1"
-        (rectangle (start -5.08 1.905) (end 5.08 -5.08)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-      )
-      (symbol "LM7805_TO220_1_1"
-        (pin power_in line (at -7.62 0 0) (length 2.54)
-          (name "VI" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 0 -7.62 90) (length 2.54)
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_out line (at 7.62 0 180) (length 2.54)
-          (name "VO" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "power:+3.3V" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "+3.3V" (at 0 3.556 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"+3.3V\"" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "+3.3V_0_1"
-        (polyline
-          (pts
-            (xy -0.762 1.27)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.54)
-            (xy 0.762 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "+3.3V_1_1"
-        (pin power_in line (at 0 0 90) (length 0) hide
-          (name "+3.3V" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "power:+5V" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "+5V" (at 0 3.556 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"+5V\"" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "+5V_0_1"
-        (polyline
-          (pts
-            (xy -0.762 1.27)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.54)
-            (xy 0.762 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "+5V_1_1"
-        (pin power_in line (at 0 0 90) (length 0) hide
-          (name "+5V" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "power:PWR_FLAG" (power) (pin_numbers hide) (pin_names (offset 0) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "#FLG" (at 0 1.905 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "PWR_FLAG" (at 0 3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "flag power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Special symbol for telling ERC where power comes from" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "PWR_FLAG_0_0"
-        (pin power_out line (at 0 0 90) (length 0)
-          (name "pwr" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-      (symbol "PWR_FLAG_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 1.27)
-            (xy -1.016 1.905)
-            (xy 0 2.54)
-            (xy 1.016 1.905)
-            (xy 0 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-  )
-
-  (junction (at 161.29 91.44) (diameter 0) (color 0 0 0 0)
-    (uuid 03468543-327b-47f3-9671-11e40e6c365d)
-  )
-  (junction (at 111.76 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 03621892-b27c-4129-9d25-96e7e46fc9ca)
-  )
-  (junction (at 111.76 106.68) (diameter 0) (color 0 0 0 0)
-    (uuid 039d8d9d-cee0-451e-87bf-367c7bd79d0c)
-  )
-  (junction (at 210.82 134.62) (diameter 0) (color 0 0 0 0)
-    (uuid 0554b82b-960b-4c3b-ac71-c4ea76a56ac7)
-  )
-  (junction (at 144.78 138.43) (diameter 0) (color 0 0 0 0)
-    (uuid 055c117d-ab7d-406b-a05e-0ff8e606605b)
-  )
-  (junction (at 147.32 138.43) (diameter 0) (color 0 0 0 0)
-    (uuid 0d5cfec3-60b8-4ead-9751-2e942cd0a570)
-  )
-  (junction (at 171.45 99.06) (diameter 0) (color 0 0 0 0)
-    (uuid 13712ae1-b4e4-4645-8f0d-37b6e1bc237d)
-  )
-  (junction (at 210.82 139.7) (diameter 0) (color 0 0 0 0)
-    (uuid 14dc0ad6-2547-4241-bbb4-ab8ee0d14274)
-  )
-  (junction (at 33.02 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 168541e9-4b42-499e-bc97-341acbfb186a)
-  )
-  (junction (at 121.92 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid 195f0b50-6417-4727-814b-cf1391e47f25)
-  )
-  (junction (at 190.5 137.16) (diameter 0) (color 0 0 0 0)
-    (uuid 1ff8c054-6d67-4bca-b740-900ed8ff62e3)
-  )
-  (junction (at 74.93 105.41) (diameter 0) (color 0 0 0 0)
-    (uuid 3027e5a5-c41a-40fb-ba4f-793c7545cdd5)
-  )
-  (junction (at 111.76 96.52) (diameter 0) (color 0 0 0 0)
-    (uuid 33fdc9ee-bd3c-4433-b322-f3d045dc5894)
-  )
-  (junction (at 147.32 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid 3776d9fc-34f1-47cb-828d-285a18c1c50b)
-  )
-  (junction (at 190.5 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid 397602ef-9661-4e78-b678-96bb0057799a)
-  )
-  (junction (at 101.6 93.98) (diameter 0) (color 0 0 0 0)
-    (uuid 41bc5617-a2bf-429d-a0aa-9ec5dbf92fce)
-  )
-  (junction (at 36.83 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid 444154d3-c757-4e59-aaf5-de4585250cbf)
-  )
-  (junction (at 35.56 33.02) (diameter 0) (color 0 0 0 0)
-    (uuid 4aa1cccd-27e6-40d5-88ad-95cc6d778882)
-  )
-  (junction (at 173.99 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 4ce67390-a76a-4513-860e-9d10a5dd6936)
-  )
-  (junction (at 111.76 111.76) (diameter 0) (color 0 0 0 0)
-    (uuid 5237aee7-a4e0-4179-b9cb-bf9b58957aba)
-  )
-  (junction (at 39.37 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid 53643437-1d77-4de7-bd0b-b04e2a707771)
-  )
-  (junction (at 127 138.43) (diameter 0) (color 0 0 0 0)
-    (uuid 545a140e-d467-46da-9b81-41caa80279ab)
-  )
-  (junction (at 210.82 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 54abda77-8082-4431-8a05-d2b9a55743fd)
-  )
-  (junction (at 161.29 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 5bc1644a-04ef-4eaf-8485-f1349ce0667c)
-  )
-  (junction (at 262.89 34.29) (diameter 0) (color 0 0 0 0)
-    (uuid 6134dd35-a9fd-49ca-94b5-a350606fa23e)
-  )
-  (junction (at 35.56 92.71) (diameter 0) (color 0 0 0 0)
-    (uuid 64afb8fe-419f-4632-9719-0b3c9c7bf92c)
-  )
-  (junction (at 124.46 138.43) (diameter 0) (color 0 0 0 0)
-    (uuid 659ca905-0664-48b1-ac86-3e8199cae7fc)
-  )
-  (junction (at 236.22 34.29) (diameter 0) (color 0 0 0 0)
-    (uuid 698e6353-e8f1-408f-a5b3-eaa185e606db)
-  )
-  (junction (at 43.18 66.04) (diameter 0) (color 0 0 0 0)
-    (uuid 6c5a1751-0efe-4b3a-bcd7-ecc33694ce29)
-  )
-  (junction (at 111.76 91.44) (diameter 0) (color 0 0 0 0)
-    (uuid 6cd0e424-c94a-45e4-a629-f4677de250b6)
-  )
-  (junction (at 35.56 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid 6e642b49-a859-41f1-a5d7-a4322f76b310)
-  )
-  (junction (at 111.76 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 6f67c1d7-253b-4612-b0de-010ee1456657)
-  )
-  (junction (at 40.64 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 6fb13ebf-e482-4746-a96d-af0c2c7b7c67)
-  )
-  (junction (at 36.83 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 7038dc1f-9eba-43e5-a9d1-b67d2eaec00f)
-  )
-  (junction (at 275.59 34.29) (diameter 0) (color 0 0 0 0)
-    (uuid 7071553b-818a-4728-9ca1-80500eb457e5)
-  )
-  (junction (at 210.82 152.4) (diameter 0) (color 0 0 0 0)
-    (uuid 707606ee-9971-4796-9b36-804d6c8790ed)
-  )
-  (junction (at 161.29 119.38) (diameter 0) (color 0 0 0 0)
-    (uuid 7526ee9c-d1d8-4ea1-8157-a823e3c523e8)
-  )
-  (junction (at 111.76 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 76a80887-cb1a-42ce-afdc-6548a41cb7d6)
-  )
-  (junction (at 210.82 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 76b50a90-6e4d-479c-ac0d-e8736ad2d53d)
-  )
-  (junction (at 111.76 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 77e8fd82-a18f-4184-a532-3ed516f46e86)
-  )
-  (junction (at 68.58 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 7a842307-2b31-4a52-926c-0b714d544955)
-  )
-  (junction (at 54.61 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 7b02338b-8a00-4c28-8ecd-234b1aabe897)
-  )
-  (junction (at 29.21 44.45) (diameter 0) (color 0 0 0 0)
-    (uuid 7b5e784c-ea5b-4f61-8c1c-7b17f6c36992)
-  )
-  (junction (at 101.6 74.93) (diameter 0) (color 0 0 0 0)
-    (uuid 7d3aa73b-91fa-43f0-80bc-6f538523848d)
-  )
-  (junction (at 36.83 44.45) (diameter 0) (color 0 0 0 0)
-    (uuid 7d3d8af7-7b43-481a-a4ad-aca68bdf2d6f)
-  )
-  (junction (at 161.29 93.98) (diameter 0) (color 0 0 0 0)
-    (uuid 81ff9a06-26ac-480d-b245-a2e158524e34)
-  )
-  (junction (at 62.23 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid 82790838-6fe0-45b6-bf2d-e2a9cd72193a)
-  )
-  (junction (at 57.15 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 897f109d-1110-472c-96dc-b0703ced6ca9)
-  )
-  (junction (at 161.29 106.68) (diameter 0) (color 0 0 0 0)
-    (uuid 8ba36a18-e944-4796-9846-8f0cb45c7a09)
-  )
-  (junction (at 161.29 114.3) (diameter 0) (color 0 0 0 0)
-    (uuid 9042ff97-4455-413a-bf7c-7f2e1fa37256)
-  )
-  (junction (at 184.15 31.75) (diameter 0) (color 0 0 0 0)
-    (uuid 95befd87-3192-4f05-933a-0f47e9d25c2d)
-  )
-  (junction (at 161.29 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 961defd8-71de-48b4-a696-2f1d1d7501f7)
-  )
-  (junction (at 71.12 134.62) (diameter 0) (color 0 0 0 0)
-    (uuid 99b5c5ea-9bf1-4d9f-92dd-f15ca011df61)
-  )
-  (junction (at 111.76 116.84) (diameter 0) (color 0 0 0 0)
-    (uuid 9afbf8ad-d9b7-4d19-982d-24158cf9f2b2)
-  )
-  (junction (at 31.75 44.45) (diameter 0) (color 0 0 0 0)
-    (uuid 9ed499c7-5425-4cb5-9a87-99e3edb35e15)
-  )
-  (junction (at 60.96 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 9f3c99a1-8a4d-4259-b670-67c4fdb1da9c)
-  )
-  (junction (at 101.6 72.39) (diameter 0) (color 0 0 0 0)
-    (uuid ac791dc9-db68-4a56-87e6-0cf7bed47b98)
-  )
-  (junction (at 161.29 111.76) (diameter 0) (color 0 0 0 0)
-    (uuid ad322ace-4935-4845-a88a-1a249ec5f7f9)
-  )
-  (junction (at 111.76 93.98) (diameter 0) (color 0 0 0 0)
-    (uuid ae5f9aa9-de46-4c5c-9ec7-4e1137328c6e)
-  )
-  (junction (at 133.35 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid afbde9e9-c37b-4718-9dfa-36259b43e1eb)
-  )
-  (junction (at 67.31 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid b018eb50-59d5-40f8-9e07-95fd22f3dae6)
-  )
-  (junction (at 234.95 34.29) (diameter 0) (color 0 0 0 0)
-    (uuid b0a2e6f2-0dd1-4e76-8be2-a77b63d3bf3f)
-  )
-  (junction (at 161.29 96.52) (diameter 0) (color 0 0 0 0)
-    (uuid b50a46ae-49a5-4aec-bdb6-84fc9a68491f)
-  )
-  (junction (at 161.29 116.84) (diameter 0) (color 0 0 0 0)
-    (uuid bc45b9fd-e049-4a17-ba46-0d7100817fcd)
-  )
-  (junction (at 101.6 71.12) (diameter 0) (color 0 0 0 0)
-    (uuid be1bec4b-041a-4e01-af6a-b4c3661c0942)
-  )
-  (junction (at 273.05 34.29) (diameter 0) (color 0 0 0 0)
-    (uuid c2fcdc36-5c0e-41f8-ac32-69992883fe87)
-  )
-  (junction (at 111.76 119.38) (diameter 0) (color 0 0 0 0)
-    (uuid c38da32d-fb8c-4a8d-bf76-c5be3ac14d84)
-  )
-  (junction (at 85.09 71.12) (diameter 0) (color 0 0 0 0)
-    (uuid c668d3e4-8d66-42f4-a4c3-173ddc957afc)
-  )
-  (junction (at 119.38 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid c6fe1b85-f97d-4bfd-9e78-056d597ff1b6)
-  )
-  (junction (at 137.16 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid ca7094ce-fe61-40eb-a6a8-198d0445006d)
-  )
-  (junction (at 161.29 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid cb989bcc-5d7c-4831-a361-daa2f30130ff)
-  )
-  (junction (at 179.07 134.62) (diameter 0) (color 0 0 0 0)
-    (uuid cdbdc718-033b-4a38-920a-b047d114e262)
-  )
-  (junction (at 111.76 104.14) (diameter 0) (color 0 0 0 0)
-    (uuid d4ec2be4-cc0d-44b6-bf66-3c68f9cd5569)
-  )
-  (junction (at 242.57 34.29) (diameter 0) (color 0 0 0 0)
-    (uuid d53cfcfe-6178-478a-b832-10a5e0f566ac)
-  )
-  (junction (at 49.53 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid dbacfa0d-d96a-4421-9366-dcde6c6cc1ed)
-  )
-  (junction (at 210.82 127) (diameter 0) (color 0 0 0 0)
-    (uuid e4b7e3cc-3e58-45c9-82a4-25b7beb49ead)
-  )
-  (junction (at 163.83 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid e582e3cf-90ba-4170-bcc1-bd27db3de3ac)
-  )
-  (junction (at 238.76 34.29) (diameter 0) (color 0 0 0 0)
-    (uuid eafa446a-b330-49a1-ab14-b8f3828f0a1c)
-  )
-  (junction (at 64.77 24.13) (diameter 0) (color 0 0 0 0)
-    (uuid eb4babce-b649-4484-825b-70f6a873515a)
-  )
-  (junction (at 72.39 104.14) (diameter 0) (color 0 0 0 0)
-    (uuid eecccfab-7303-475b-ae08-a9ebf9e67dbc)
-  )
-  (junction (at 161.29 99.06) (diameter 0) (color 0 0 0 0)
-    (uuid f3015d71-82be-4be9-9545-d6ed2af4bcd1)
-  )
-  (junction (at 111.76 99.06) (diameter 0) (color 0 0 0 0)
-    (uuid f3bb3367-adfa-40ab-8c86-02713bfe9d9d)
-  )
-  (junction (at 171.45 87.63) (diameter 0) (color 0 0 0 0)
-    (uuid f4c9f50d-dbbe-4768-9efb-9e33f56f53d7)
-  )
-  (junction (at 69.85 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid f55e9c3b-b023-41a5-9056-e959734a22f8)
-  )
-  (junction (at 64.77 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid f5c78b36-4ad8-4138-851d-1ca90e8ef509)
-  )
-  (junction (at 111.76 114.3) (diameter 0) (color 0 0 0 0)
-    (uuid f664cf0b-28a9-4324-b0b5-4b47b2940695)
-  )
-  (junction (at 151.13 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid f83ead1a-75d9-4d68-988b-2502bc6bf206)
-  )
-  (junction (at 161.29 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid fdbe3e86-8364-4e79-baa3-6d7040901b14)
-  )
-
-  (wire (pts (xy 236.22 29.21) (xy 236.22 34.29))
-    (stroke (width 0) (type default))
-    (uuid 007990a9-c320-4aa2-a0ce-ff13e677b0e9)
-  )
-  (wire (pts (xy 101.6 179.07) (xy 100.33 179.07))
-    (stroke (width 0) (type default))
-    (uuid 009365d1-aabd-44d4-a2c6-0f3e14bb1fd3)
-  )
-  (wire (pts (xy 97.79 104.14) (xy 111.76 104.14))
-    (stroke (width 0) (type default))
-    (uuid 014d4585-54c9-4d9d-926d-c9b3276287b3)
-  )
-  (wire (pts (xy 137.16 27.94) (xy 137.16 25.4))
-    (stroke (width 0) (type default))
-    (uuid 02453566-9de5-4eee-956f-e83ce9df1c0c)
-  )
-  (wire (pts (xy 92.71 111.76) (xy 111.76 111.76))
-    (stroke (width 0) (type default))
-    (uuid 042f2a42-66fb-42f8-88f2-ef5f489830ae)
-  )
-  (wire (pts (xy 171.45 97.79) (xy 171.45 99.06))
-    (stroke (width 0) (type default))
-    (uuid 0466292d-ad7f-4bb9-8e28-f0d4310b85f2)
-  )
-  (wire (pts (xy 67.31 19.05) (xy 175.26 19.05))
-    (stroke (width 0) (type default))
-    (uuid 04a3c572-8732-49af-a6fa-a0dc1695593b)
-  )
-  (wire (pts (xy 180.34 46.99) (xy 173.99 46.99))
-    (stroke (width 0) (type default))
-    (uuid 0518cace-86b1-4ba2-b373-5a1d2a3ad0e0)
-  )
-  (wire (pts (xy 124.46 138.43) (xy 124.46 146.05))
-    (stroke (width 0) (type default))
-    (uuid 0625045d-05ca-4a01-8954-420dde7b2fa6)
-  )
-  (wire (pts (xy 53.34 134.62) (xy 55.88 134.62))
-    (stroke (width 0) (type default))
-    (uuid 067522d9-7bb0-41bc-97b3-ae66446320e7)
-  )
-  (wire (pts (xy 179.07 134.62) (xy 179.07 139.7))
-    (stroke (width 0) (type default))
-    (uuid 078a5778-a240-4b14-ba4a-61d79b595764)
-  )
-  (wire (pts (xy 210.82 149.86) (xy 210.82 152.4))
-    (stroke (width 0) (type default))
-    (uuid 07d23bba-8c23-4bac-a63b-cd3825880c01)
-  )
-  (wire (pts (xy 137.16 135.89) (xy 137.16 138.43))
-    (stroke (width 0) (type default))
-    (uuid 0821ff62-2b84-4df1-8eff-877922d134ae)
-  )
-  (wire (pts (xy 40.64 92.71) (xy 40.64 88.9))
-    (stroke (width 0) (type default))
-    (uuid 088d5e51-d335-4ec3-b973-84929e7e5d79)
-  )
-  (wire (pts (xy 262.89 43.18) (xy 262.89 45.72))
-    (stroke (width 0) (type default))
-    (uuid 09741eab-1e1d-478c-a889-f3c4d6f865e1)
-  )
-  (wire (pts (xy 147.32 46.99) (xy 147.32 27.94))
-    (stroke (width 0) (type default))
-    (uuid 09eff4f5-a0fa-472b-a332-19f443fdaacb)
-  )
-  (wire (pts (xy 97.79 93.98) (xy 101.6 93.98))
-    (stroke (width 0) (type default))
-    (uuid 0a6dbdb3-91a3-4710-95c2-e4cb0fec3ba9)
-  )
-  (wire (pts (xy 161.29 116.84) (xy 173.99 116.84))
-    (stroke (width 0) (type default))
-    (uuid 0a75b557-a09a-4fb1-91be-3ddce06c3e13)
-  )
-  (wire (pts (xy 50.8 139.7) (xy 55.88 139.7))
-    (stroke (width 0) (type default))
-    (uuid 0bbcfb05-08cb-410b-8803-56056cbf829f)
-  )
-  (wire (pts (xy 133.35 27.94) (xy 137.16 27.94))
-    (stroke (width 0) (type default))
-    (uuid 0c297fdb-786d-44c4-a442-1ed275998790)
-  )
-  (wire (pts (xy 33.02 25.4) (xy 35.56 25.4))
-    (stroke (width 0) (type default))
-    (uuid 0c4a6881-e316-4506-b478-be45d2374882)
-  )
-  (wire (pts (xy 133.35 29.21) (xy 133.35 27.94))
-    (stroke (width 0) (type default))
-    (uuid 0cb3a2f9-fd32-4dc0-ad92-fe8e648f8f5e)
-  )
-  (wire (pts (xy 54.61 88.9) (xy 54.61 91.44))
-    (stroke (width 0) (type default))
-    (uuid 0d933a3f-3440-4e0d-861e-292ffd45e9ca)
-  )
-  (wire (pts (xy 273.05 35.56) (xy 273.05 34.29))
-    (stroke (width 0) (type default))
-    (uuid 0dff39f0-d730-4050-a315-9a0d91e91577)
-  )
-  (wire (pts (xy 33.02 30.48) (xy 35.56 30.48))
-    (stroke (width 0) (type default))
-    (uuid 0f577625-8d53-4c2e-b392-87074b798556)
-  )
-  (wire (pts (xy 190.5 27.94) (xy 190.5 31.75))
-    (stroke (width 0) (type default))
-    (uuid 10e74ae7-e34f-4ca4-8b78-e0a740259c92)
-  )
-  (wire (pts (xy 214.63 34.29) (xy 217.17 34.29))
-    (stroke (width 0) (type default))
-    (uuid 12fda8d1-f574-4a7a-aa21-e7e2262625f5)
-  )
-  (wire (pts (xy 111.76 88.9) (xy 114.3 88.9))
-    (stroke (width 0) (type default))
-    (uuid 13358993-267e-4de7-86c6-a78b0914ae61)
-  )
-  (wire (pts (xy 242.57 43.18) (xy 242.57 45.72))
-    (stroke (width 0) (type default))
-    (uuid 146f00b5-69b2-4772-9450-043ed39adc6b)
-  )
-  (wire (pts (xy 157.48 91.44) (xy 161.29 91.44))
-    (stroke (width 0) (type default))
-    (uuid 14e05fc7-47e7-46ed-9391-124c096321fd)
-  )
-  (wire (pts (xy 127 158.75) (xy 119.38 158.75))
-    (stroke (width 0) (type default))
-    (uuid 150012b8-86c0-432d-badf-122f0d7f7141)
-  )
-  (wire (pts (xy 251.46 45.72) (xy 251.46 41.91))
-    (stroke (width 0) (type default))
-    (uuid 166b432e-dd26-43b0-b5aa-c53564487569)
-  )
-  (wire (pts (xy 173.99 121.92) (xy 181.61 121.92))
-    (stroke (width 0) (type default))
-    (uuid 172670cd-d136-45d6-9376-cc007d2b0725)
-  )
-  (wire (pts (xy 29.21 44.45) (xy 31.75 44.45))
-    (stroke (width 0) (type default))
-    (uuid 17295aac-6f5e-4629-a691-0986aa311896)
-  )
-  (wire (pts (xy 238.76 27.94) (xy 238.76 34.29))
-    (stroke (width 0) (type default))
-    (uuid 17cf0df8-96d4-47fc-874c-6767973f280e)
-  )
-  (wire (pts (xy 153.67 35.56) (xy 151.13 35.56))
-    (stroke (width 0) (type default))
-    (uuid 1a8b417f-53c1-4c04-99ad-648f94c546f6)
-  )
-  (wire (pts (xy 242.57 35.56) (xy 242.57 34.29))
-    (stroke (width 0) (type default))
-    (uuid 1adf7c80-3f7f-4ef4-9149-c1e4d2f7d491)
-  )
-  (wire (pts (xy 67.31 19.05) (xy 67.31 27.94))
-    (stroke (width 0) (type default))
-    (uuid 1ba606f6-f9aa-4e71-a1a0-e1d721ef59d9)
-  )
-  (wire (pts (xy 49.53 80.01) (xy 49.53 88.9))
-    (stroke (width 0) (type default))
-    (uuid 1cfe3f49-7172-43b7-97d6-ee2e83b77201)
-  )
-  (wire (pts (xy 157.48 119.38) (xy 161.29 119.38))
-    (stroke (width 0) (type default))
-    (uuid 1e12c4fa-95d4-4da0-a05c-feff406c9d2f)
-  )
-  (wire (pts (xy 271.78 80.01) (xy 265.43 80.01))
-    (stroke (width 0) (type default))
-    (uuid 1ec7070f-5644-48b7-b11e-28b14dd09ccd)
-  )
-  (wire (pts (xy 121.92 27.94) (xy 133.35 27.94))
-    (stroke (width 0) (type default))
-    (uuid 1ef1760a-38d6-4ffa-962d-f7de7d8501d0)
-  )
-  (wire (pts (xy 274.32 152.4) (xy 266.7 152.4))
-    (stroke (width 0) (type default))
-    (uuid 20857af3-e57f-4c07-b06a-07d30ab730ea)
-  )
-  (wire (pts (xy 69.85 34.29) (xy 69.85 27.94))
-    (stroke (width 0) (type default))
-    (uuid 2116ffcb-f0eb-4e93-b329-3a6beb901b04)
-  )
-  (wire (pts (xy 179.07 139.7) (xy 180.34 139.7))
-    (stroke (width 0) (type default))
-    (uuid 214afdce-2ddf-422a-a1fe-b0f333dcdb48)
-  )
-  (wire (pts (xy 57.15 66.04) (xy 57.15 60.96))
-    (stroke (width 0) (type default))
-    (uuid 22476318-d783-4fc2-ba4a-5b67b6c4c49a)
-  )
-  (wire (pts (xy 269.24 114.3) (xy 266.7 114.3))
-    (stroke (width 0) (type default))
-    (uuid 226b0b38-0ccb-4dd1-8705-7d12bb46df96)
-  )
-  (wire (pts (xy 105.41 121.92) (xy 111.76 121.92))
-    (stroke (width 0) (type default))
-    (uuid 22d4a748-a6ee-4b94-ad4b-89b5d995e1c8)
-  )
-  (wire (pts (xy 187.96 26.67) (xy 187.96 31.75))
-    (stroke (width 0) (type default))
-    (uuid 231bfd33-e9a7-4dd1-a7fc-14b6f918eab1)
-  )
-  (wire (pts (xy 26.67 49.53) (xy 31.75 49.53))
-    (stroke (width 0) (type default))
-    (uuid 2345aabc-f329-4fce-a1f5-45293716b794)
-  )
-  (wire (pts (xy 97.79 71.12) (xy 101.6 71.12))
-    (stroke (width 0) (type default))
-    (uuid 2348d889-f5b9-492e-8dfb-862d94168a8a)
-  )
-  (wire (pts (xy 234.95 34.29) (xy 234.95 35.56))
-    (stroke (width 0) (type default))
-    (uuid 23e72f93-c944-47ca-9311-73de4b6e3496)
-  )
-  (wire (pts (xy 54.61 123.19) (xy 77.47 123.19))
-    (stroke (width 0) (type default))
-    (uuid 243c0e23-4725-4e8b-9266-fd201ca8ba88)
-  )
-  (wire (pts (xy 111.76 119.38) (xy 114.3 119.38))
-    (stroke (width 0) (type default))
-    (uuid 24459baf-4ab4-4210-bac0-0f0bdb004c07)
-  )
-  (wire (pts (xy 161.29 111.76) (xy 170.18 111.76))
-    (stroke (width 0) (type default))
-    (uuid 25f1741f-35d7-4857-91fe-1ab72080a414)
-  )
-  (wire (pts (xy 176.53 31.75) (xy 175.26 31.75))
-    (stroke (width 0) (type default))
-    (uuid 27b1da6c-48fa-4322-b32c-4045e9fc6c2e)
-  )
-  (wire (pts (xy 217.17 142.24) (xy 210.82 142.24))
-    (stroke (width 0) (type default))
-    (uuid 294eb528-140f-4c57-b0c7-64efcf956c4d)
-  )
-  (wire (pts (xy 140.97 182.88) (xy 143.51 182.88))
-    (stroke (width 0) (type default))
-    (uuid 299e608b-a216-4b2e-a6b7-5d0a275049b9)
-  )
-  (wire (pts (xy 39.37 27.94) (xy 36.83 27.94))
-    (stroke (width 0) (type default))
-    (uuid 2c6198d8-fefd-4aaf-bd8d-ffbd97bb0a34)
-  )
-  (wire (pts (xy 158.75 27.94) (xy 158.75 26.67))
-    (stroke (width 0) (type default))
-    (uuid 2cfa9481-c72f-4293-9eb5-4d8aff27c0a0)
-  )
-  (wire (pts (xy 95.25 109.22) (xy 111.76 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2d1a0fda-d10d-403b-a75f-cbc2effe7a3c)
-  )
-  (wire (pts (xy 111.76 96.52) (xy 114.3 96.52))
-    (stroke (width 0) (type default))
-    (uuid 2d33768e-15a2-47d1-b227-5c95c7d1ff39)
-  )
-  (wire (pts (xy 262.89 35.56) (xy 262.89 34.29))
-    (stroke (width 0) (type default))
-    (uuid 2d8ad920-4cfd-4ffd-8dac-acaa70eb348d)
-  )
-  (wire (pts (xy 45.72 60.96) (xy 43.18 60.96))
-    (stroke (width 0) (type default))
-    (uuid 2e7d5a12-37e6-4f18-8220-bab1a98e48a7)
-  )
-  (wire (pts (xy 72.39 104.14) (xy 72.39 125.73))
-    (stroke (width 0) (type default))
-    (uuid 2ece91bd-5817-4200-ac7f-11792a244d66)
-  )
-  (wire (pts (xy 36.83 87.63) (xy 36.83 88.9))
-    (stroke (width 0) (type default))
-    (uuid 2f65cdd9-21c5-43b6-ad78-6c22576e919f)
-  )
-  (wire (pts (xy 140.97 191.77) (xy 143.51 191.77))
-    (stroke (width 0) (type default))
-    (uuid 2f8694fb-d7e1-4ff7-b233-2b1e0e89a2a0)
-  )
-  (wire (pts (xy 31.75 44.45) (xy 36.83 44.45))
-    (stroke (width 0) (type default))
-    (uuid 2fe61f34-bcf8-49a9-8b23-187e87c6349c)
-  )
-  (wire (pts (xy 105.41 60.96) (xy 105.41 72.39))
-    (stroke (width 0) (type default))
-    (uuid 3161c57f-2a27-409f-aeae-9f1e360aa44a)
-  )
-  (wire (pts (xy 54.61 88.9) (xy 60.96 88.9))
-    (stroke (width 0) (type default))
-    (uuid 331fd281-6aa8-455b-a792-8e60d1225ac3)
-  )
-  (wire (pts (xy 190.5 31.75) (xy 194.31 31.75))
-    (stroke (width 0) (type default))
-    (uuid 33880395-3412-4935-ae55-4d1a02ea11b3)
-  )
-  (wire (pts (xy 161.29 101.6) (xy 177.8 101.6))
-    (stroke (width 0) (type default))
-    (uuid 341910b7-d87d-4dd8-9cc5-13f7845cb899)
-  )
-  (wire (pts (xy 64.77 27.94) (xy 67.31 27.94))
-    (stroke (width 0) (type default))
-    (uuid 35712cc5-6346-42d6-97ca-b9af4ddff0de)
-  )
-  (wire (pts (xy 33.02 88.9) (xy 36.83 88.9))
-    (stroke (width 0) (type default))
-    (uuid 3862b270-9043-4a9f-a16e-5f9883d727d6)
-  )
-  (wire (pts (xy 111.76 93.98) (xy 114.3 93.98))
-    (stroke (width 0) (type default))
-    (uuid 3a2b9db1-17d2-47e7-a685-7ea1b98a646f)
-  )
-  (wire (pts (xy 161.29 119.38) (xy 170.18 119.38))
-    (stroke (width 0) (type default))
-    (uuid 3a998f4e-54cc-4dc6-bafc-19afbfeab24a)
-  )
-  (wire (pts (xy 171.45 86.36) (xy 157.48 86.36))
-    (stroke (width 0) (type default))
-    (uuid 3aa56749-41b4-4733-9bf4-a608d8b83b5d)
-  )
-  (wire (pts (xy 190.5 137.16) (xy 194.31 137.16))
-    (stroke (width 0) (type default))
-    (uuid 3b649d82-18f2-41d0-a97b-bded544abc4b)
-  )
-  (wire (pts (xy 234.95 43.18) (xy 234.95 45.72))
-    (stroke (width 0) (type default))
-    (uuid 3bb89fab-c3e4-483e-87f3-44b4d36d1a1e)
-  )
-  (wire (pts (xy 67.31 27.94) (xy 69.85 27.94))
-    (stroke (width 0) (type default))
-    (uuid 3c9283ea-8f18-484c-8395-d112caac26ef)
-  )
-  (wire (pts (xy 77.47 133.35) (xy 71.12 133.35))
-    (stroke (width 0) (type default))
-    (uuid 3e43cbc7-4b42-482f-a461-55767f062736)
-  )
-  (wire (pts (xy 46.99 180.34) (xy 52.07 180.34))
-    (stroke (width 0) (type default))
-    (uuid 3f05da57-fe55-4b78-81d0-76128bda1d66)
-  )
-  (wire (pts (xy 68.58 88.9) (xy 76.2 88.9))
-    (stroke (width 0) (type default))
-    (uuid 3f31c2ab-fda5-440d-bfd3-219288ac16b9)
-  )
-  (wire (pts (xy 119.38 27.94) (xy 121.92 27.94))
-    (stroke (width 0) (type default))
-    (uuid 44c5e640-2fb1-4da6-986d-27657827e9d0)
-  )
-  (wire (pts (xy 238.76 34.29) (xy 242.57 34.29))
-    (stroke (width 0) (type default))
-    (uuid 44e319f7-abd2-40a3-82c2-f182da6c25c1)
-  )
-  (wire (pts (xy 157.48 114.3) (xy 161.29 114.3))
-    (stroke (width 0) (type default))
-    (uuid 45b1f27a-f375-4495-bd91-59a8b7e0787a)
-  )
-  (wire (pts (xy 177.8 111.76) (xy 189.23 111.76))
-    (stroke (width 0) (type default))
-    (uuid 45ff6760-ea15-44d5-83ac-1b23340dd048)
-  )
-  (wire (pts (xy 161.29 109.22) (xy 179.07 109.22))
-    (stroke (width 0) (type default))
-    (uuid 4608d120-6807-4a2a-b6f8-98ff93393f12)
-  )
-  (wire (pts (xy 209.55 96.52) (xy 209.55 97.79))
-    (stroke (width 0) (type default))
-    (uuid 461f8a18-5435-4c4e-95c7-474118b60c98)
-  )
-  (wire (pts (xy 101.6 93.98) (xy 111.76 93.98))
-    (stroke (width 0) (type default))
-    (uuid 46a7e2b7-8b76-43bc-8e98-40b7e78a16f6)
-  )
-  (wire (pts (xy 157.48 109.22) (xy 161.29 109.22))
-    (stroke (width 0) (type default))
-    (uuid 46ae839f-75d1-4afc-b1a8-8336c500df49)
-  )
-  (wire (pts (xy 161.29 35.56) (xy 163.83 35.56))
-    (stroke (width 0) (type default))
-    (uuid 4730c87d-5dbf-4ca9-9051-7058d9c02690)
-  )
-  (wire (pts (xy 77.47 123.19) (xy 77.47 133.35))
-    (stroke (width 0) (type default))
-    (uuid 48a5c05b-06df-4104-9e9c-40b3dea96a23)
-  )
-  (wire (pts (xy 68.58 99.06) (xy 68.58 104.14))
-    (stroke (width 0) (type default))
-    (uuid 48b7e579-7a4c-4cd1-b9be-f12f7a0aa2d1)
-  )
-  (wire (pts (xy 267.97 85.09) (xy 265.43 85.09))
-    (stroke (width 0) (type default))
-    (uuid 4906e5ab-8ac8-4adc-954d-0e4ffb80c78b)
-  )
-  (wire (pts (xy 205.74 152.4) (xy 210.82 152.4))
-    (stroke (width 0) (type default))
-    (uuid 4a14aee1-92c4-4c19-aa15-cbad854852ca)
-  )
-  (wire (pts (xy 40.64 27.94) (xy 39.37 27.94))
-    (stroke (width 0) (type default))
-    (uuid 4fbf9bdd-a3ae-489f-ae61-27169fcb68d6)
-  )
-  (wire (pts (xy 81.28 101.6) (xy 111.76 101.6))
-    (stroke (width 0) (type default))
-    (uuid 517b5782-8d90-48aa-b722-8a2859c7b139)
-  )
-  (wire (pts (xy 157.48 96.52) (xy 161.29 96.52))
-    (stroke (width 0) (type default))
-    (uuid 5216187d-69ee-4a73-ac6d-561e8ff373fd)
-  )
-  (wire (pts (xy 157.48 99.06) (xy 161.29 99.06))
-    (stroke (width 0) (type default))
-    (uuid 522b2f25-c8c9-4797-b5e2-2413c5a9483c)
-  )
-  (wire (pts (xy 144.78 135.89) (xy 144.78 138.43))
-    (stroke (width 0) (type default))
-    (uuid 52d26c6a-9efc-461a-97e4-5a3a6381b196)
-  )
-  (wire (pts (xy 71.12 71.12) (xy 71.12 80.01))
-    (stroke (width 0) (type default))
-    (uuid 531640c5-3b42-4419-834e-ac2a9c56bff9)
-  )
-  (wire (pts (xy 236.22 34.29) (xy 238.76 34.29))
-    (stroke (width 0) (type default))
-    (uuid 534fbc92-4739-441d-98bb-9d97a511ff68)
-  )
-  (wire (pts (xy 157.48 111.76) (xy 161.29 111.76))
-    (stroke (width 0) (type default))
-    (uuid 541393f3-2a8c-47ea-9069-9b938d32fb81)
-  )
-  (wire (pts (xy 74.93 105.41) (xy 74.93 128.27))
-    (stroke (width 0) (type default))
-    (uuid 5495b4ec-f230-430d-9e88-9cc9f8414cf7)
-  )
-  (wire (pts (xy 36.83 35.56) (xy 36.83 27.94))
-    (stroke (width 0) (type default))
-    (uuid 555a3626-fb24-4c4a-a6c2-82ef3480af5c)
-  )
-  (wire (pts (xy 46.99 129.54) (xy 46.99 132.08))
-    (stroke (width 0) (type default))
-    (uuid 5676c50e-73d7-48d9-aca9-9488c668018e)
-  )
-  (wire (pts (xy 111.76 121.92) (xy 114.3 121.92))
-    (stroke (width 0) (type default))
-    (uuid 578eabd7-081b-4f8b-8fe6-f7e11a83ce34)
-  )
-  (wire (pts (xy 62.23 27.94) (xy 64.77 27.94))
-    (stroke (width 0) (type default))
-    (uuid 58082787-784d-45c5-9574-ce82374d0643)
-  )
-  (wire (pts (xy 72.39 96.52) (xy 72.39 104.14))
-    (stroke (width 0) (type default))
-    (uuid 5899bd74-597f-4bb3-a0ad-cdf4267f5297)
-  )
-  (wire (pts (xy 266.7 148.59) (xy 274.32 148.59))
-    (stroke (width 0) (type default))
-    (uuid 58b6dc11-58e4-4e0a-9b0e-3020e5cdcafb)
-  )
-  (wire (pts (xy 175.26 31.75) (xy 175.26 19.05))
-    (stroke (width 0) (type default))
-    (uuid 59042357-1906-4cc3-8728-aac7327f825e)
-  )
-  (wire (pts (xy 50.8 139.7) (xy 50.8 125.73))
-    (stroke (width 0) (type default))
-    (uuid 59789abf-2b3b-4570-aca7-686343642e49)
-  )
-  (wire (pts (xy 55.88 33.02) (xy 62.23 33.02))
-    (stroke (width 0) (type default))
-    (uuid 5a37c812-2d01-4842-a654-68f469573638)
-  )
-  (wire (pts (xy 60.96 88.9) (xy 60.96 91.44))
-    (stroke (width 0) (type default))
-    (uuid 5b28062c-03c8-4f62-89d6-a412e40bee1f)
-  )
-  (wire (pts (xy 46.99 185.42) (xy 48.26 185.42))
-    (stroke (width 0) (type default))
-    (uuid 5c201be8-28a4-4de5-b9ec-6e2bdb173590)
-  )
-  (wire (pts (xy 78.74 99.06) (xy 111.76 99.06))
-    (stroke (width 0) (type default))
-    (uuid 5f343bf7-3585-409f-933e-ce876c69aaf9)
-  )
-  (wire (pts (xy 101.6 63.5) (xy 101.6 71.12))
-    (stroke (width 0) (type default))
-    (uuid 60a933e2-aa33-40c6-80d2-133e9d882435)
-  )
-  (wire (pts (xy 194.31 31.75) (xy 194.31 38.1))
-    (stroke (width 0) (type default))
-    (uuid 6178ebd8-b2f9-4ffe-9f35-5c459968cd00)
-  )
-  (wire (pts (xy 99.06 116.84) (xy 111.76 116.84))
-    (stroke (width 0) (type default))
-    (uuid 61a1ae6a-ee06-4a5d-b30c-db02755c70ee)
-  )
-  (wire (pts (xy 101.6 182.88) (xy 100.33 182.88))
-    (stroke (width 0) (type default))
-    (uuid 623f9f16-c117-4c45-8b1d-ca84801100cf)
-  )
-  (wire (pts (xy 60.96 99.06) (xy 60.96 105.41))
-    (stroke (width 0) (type default))
-    (uuid 62441b8e-bff5-49b1-a485-4272e3dfdfdd)
-  )
-  (wire (pts (xy 100.33 185.42) (xy 101.6 185.42))
-    (stroke (width 0) (type default))
-    (uuid 624c4d6f-3e9e-4785-83b1-f81f96168a9d)
-  )
-  (wire (pts (xy 149.86 46.99) (xy 147.32 46.99))
-    (stroke (width 0) (type default))
-    (uuid 625a7cfc-5eb2-4026-9c29-b2abfc485af5)
-  )
-  (wire (pts (xy 64.77 24.13) (xy 64.77 27.94))
-    (stroke (width 0) (type default))
-    (uuid 62ec098b-1fce-414d-b5ab-faaa33f2b273)
-  )
-  (wire (pts (xy 124.46 135.89) (xy 124.46 138.43))
-    (stroke (width 0) (type default))
-    (uuid 6804cb72-ea5e-4f82-8dd9-be415086da09)
-  )
-  (wire (pts (xy 86.36 27.94) (xy 119.38 27.94))
-    (stroke (width 0) (type default))
-    (uuid 691c947a-c326-4585-86df-5f2b82ecd531)
-  )
-  (wire (pts (xy 161.29 106.68) (xy 171.45 106.68))
-    (stroke (width 0) (type default))
-    (uuid 694cc900-10e7-4769-812b-0a9a46c6ea4a)
-  )
-  (wire (pts (xy 140.97 189.23) (xy 143.51 189.23))
-    (stroke (width 0) (type default))
-    (uuid 695d0127-ac63-4825-8ae2-e06395533d4b)
-  )
-  (wire (pts (xy 17.78 88.9) (xy 25.4 88.9))
-    (stroke (width 0) (type default))
-    (uuid 697fd977-9eaa-4dd2-8642-26fb12dc66e4)
-  )
-  (wire (pts (xy 156.21 27.94) (xy 156.21 26.67))
-    (stroke (width 0) (type default))
-    (uuid 69861798-e967-44ca-a012-573f6c16bb26)
-  )
-  (wire (pts (xy 64.77 60.96) (xy 57.15 60.96))
-    (stroke (width 0) (type default))
-    (uuid 6a44e070-8bd0-4048-97b7-e4b94fe9a0ad)
-  )
-  (wire (pts (xy 45.72 27.94) (xy 49.53 27.94))
-    (stroke (width 0) (type default))
-    (uuid 6af8e452-28b4-4e97-9ec5-d0550a3fd366)
-  )
-  (wire (pts (xy 121.92 146.05) (xy 124.46 146.05))
-    (stroke (width 0) (type default))
-    (uuid 6b2dfce6-bfda-4035-ac32-c246a06648d5)
-  )
-  (wire (pts (xy 101.6 119.38) (xy 111.76 119.38))
-    (stroke (width 0) (type default))
-    (uuid 6b59a1c2-62df-4fec-be2a-d842d77efa80)
-  )
-  (wire (pts (xy 66.04 181.61) (xy 69.85 181.61))
-    (stroke (width 0) (type default))
-    (uuid 6be81913-a9c9-4a7c-bf3a-56db5f50ce5d)
-  )
-  (wire (pts (xy 105.41 140.97) (xy 105.41 121.92))
-    (stroke (width 0) (type default))
-    (uuid 6c7bbb88-517f-4bee-b9cf-cdef44a0d7ea)
-  )
-  (wire (pts (xy 57.15 27.94) (xy 62.23 27.94))
-    (stroke (width 0) (type default))
-    (uuid 6ca2b0df-d934-40c7-af5e-aebad87786c0)
-  )
-  (wire (pts (xy 48.26 189.23) (xy 46.99 189.23))
-    (stroke (width 0) (type default))
-    (uuid 6d978f74-8ea9-4ff6-b8e5-8673b23c63d6)
-  )
-  (wire (pts (xy 96.52 63.5) (xy 101.6 63.5))
-    (stroke (width 0) (type default))
-    (uuid 6e87f750-b4b1-4063-94b8-f53b8d289f05)
-  )
-  (wire (pts (xy 194.31 38.1) (xy 193.04 38.1))
-    (stroke (width 0) (type default))
-    (uuid 6f6bc88b-0171-4d91-a248-c603415eaeff)
-  )
-  (wire (pts (xy 111.76 91.44) (xy 114.3 91.44))
-    (stroke (width 0) (type default))
-    (uuid 6ff1ff0e-4dca-4600-9b26-8b625ebcd038)
-  )
-  (wire (pts (xy 163.83 27.94) (xy 167.64 27.94))
-    (stroke (width 0) (type default))
-    (uuid 71cfaf8b-2e6e-4844-bcc1-42e0f236d310)
-  )
-  (wire (pts (xy 171.45 87.63) (xy 173.99 87.63))
-    (stroke (width 0) (type default))
-    (uuid 731ed305-46de-41e1-bff1-52902ae0b1c4)
-  )
-  (wire (pts (xy 35.56 93.98) (xy 35.56 92.71))
-    (stroke (width 0) (type default))
-    (uuid 74261126-978c-4708-9d14-9158d606d1af)
-  )
-  (wire (pts (xy 129.54 135.89) (xy 129.54 138.43))
-    (stroke (width 0) (type default))
-    (uuid 75c1ebe6-53b3-4917-afb1-09bb98e450bb)
-  )
-  (wire (pts (xy 190.5 137.16) (xy 190.5 139.7))
-    (stroke (width 0) (type default))
-    (uuid 76d1aef2-fb53-4d4f-9616-20e485006328)
-  )
-  (wire (pts (xy 71.12 80.01) (xy 49.53 80.01))
-    (stroke (width 0) (type default))
-    (uuid 76f6150c-1a8d-457f-b5da-7b41007c7db5)
-  )
-  (wire (pts (xy 101.6 140.97) (xy 101.6 119.38))
-    (stroke (width 0) (type default))
-    (uuid 774a662d-4138-4617-bc63-eea1b3e25dca)
-  )
-  (wire (pts (xy 119.38 36.83) (xy 119.38 39.37))
-    (stroke (width 0) (type default))
-    (uuid 77648e31-bba4-48bd-afa4-a2a28192e442)
-  )
-  (wire (pts (xy 26.67 44.45) (xy 29.21 44.45))
-    (stroke (width 0) (type default))
-    (uuid 78d98b38-a8c6-4b76-87b4-989f4c06eb27)
-  )
-  (wire (pts (xy 273.05 43.18) (xy 273.05 45.72))
-    (stroke (width 0) (type default))
-    (uuid 7a87bbf2-0a7f-4c21-a15d-659ec40e0d18)
-  )
-  (wire (pts (xy 269.24 111.76) (xy 266.7 111.76))
-    (stroke (width 0) (type default))
-    (uuid 7aba6ff9-f6e8-4dec-8e17-5c7f3afb55b1)
-  )
-  (wire (pts (xy 53.34 128.27) (xy 74.93 128.27))
-    (stroke (width 0) (type default))
-    (uuid 7b4ec8a9-6ee8-4ea2-a978-9223cce3549f)
-  )
-  (wire (pts (xy 101.6 71.12) (xy 101.6 72.39))
-    (stroke (width 0) (type default))
-    (uuid 7d0413b3-7afa-4ccb-b9a6-16e191a7fa34)
-  )
-  (wire (pts (xy 100.33 191.77) (xy 101.6 191.77))
-    (stroke (width 0) (type default))
-    (uuid 7d2becc5-53f7-4376-8dc4-32d2a3543fd1)
-  )
-  (wire (pts (xy 274.32 137.16) (xy 266.7 137.16))
-    (stroke (width 0) (type default))
-    (uuid 7d571609-6a69-41ff-a28d-2224c15c2cbc)
-  )
-  (wire (pts (xy 76.2 88.9) (xy 76.2 91.44))
-    (stroke (width 0) (type default))
-    (uuid 7d642da2-ba9a-44bd-8f1d-58f793497ec9)
-  )
-  (wire (pts (xy 157.48 104.14) (xy 161.29 104.14))
-    (stroke (width 0) (type default))
-    (uuid 7e1c7490-0636-44f0-add4-c3505e733d7e)
-  )
-  (wire (pts (xy 273.05 34.29) (xy 275.59 34.29))
-    (stroke (width 0) (type default))
-    (uuid 7e39ca3c-b0d2-4805-9e0c-bb19e9fba8d0)
-  )
-  (wire (pts (xy 57.15 66.04) (xy 55.88 66.04))
-    (stroke (width 0) (type default))
-    (uuid 7f8a5044-d337-47ff-8e27-132ba923f90d)
-  )
-  (wire (pts (xy 157.48 88.9) (xy 161.29 88.9))
-    (stroke (width 0) (type default))
-    (uuid 81363b2d-0a37-4e94-b942-de620bf8dd10)
-  )
-  (wire (pts (xy 81.28 101.6) (xy 81.28 134.62))
-    (stroke (width 0) (type default))
-    (uuid 8156a450-2657-41a8-9899-ad0a6118022a)
-  )
-  (wire (pts (xy 43.18 66.04) (xy 45.72 66.04))
-    (stroke (width 0) (type default))
-    (uuid 817f8498-e6b0-4924-95a0-2b9dfe56ae88)
-  )
-  (wire (pts (xy 85.09 63.5) (xy 85.09 71.12))
-    (stroke (width 0) (type default))
-    (uuid 81b77e27-07b2-4383-b655-e605a64714a4)
-  )
-  (wire (pts (xy 52.07 137.16) (xy 55.88 137.16))
-    (stroke (width 0) (type default))
-    (uuid 828bd17d-c5e8-416a-b5e9-57737db12a97)
-  )
-  (wire (pts (xy 142.24 135.89) (xy 142.24 138.43))
-    (stroke (width 0) (type default))
-    (uuid 82b215f1-1dd7-4ecd-bcb6-375f3405bd31)
-  )
-  (wire (pts (xy 36.83 27.94) (xy 35.56 27.94))
-    (stroke (width 0) (type default))
-    (uuid 82b6f929-9ce7-48fa-b6df-8d394b178747)
-  )
-  (wire (pts (xy 48.26 191.77) (xy 46.99 191.77))
-    (stroke (width 0) (type default))
-    (uuid 8598184d-b7ab-4b13-a1e9-766fd487e24d)
-  )
-  (wire (pts (xy 93.98 88.9) (xy 111.76 88.9))
-    (stroke (width 0) (type default))
-    (uuid 86135405-fa22-4447-ae20-e586f7e44ce2)
-  )
-  (wire (pts (xy 49.53 88.9) (xy 54.61 88.9))
-    (stroke (width 0) (type default))
-    (uuid 871d9c71-c258-41e6-98e4-70483c3d6775)
-  )
-  (wire (pts (xy 179.07 134.62) (xy 173.99 134.62))
-    (stroke (width 0) (type default))
-    (uuid 879a58ff-f4c7-4faf-8d52-002e7460e21e)
-  )
-  (wire (pts (xy 35.56 33.02) (xy 35.56 36.83))
-    (stroke (width 0) (type default))
-    (uuid 88485288-4500-47f3-a57c-7d2569fb56ed)
-  )
-  (wire (pts (xy 71.12 71.12) (xy 85.09 71.12))
-    (stroke (width 0) (type default))
-    (uuid 885defbb-9402-454e-9c19-2a3a9b6d317c)
-  )
-  (wire (pts (xy 161.29 93.98) (xy 176.53 93.98))
-    (stroke (width 0) (type default))
-    (uuid 890f181a-cfcd-49ec-926f-b55166d1b6f7)
-  )
-  (wire (pts (xy 161.29 88.9) (xy 171.45 88.9))
-    (stroke (width 0) (type default))
-    (uuid 89c3f855-845a-4471-8c79-0ee0530b50c4)
-  )
-  (wire (pts (xy 21.59 93.98) (xy 21.59 92.71))
-    (stroke (width 0) (type default))
-    (uuid 89ef6afe-0ce0-4eae-81a5-152f8b07d258)
-  )
-  (wire (pts (xy 71.12 133.35) (xy 71.12 134.62))
-    (stroke (width 0) (type default))
-    (uuid 8a55ce41-13af-4d76-ab78-b2d1fa9bd055)
-  )
-  (wire (pts (xy 64.77 22.86) (xy 64.77 24.13))
-    (stroke (width 0) (type default))
-    (uuid 8b78a3fc-4347-44dc-a512-456515762b9c)
-  )
-  (wire (pts (xy 71.12 134.62) (xy 81.28 134.62))
-    (stroke (width 0) (type default))
-    (uuid 8cca549c-fd14-4368-8b72-e508e0d79ef0)
-  )
-  (wire (pts (xy 224.79 34.29) (xy 234.95 34.29))
-    (stroke (width 0) (type default))
-    (uuid 8d23800f-9449-43bd-8122-fa504f4747c0)
-  )
-  (wire (pts (xy 262.89 34.29) (xy 273.05 34.29))
-    (stroke (width 0) (type default))
-    (uuid 8df9065a-bfee-4b53-a3ac-14801da8192f)
-  )
-  (wire (pts (xy 36.83 44.45) (xy 36.83 45.72))
-    (stroke (width 0) (type default))
-    (uuid 906fa46a-7dd7-4a69-8896-82d82a5f98ce)
-  )
-  (wire (pts (xy 38.1 66.04) (xy 43.18 66.04))
-    (stroke (width 0) (type default))
-    (uuid 90949bf3-bde3-47ee-9e98-ba88cb95d6eb)
-  )
-  (wire (pts (xy 60.96 105.41) (xy 74.93 105.41))
-    (stroke (width 0) (type default))
-    (uuid 9215bbeb-105f-4d14-b378-6481bab00b8f)
-  )
-  (wire (pts (xy 111.76 106.68) (xy 114.3 106.68))
-    (stroke (width 0) (type default))
-    (uuid 923dc0be-c4e1-4f46-b01c-3e9fdaea3f65)
-  )
-  (wire (pts (xy 190.5 134.62) (xy 190.5 137.16))
-    (stroke (width 0) (type default))
-    (uuid 92538116-995e-4d74-b1ee-6eefe22e73c7)
-  )
-  (wire (pts (xy 73.66 142.24) (xy 73.66 139.7))
-    (stroke (width 0) (type default))
-    (uuid 92d8800c-4713-4ffd-a35c-cbb2e7166078)
-  )
-  (wire (pts (xy 166.37 46.99) (xy 157.48 46.99))
-    (stroke (width 0) (type default))
-    (uuid 946176c8-8081-4101-a7f8-94c2216345cc)
-  )
-  (wire (pts (xy 31.75 49.53) (xy 31.75 44.45))
-    (stroke (width 0) (type default))
-    (uuid 94ac6993-3218-41cc-8aac-ba6e504e0868)
-  )
-  (wire (pts (xy 119.38 29.21) (xy 119.38 27.94))
-    (stroke (width 0) (type default))
-    (uuid 95414291-1ffd-445c-a597-b58b34bef509)
-  )
-  (wire (pts (xy 35.56 36.83) (xy 29.21 36.83))
-    (stroke (width 0) (type default))
-    (uuid 95efc0c1-80d7-48c3-b5f8-3e7f38fb46d6)
-  )
-  (wire (pts (xy 161.29 99.06) (xy 171.45 99.06))
-    (stroke (width 0) (type default))
-    (uuid 95fb9b57-3c5c-4512-9dfc-f77658a5a945)
-  )
-  (wire (pts (xy 157.48 93.98) (xy 161.29 93.98))
-    (stroke (width 0) (type default))
-    (uuid 9633cc63-4921-47e2-824e-417d3454ef3e)
-  )
-  (wire (pts (xy 210.82 139.7) (xy 210.82 142.24))
-    (stroke (width 0) (type default))
-    (uuid 96dfed56-73be-4d8a-95fc-f078974b8349)
-  )
-  (wire (pts (xy 140.97 185.42) (xy 144.78 185.42))
-    (stroke (width 0) (type default))
-    (uuid 97f18940-42e0-4e0b-b2b0-1d7dfd1d616e)
-  )
-  (wire (pts (xy 161.29 114.3) (xy 179.07 114.3))
-    (stroke (width 0) (type default))
-    (uuid 9862760b-77f5-41e5-a0da-be1445a40e6d)
-  )
-  (wire (pts (xy 280.67 34.29) (xy 280.67 31.75))
-    (stroke (width 0) (type default))
-    (uuid 9ab4a278-05cc-4ca8-9949-eb0c29727754)
-  )
-  (wire (pts (xy 214.63 29.21) (xy 214.63 34.29))
-    (stroke (width 0) (type default))
-    (uuid 9aea3c55-b2f2-4299-b0ee-529165c76e07)
-  )
-  (wire (pts (xy 210.82 127) (xy 210.82 134.62))
-    (stroke (width 0) (type default))
-    (uuid 9bd11fcd-4da2-4d2a-8f82-e7a6d0028191)
-  )
-  (wire (pts (xy 72.39 96.52) (xy 111.76 96.52))
-    (stroke (width 0) (type default))
-    (uuid 9c46fae2-b8e2-44c7-8c42-79ef78582e3c)
-  )
-  (wire (pts (xy 134.62 135.89) (xy 134.62 138.43))
-    (stroke (width 0) (type default))
-    (uuid a0091a17-892f-4799-86ed-50c9454a0477)
-  )
-  (wire (pts (xy 163.83 35.56) (xy 163.83 27.94))
-    (stroke (width 0) (type default))
-    (uuid a07a2b73-2a24-484f-89df-c2ee38f6aa4b)
-  )
-  (wire (pts (xy 127 135.89) (xy 127 138.43))
-    (stroke (width 0) (type default))
-    (uuid a11397fa-8c25-41b3-b548-810999fe71ac)
-  )
-  (wire (pts (xy 71.12 189.23) (xy 77.47 189.23))
-    (stroke (width 0) (type default))
-    (uuid a27b8122-7c38-468f-8e80-7984351b810f)
-  )
-  (wire (pts (xy 29.21 36.83) (xy 29.21 44.45))
-    (stroke (width 0) (type default))
-    (uuid a3c1a6ff-8a21-4fea-87ec-c5cf6716c332)
-  )
-  (wire (pts (xy 36.83 43.18) (xy 36.83 44.45))
-    (stroke (width 0) (type default))
-    (uuid a476ec8c-a62f-4c77-a591-48b3bef849eb)
-  )
-  (wire (pts (xy 95.25 106.68) (xy 111.76 106.68))
-    (stroke (width 0) (type default))
-    (uuid a51201ce-1353-47ff-affc-a923b3ba2066)
-  )
-  (wire (pts (xy 210.82 142.24) (xy 210.82 149.86))
-    (stroke (width 0) (type default))
-    (uuid a5450344-b5d1-4997-b7ca-fce6b1525402)
-  )
-  (wire (pts (xy 139.7 166.37) (xy 119.38 166.37))
-    (stroke (width 0) (type default))
-    (uuid a5f23641-5a26-4fba-ab74-a7d2446074ba)
-  )
-  (wire (pts (xy 95.25 114.3) (xy 111.76 114.3))
-    (stroke (width 0) (type default))
-    (uuid a60b7e43-cfb2-4f6b-a164-d2899332fdc9)
-  )
-  (wire (pts (xy 189.23 91.44) (xy 190.5 91.44))
-    (stroke (width 0) (type default))
-    (uuid a804039b-8dac-4be9-8d1c-f53ef1c68693)
-  )
-  (wire (pts (xy 147.32 138.43) (xy 147.32 153.67))
-    (stroke (width 0) (type default))
-    (uuid a8ced33a-fed0-4d4d-b300-e4fff4ab72e9)
-  )
-  (wire (pts (xy 111.76 101.6) (xy 114.3 101.6))
-    (stroke (width 0) (type default))
-    (uuid aa3571e0-51c2-4c46-b768-306543f56461)
-  )
-  (wire (pts (xy 217.17 149.86) (xy 210.82 149.86))
-    (stroke (width 0) (type default))
-    (uuid abaa63e1-24ad-411f-b914-2666c1827d4b)
-  )
-  (wire (pts (xy 151.13 35.56) (xy 151.13 27.94))
-    (stroke (width 0) (type default))
-    (uuid abeb9fe9-dc98-44ab-ab3b-742c8d493c6b)
-  )
-  (wire (pts (xy 69.85 41.91) (xy 69.85 43.18))
-    (stroke (width 0) (type default))
-    (uuid ac226511-41fc-4e4b-9810-f755e03f681e)
-  )
-  (wire (pts (xy 21.59 176.53) (xy 24.13 176.53))
-    (stroke (width 0) (type default))
-    (uuid ac41630d-ce9e-412f-bbde-7e4f7cc0dab5)
-  )
-  (wire (pts (xy 78.74 99.06) (xy 78.74 105.41))
-    (stroke (width 0) (type default))
-    (uuid ad38da87-0b42-4c3e-a776-63a5194b84f1)
-  )
-  (wire (pts (xy 210.82 125.73) (xy 210.82 127))
-    (stroke (width 0) (type default))
-    (uuid ae70448e-542d-431e-8f38-62a2358dade0)
-  )
-  (wire (pts (xy 111.76 109.22) (xy 114.3 109.22))
-    (stroke (width 0) (type default))
-    (uuid aef5f99d-7693-4429-80b7-bd3798a67045)
-  )
-  (wire (pts (xy 35.56 30.48) (xy 35.56 33.02))
-    (stroke (width 0) (type default))
-    (uuid afdf75e6-8996-4246-a688-6d377984791d)
-  )
-  (wire (pts (xy 78.74 40.64) (xy 78.74 35.56))
-    (stroke (width 0) (type default))
-    (uuid aff5ea89-86a6-4e3e-a187-dc2b99f64ddf)
-  )
-  (wire (pts (xy 99.06 140.97) (xy 99.06 116.84))
-    (stroke (width 0) (type default))
-    (uuid b016e04d-c0bf-4a86-9b6c-bcf76ace7247)
-  )
-  (wire (pts (xy 161.29 121.92) (xy 173.99 121.92))
-    (stroke (width 0) (type default))
-    (uuid b111959d-5779-4cc6-b5da-993d38612d12)
-  )
-  (wire (pts (xy 132.08 135.89) (xy 132.08 138.43))
-    (stroke (width 0) (type default))
-    (uuid b2d28381-1776-43f5-8102-e6638e6e772e)
-  )
-  (wire (pts (xy 53.34 128.27) (xy 53.34 134.62))
-    (stroke (width 0) (type default))
-    (uuid b3c41e09-515f-490e-8188-e2dd71cba849)
-  )
-  (wire (pts (xy 69.85 27.94) (xy 71.12 27.94))
-    (stroke (width 0) (type default))
-    (uuid b41eec96-de99-4cca-a174-16528685c0a2)
-  )
-  (wire (pts (xy 275.59 30.48) (xy 275.59 34.29))
-    (stroke (width 0) (type default))
-    (uuid b6a9be71-0b37-4365-aaef-2b3a701edc88)
-  )
-  (wire (pts (xy 144.78 138.43) (xy 144.78 153.67))
-    (stroke (width 0) (type default))
-    (uuid b79f7f0c-b1e5-449e-ad50-c2d15a8e8871)
-  )
-  (wire (pts (xy 35.56 25.4) (xy 35.56 27.94))
-    (stroke (width 0) (type default))
-    (uuid b7a9536a-7f29-4bd7-8049-6368db1d7124)
-  )
-  (wire (pts (xy 157.48 121.92) (xy 161.29 121.92))
-    (stroke (width 0) (type default))
-    (uuid b7c05c66-57ba-4502-a290-19af8c44cb47)
-  )
-  (wire (pts (xy 21.59 104.14) (xy 21.59 101.6))
-    (stroke (width 0) (type default))
-    (uuid b7c5e5bf-4f0d-4eaa-89fa-e2ffac52b38d)
-  )
-  (wire (pts (xy 217.17 134.62) (xy 210.82 134.62))
-    (stroke (width 0) (type default))
-    (uuid b7d07269-7836-4faa-b058-a3eb1186395f)
-  )
-  (wire (pts (xy 111.76 114.3) (xy 114.3 114.3))
-    (stroke (width 0) (type default))
-    (uuid b8130a4c-8d3a-4161-aa72-9f22cac050f8)
-  )
-  (wire (pts (xy 60.96 24.13) (xy 64.77 24.13))
-    (stroke (width 0) (type default))
-    (uuid b86e5e46-e623-470f-aab4-0a654715c7c1)
-  )
-  (wire (pts (xy 161.29 91.44) (xy 181.61 91.44))
-    (stroke (width 0) (type default))
-    (uuid b9a2b5de-0a55-46d7-8ed8-9d130d3feea3)
-  )
-  (wire (pts (xy 210.82 134.62) (xy 210.82 139.7))
-    (stroke (width 0) (type default))
-    (uuid b9de82ac-e92f-4c86-95ef-5d2acd3ee878)
-  )
-  (wire (pts (xy 157.48 101.6) (xy 161.29 101.6))
-    (stroke (width 0) (type default))
-    (uuid bb296156-184f-474b-8d0b-88ca4c72a2d7)
-  )
-  (wire (pts (xy 127 138.43) (xy 127 151.13))
-    (stroke (width 0) (type default))
-    (uuid bbfbfc68-0cb4-4bfa-832c-87aa503264be)
-  )
-  (wire (pts (xy 158.75 27.94) (xy 163.83 27.94))
-    (stroke (width 0) (type default))
-    (uuid bcb27b86-fc52-4c42-ad8a-2c4a60749310)
-  )
-  (wire (pts (xy 186.69 114.3) (xy 189.23 114.3))
-    (stroke (width 0) (type default))
-    (uuid bcb6d768-6a47-46c7-ad29-cf6300ebc86f)
-  )
-  (wire (pts (xy 73.66 139.7) (xy 71.12 139.7))
-    (stroke (width 0) (type default))
-    (uuid bd6bcb21-0982-470d-837e-d2fba9d96e68)
-  )
-  (wire (pts (xy 147.32 135.89) (xy 147.32 138.43))
-    (stroke (width 0) (type default))
-    (uuid bda5acc5-34c2-4142-8def-aa7a9c193d5e)
-  )
-  (wire (pts (xy 269.24 121.92) (xy 266.7 121.92))
-    (stroke (width 0) (type default))
-    (uuid bdae4942-d901-4085-99f3-d1b5a1aa6f74)
-  )
-  (wire (pts (xy 133.35 36.83) (xy 133.35 38.1))
-    (stroke (width 0) (type default))
-    (uuid be215129-36e4-4e28-bcda-921e58bb5581)
-  )
-  (wire (pts (xy 243.84 123.19) (xy 246.38 123.19))
-    (stroke (width 0) (type default))
-    (uuid be64f0af-d65c-4ef1-8ab0-ff1186c81f83)
-  )
-  (wire (pts (xy 36.83 88.9) (xy 40.64 88.9))
-    (stroke (width 0) (type default))
-    (uuid c119fda0-285c-432e-8fce-a04f70bdca4c)
-  )
-  (wire (pts (xy 74.93 105.41) (xy 78.74 105.41))
-    (stroke (width 0) (type default))
-    (uuid c3f0fee0-b339-4d2f-b88d-939e34e025e2)
-  )
-  (wire (pts (xy 234.95 34.29) (xy 236.22 34.29))
-    (stroke (width 0) (type default))
-    (uuid c50847a2-09a5-4f67-885e-41433f06da2b)
-  )
-  (wire (pts (xy 147.32 27.94) (xy 151.13 27.94))
-    (stroke (width 0) (type default))
-    (uuid c55c82e9-00b6-457c-8ead-5b9658f6d6e1)
-  )
-  (wire (pts (xy 209.55 97.79) (xy 171.45 97.79))
-    (stroke (width 0) (type default))
-    (uuid c6330d00-8001-4b9a-aa07-6099bb7fe3f4)
-  )
-  (wire (pts (xy 105.41 72.39) (xy 101.6 72.39))
-    (stroke (width 0) (type default))
-    (uuid c92c5c65-793c-4074-9a61-6ec4ebe90f90)
-  )
-  (wire (pts (xy 52.07 144.78) (xy 52.07 137.16))
-    (stroke (width 0) (type default))
-    (uuid ca9797da-1d82-4438-b60f-a8825b6bf7bd)
-  )
-  (wire (pts (xy 179.07 134.62) (xy 180.34 134.62))
-    (stroke (width 0) (type default))
-    (uuid cab728af-011a-4c57-98be-d036c4c60962)
-  )
-  (wire (pts (xy 33.02 80.01) (xy 33.02 88.9))
-    (stroke (width 0) (type default))
-    (uuid cb7adfc4-ae2e-4bcc-a684-93ad2c4e0163)
-  )
-  (wire (pts (xy 62.23 27.94) (xy 62.23 33.02))
-    (stroke (width 0) (type default))
-    (uuid cee93102-27c6-47f9-8fbd-8dea24274cf5)
-  )
-  (wire (pts (xy 171.45 99.06) (xy 175.26 99.06))
-    (stroke (width 0) (type default))
-    (uuid cf9d2d25-48ff-4409-9cee-563c72613003)
-  )
-  (wire (pts (xy 111.76 111.76) (xy 114.3 111.76))
-    (stroke (width 0) (type default))
-    (uuid d0eb0eea-7067-4655-93c1-b055dca1317a)
-  )
-  (wire (pts (xy 190.5 27.94) (xy 190.5 26.67))
-    (stroke (width 0) (type default))
-    (uuid d186982d-7de4-4661-af4e-3b388f86da9b)
-  )
-  (wire (pts (xy 63.5 129.54) (xy 46.99 129.54))
-    (stroke (width 0) (type default))
-    (uuid d20d10fb-98c0-489d-8596-6637a9f2bfd4)
-  )
-  (wire (pts (xy 171.45 87.63) (xy 171.45 88.9))
-    (stroke (width 0) (type default))
-    (uuid d22f21b6-d0da-4a23-8747-42409ef226c2)
-  )
-  (wire (pts (xy 173.99 134.62) (xy 173.99 121.92))
-    (stroke (width 0) (type default))
-    (uuid d2bdf1ec-ef61-4ec8-9a64-eb6b363f4b22)
-  )
-  (wire (pts (xy 184.15 38.1) (xy 184.15 31.75))
-    (stroke (width 0) (type default))
-    (uuid d2e0f101-8308-480f-b3c1-4da5e551a04e)
-  )
-  (wire (pts (xy 137.16 27.94) (xy 147.32 27.94))
-    (stroke (width 0) (type default))
-    (uuid d3d8b3a4-da4a-406f-b5e4-71ec7321f954)
-  )
-  (wire (pts (xy 266.7 140.97) (xy 274.32 140.97))
-    (stroke (width 0) (type default))
-    (uuid d4aa9520-c696-40ed-b309-e5c63619d093)
-  )
-  (wire (pts (xy 90.17 71.12) (xy 85.09 71.12))
-    (stroke (width 0) (type default))
-    (uuid d6c59023-2144-4a29-b58b-21a755f77350)
-  )
-  (wire (pts (xy 95.25 140.97) (xy 95.25 114.3))
-    (stroke (width 0) (type default))
-    (uuid d83a0525-0045-43d6-b38e-e90d4af6e38b)
-  )
-  (wire (pts (xy 217.17 127) (xy 210.82 127))
-    (stroke (width 0) (type default))
-    (uuid d8705b57-0942-45fa-9a23-d5d53a1e0112)
-  )
-  (wire (pts (xy 274.32 144.78) (xy 266.7 144.78))
-    (stroke (width 0) (type default))
-    (uuid da113ef5-6fe8-414b-b168-3be7d62ff95d)
-  )
-  (wire (pts (xy 269.24 109.22) (xy 266.7 109.22))
-    (stroke (width 0) (type default))
-    (uuid da941a4d-535c-46dd-9506-9a1f105eb07a)
-  )
-  (wire (pts (xy 259.08 34.29) (xy 262.89 34.29))
-    (stroke (width 0) (type default))
-    (uuid ddc90e1e-01b1-495e-b136-102a14921c41)
-  )
-  (wire (pts (xy 60.96 88.9) (xy 68.58 88.9))
-    (stroke (width 0) (type default))
-    (uuid df0b8206-8ee3-455c-ae85-a636c2af18bc)
-  )
-  (wire (pts (xy 76.2 91.44) (xy 111.76 91.44))
-    (stroke (width 0) (type default))
-    (uuid df92658c-758b-47c3-9f1a-302b0da1b36b)
-  )
-  (wire (pts (xy 111.76 99.06) (xy 114.3 99.06))
-    (stroke (width 0) (type default))
-    (uuid e009fedf-a80f-4d86-bc36-1149b5a9713a)
-  )
-  (wire (pts (xy 242.57 34.29) (xy 243.84 34.29))
-    (stroke (width 0) (type default))
-    (uuid e0d9468d-ca69-4fb5-b09b-bae5e03c47b3)
-  )
-  (wire (pts (xy 186.69 109.22) (xy 187.96 109.22))
-    (stroke (width 0) (type default))
-    (uuid e1bbbcec-f562-49e7-8ace-ad521d186d52)
-  )
-  (wire (pts (xy 210.82 152.4) (xy 210.82 153.67))
-    (stroke (width 0) (type default))
-    (uuid e1cf445d-6652-44ae-a67e-987ca5db2ca7)
-  )
-  (wire (pts (xy 68.58 104.14) (xy 72.39 104.14))
-    (stroke (width 0) (type default))
-    (uuid e2975829-0eb7-467b-9ce9-526de8d8bca5)
-  )
-  (wire (pts (xy 193.04 27.94) (xy 190.5 27.94))
-    (stroke (width 0) (type default))
-    (uuid e2c56d74-fa93-4234-8f2d-b6cd9bc778fc)
-  )
-  (wire (pts (xy 267.97 92.71) (xy 265.43 92.71))
-    (stroke (width 0) (type default))
-    (uuid e437264a-2893-4983-9d20-90f356e33265)
-  )
-  (wire (pts (xy 139.7 135.89) (xy 139.7 138.43))
-    (stroke (width 0) (type default))
-    (uuid e4b0b187-969f-48cb-bb04-1d8228ef0d51)
-  )
-  (wire (pts (xy 101.6 189.23) (xy 100.33 189.23))
-    (stroke (width 0) (type default))
-    (uuid e66d62e6-b777-4f62-bb49-c471581fe623)
-  )
-  (wire (pts (xy 185.42 38.1) (xy 184.15 38.1))
-    (stroke (width 0) (type default))
-    (uuid e6902e20-f118-4811-a431-decb652c2bd9)
-  )
-  (wire (pts (xy 21.59 92.71) (xy 35.56 92.71))
-    (stroke (width 0) (type default))
-    (uuid e7cb38a7-1a88-4af1-a135-94afb4068d9b)
-  )
-  (wire (pts (xy 157.48 106.68) (xy 161.29 106.68))
-    (stroke (width 0) (type default))
-    (uuid e89349a1-0955-4ab6-9212-43fb7a67da06)
-  )
-  (wire (pts (xy 111.76 104.14) (xy 114.3 104.14))
-    (stroke (width 0) (type default))
-    (uuid e9750486-8899-4994-a5c9-dbfd83dde26a)
-  )
-  (wire (pts (xy 111.76 116.84) (xy 114.3 116.84))
-    (stroke (width 0) (type default))
-    (uuid ec47447d-773a-4bcd-84f4-7f081a3e0902)
-  )
-  (wire (pts (xy 157.48 116.84) (xy 161.29 116.84))
-    (stroke (width 0) (type default))
-    (uuid ef1ff236-1b61-4d16-9cae-0683020d3aab)
-  )
-  (wire (pts (xy 35.56 33.02) (xy 33.02 33.02))
-    (stroke (width 0) (type default))
-    (uuid ef6b7de1-d99d-4417-a150-1b09ec049a3b)
-  )
-  (wire (pts (xy 187.96 31.75) (xy 184.15 31.75))
-    (stroke (width 0) (type default))
-    (uuid ef866b12-abaf-4f18-b848-9168c4af126c)
-  )
-  (wire (pts (xy 88.9 63.5) (xy 85.09 63.5))
-    (stroke (width 0) (type default))
-    (uuid f070043f-4f08-4434-ad66-8c419f58c0e4)
-  )
-  (wire (pts (xy 171.45 86.36) (xy 171.45 87.63))
-    (stroke (width 0) (type default))
-    (uuid f0c1f3e1-0b68-4b77-9e60-4b6b3245f5ac)
-  )
-  (wire (pts (xy 57.15 60.96) (xy 55.88 60.96))
-    (stroke (width 0) (type default))
-    (uuid f1764a93-95af-4bea-aede-f0673319fc8e)
-  )
-  (wire (pts (xy 92.71 140.97) (xy 92.71 111.76))
-    (stroke (width 0) (type default))
-    (uuid f18992fb-6484-4baf-add4-7036a5d39376)
-  )
-  (wire (pts (xy 54.61 99.06) (xy 54.61 123.19))
-    (stroke (width 0) (type default))
-    (uuid f264ac9a-c4b7-4471-af16-acda245fcb9d)
-  )
-  (wire (pts (xy 68.58 88.9) (xy 68.58 91.44))
-    (stroke (width 0) (type default))
-    (uuid f346cfd6-96ee-45f9-9eab-78241f4ab3a8)
-  )
-  (wire (pts (xy 194.31 137.16) (xy 194.31 139.7))
-    (stroke (width 0) (type default))
-    (uuid f4ac11f2-e892-41cd-892f-55245b99640d)
-  )
-  (wire (pts (xy 72.39 60.96) (xy 105.41 60.96))
-    (stroke (width 0) (type default))
-    (uuid f4edecc3-61b7-4001-b758-e1a741cb679c)
-  )
-  (wire (pts (xy 35.56 92.71) (xy 40.64 92.71))
-    (stroke (width 0) (type default))
-    (uuid f577c61e-a3da-4892-aeba-895c8ef0c49e)
-  )
-  (wire (pts (xy 21.59 182.88) (xy 24.13 182.88))
-    (stroke (width 0) (type default))
-    (uuid f57dbda5-ccc6-439f-a053-aeb32530f8f4)
-  )
-  (wire (pts (xy 101.6 72.39) (xy 101.6 74.93))
-    (stroke (width 0) (type default))
-    (uuid f5b16b93-17a2-4176-8caa-e3b67c87eb3c)
-  )
-  (wire (pts (xy 43.18 66.04) (xy 43.18 60.96))
-    (stroke (width 0) (type default))
-    (uuid f5d35921-24f0-493d-a36d-b4153be1a2f2)
-  )
-  (wire (pts (xy 101.6 74.93) (xy 101.6 93.98))
-    (stroke (width 0) (type default))
-    (uuid f6100c17-3c50-4045-addd-f0629a8cce53)
-  )
-  (wire (pts (xy 40.64 88.9) (xy 49.53 88.9))
-    (stroke (width 0) (type default))
-    (uuid f642fcbd-2380-45c6-afff-38ac267774f1)
-  )
-  (wire (pts (xy 55.88 40.64) (xy 55.88 43.18))
-    (stroke (width 0) (type default))
-    (uuid f6e816b1-a4e5-4421-a6e5-1d4f494c3f69)
-  )
-  (wire (pts (xy 35.56 102.87) (xy 35.56 101.6))
-    (stroke (width 0) (type default))
-    (uuid f8237b43-684f-4512-bf1d-7181f894ea44)
-  )
-  (wire (pts (xy 275.59 34.29) (xy 280.67 34.29))
-    (stroke (width 0) (type default))
-    (uuid f8d0c5c6-271f-49b8-84b8-cce77cd340e4)
-  )
-  (wire (pts (xy 35.56 27.94) (xy 33.02 27.94))
-    (stroke (width 0) (type default))
-    (uuid f902e4e8-9ee1-4a25-9265-d1dd56c6a813)
-  )
-  (wire (pts (xy 77.47 74.93) (xy 101.6 74.93))
-    (stroke (width 0) (type default))
-    (uuid f9ae06e3-5a83-4d3b-848c-71ca2b09c7d2)
-  )
-  (wire (pts (xy 207.01 139.7) (xy 210.82 139.7))
-    (stroke (width 0) (type default))
-    (uuid fbc9d5b4-5c39-445f-9c51-50a40df05e14)
-  )
-  (wire (pts (xy 151.13 27.94) (xy 156.21 27.94))
-    (stroke (width 0) (type default))
-    (uuid fd517522-94a0-4241-a9f7-b66adeff577e)
-  )
-  (wire (pts (xy 161.29 96.52) (xy 191.77 96.52))
-    (stroke (width 0) (type default))
-    (uuid fdfca061-a266-45db-91b4-1e37f59e7c1b)
-  )
-  (wire (pts (xy 50.8 125.73) (xy 72.39 125.73))
-    (stroke (width 0) (type default))
-    (uuid fe3c454f-e1ab-46a1-8bdf-347583c6c0f8)
-  )
-  (wire (pts (xy 77.47 82.55) (xy 69.85 82.55))
-    (stroke (width 0) (type default))
-    (uuid fe721fc3-087c-4082-aa8a-a262784e7618)
-  )
-
-  (image (at 244.475 174.625) (scale 0.75)
-    (uuid a2f33916-4f74-46ac-8520-7c0afb889453)
-    (data
-      iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz
-      AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h
-      aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73
-      +/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA
-      xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y
-      Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h
-      xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO
-      GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful
-      fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv
-      4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ
-      EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R
-      Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM
-      vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H
-      cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0
-      6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT
-      O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA
-      4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86
-      sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+
-      oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/
-      55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0
-      qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+
-      KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn
-      Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4
-      mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii
-      P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr
-      voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6
-      bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO
-      h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da
-      4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y
-      YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC
-      0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP
-      SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb
-      WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw
-      v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay
-      PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX
-      Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh
-      oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD
-      7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da
-      43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l
-      zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl
-      pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS
-      H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV
-      ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY
-      MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2
-      NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx
-      fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl
-      tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew
-      iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj
-      jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI
-      cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo
-      XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R
-      9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv
-      8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV
-      RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY
-      l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf
-      YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN
-      EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU
-      sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z
-      7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs
-      OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs
-      qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7
-      G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6
-      wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7
-      zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln
-      Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX
-      apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk
-      lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw
-      TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb
-      54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID
-      qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd
-      P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l
-      UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD
-      zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH
-      Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1
-      QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/
-      ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX
-      08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC
-      KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ
-      SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu
-      h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp
-      VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf
-      G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK
-      dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO
-      uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2
-      DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn
-      byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc
-      dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N
-      iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP
-      NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4
-      wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8
-      K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s
-      xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS
-      Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC
-      Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5
-      m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm
-      aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj
-      gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn
-      p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL
-      ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx
-      u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+
-      FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa
-      ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h
-      1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj
-      DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy
-      +Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj
-      wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj
-      7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ
-      lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN
-      2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY
-      CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi
-      mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E
-      uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x
-      j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD
-      45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO
-      4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni
-      buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY
-      HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH
-      NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ
-      azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N
-      SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP
-      hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe
-      nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4
-      b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN
-      xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S
-      pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq
-      3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB
-      Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL
-      4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw
-      qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX
-      9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n
-      frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/
-      eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK
-      TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u
-      RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9
-      DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j
-      2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx
-      BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy
-      91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7
-      jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw
-      pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ
-      cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M
-      xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23
-      7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8
-      D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw
-      YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu
-      QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs
-      uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA
-      PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6
-      yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN
-      xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq
-      JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT
-      +HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg
-      hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K
-      hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt
-      g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z
-      5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf
-      u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO
-      Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG
-      gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK
-      hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x
-      moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56
-      KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp
-      ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz
-      eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO
-      0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA
-      BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ
-      2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB
-      4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF
-      6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI
-      gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv
-      OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt
-      8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI
-      bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM
-      500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4
-      CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V
-      aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5
-      yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF
-      zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss
-      tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q
-      r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj
-      xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h
-      6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y
-      9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE
-      XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh
-      oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk
-      Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4
-      ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW
-      zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr
-      wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV
-      BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7
-      LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr
-      owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX
-      hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j
-      1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF
-      5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw
-      a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6
-      Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN
-      +SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds
-      lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ
-      i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu
-      fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy
-      r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28
-      dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az
-      70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk
-      EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL
-      p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf
-      nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA
-      ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c
-      q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu
-      Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR
-      TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53
-      en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA
-      x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ
-      t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+
-      R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf
-      5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH
-      e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG
-      po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh
-      6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln
-      9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU
-      xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ
-      rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W
-      lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb
-      afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs
-      FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR
-      OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC
-      P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp
-      EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh
-      6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK
-      GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ
-      hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s
-      amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+
-      fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij
-      TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv
-      I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf
-      kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ
-      BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD
-      9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn
-      jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8
-      I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI
-      8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs
-      Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN
-      MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5
-      2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU
-      2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss
-      ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m
-      sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq
-      LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT
-      tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9
-      oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p
-      zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu
-      WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy
-      diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX
-      ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY
-      5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau
-      Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7
-      oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG
-      xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q
-      zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik
-      sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN
-      ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc
-      MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E
-      YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3
-      bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz
-      DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC
-      TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES
-      3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K
-      Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd
-      b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5
-      99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys
-      7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa
-      Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e
-      8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1
-      vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK
-      VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4
-      ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD
-      CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4
-      qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr
-      1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe
-      GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK
-      yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj
-      po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO
-      Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF
-      tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D
-      mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM
-      eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN
-      veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu
-      5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL
-      Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t
-      rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl
-      sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx
-      mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG
-      PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk
-      Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk
-      caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO
-      jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS
-      gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E
-      OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+
-      p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO
-      cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM
-      S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc
-      vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3
-      boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn
-      DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD
-      90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw
-      0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT
-      5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI
-      7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP
-      QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw
-      oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E
-      mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/
-      N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm
-      vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC
-      +OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp
-      gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz
-      gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni
-      R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3
-      j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo
-      BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl
-      IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4
-      jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA
-      Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS
-      AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz
-      6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H
-      qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp
-      cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa
-      M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv
-      4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M
-      IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD
-      Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r
-      un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr
-      2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/
-      kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF
-      7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8
-      YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk
-      zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp
-      8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF
-      o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt
-      Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA
-      hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx
-      LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk
-      iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2
-      HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5
-      K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo
-      XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/
-      D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j
-      MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c
-      O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB
-      fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X
-      /V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI
-      a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe
-      L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37
-      zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY
-      BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg==
-    )
-  )
-
-  (text "Power Input, Reverse protected." (at 15.875 18.415 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 02202e00-6caa-4788-9d4c-cd31425f7f41)
-  )
-  (text "BOOT" (at 180.34 143.51 0)
-    (effects (font (size 2.54 2.54)) (justify left bottom))
-    (uuid 07caad48-07e4-4a29-ab5d-6835f7344899)
-  )
-  (text "currect setting \nresistor" (at 124.46 161.29 0)
-    (effects (font (size 0.762 0.762)) (justify left bottom))
-    (uuid 185afef7-94de-46bb-b04b-d30f6098d406)
-  )
-  (text "RTS	Request to Send	Out\nCTS	Clear to Send	In" (at 148.59 139.7 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 26964fbf-e8bd-441a-83b8-f05dde8f2bbe)
-  )
-  (text "controls boot" (at 168.275 123.19 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 4111fe6e-ba44-4652-a43b-9cf27698d78a)
-  )
-  (text "↑StatusLED" (at 115.57 170.18 0)
-    (effects (font (size 2.54 2.54)) (justify left bottom))
-    (uuid 57b7e314-ac2c-4601-a425-4e19dd064d03)
-  )
-  (text "RESET" (at 45.72 72.39 0)
-    (effects (font (size 2.54 2.54)) (justify left bottom))
-    (uuid 62d6c0a4-8d9c-47e3-bf80-d5b0553f8bb8)
-  )
-  (text "Power Indicator" (at 157.48 54.61 0)
-    (effects (font (size 2.54 2.54)) (justify left bottom))
-    (uuid 778942c1-a5eb-4c37-a7e5-1bae8be6282f)
-  )
-  (text "MENU" (at 72.39 138.43 0)
-    (effects (font (size 2.54 2.54)) (justify left bottom))
-    (uuid 7fae4902-1b08-4e2d-8bc2-011d0c018ec5)
-  )
-  (text "clk" (at 53.34 133.985 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 9125816a-86bf-4092-9aa7-1132d49add69)
-  )
-  (text "ControllerVcc comes from a USB host." (at 168.275 17.145 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid a25e161b-833e-4d6b-9bf3-e0b8a8257f06)
-  )
-  (text "DT" (at 53.34 141.605 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid b2517a33-866c-4158-af02-5b6f54153a62)
-  )
-  (text "Voltage regulator for ESP32" (at 212.09 19.685 0)
-    (effects (font (size 2.54 2.54)) (justify left bottom))
-    (uuid b43333ec-5131-4b89-9558-536c4067a26c)
-  )
-  (text "Voltage regulator for 12V in to +5V" (at 48.26 15.24 0)
-    (effects (font (size 2.54 2.54)) (justify left bottom))
-    (uuid ecbd92f8-1a18-42f7-91dc-384884c750e8)
-  )
-
-  (label "nS1" (at 85.09 101.6 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 34dc82e3-41bd-4476-ad40-c9ffcc99baec)
-  )
-  (label "+5V" (at 125.73 27.94 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 3e3b7a61-4807-4ab1-a86d-d12a1b1a0297)
-  )
-  (label "Vin" (at 92.71 19.05 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 425ff377-0c0f-4717-923a-01041fcd1017)
-  )
-  (label "RT_ENC_B" (at 77.47 96.52 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 633c4e55-d099-4ace-8dd8-78adc5a4cb09)
-  )
-  (label "RT_ENC_A" (at 81.28 99.06 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 729e3b4a-3082-42fa-89cd-5f51ec4abc1c)
-  )
-  (label "TX1" (at 147.32 153.67 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 894b3ee2-d114-4e4d-8ce4-66b5bc73957b)
-  )
-  (label "CTS1" (at 97.79 109.22 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 946aab90-1e48-4ad1-96c7-299c7036e924)
-  )
-  (label "RTS1" (at 97.79 106.68 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 95125360-b52f-4454-837f-9dbf562b1747)
-  )
-  (label "3v3Controller" (at 40.64 88.9 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid a22bfc63-302b-4464-9e79-393a07307b02)
-  )
-  (label "+5esp32" (at 226.06 34.29 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid a3086c6d-009c-42df-a8ef-067a2ac724b5)
-  )
-  (label "LED_BUILTIN" (at 127 151.13 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid e1345516-6ea7-4984-a9df-aa13bf5393d1)
-  )
-  (label "RX1" (at 144.78 153.67 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid fe750e9b-b513-4e34-a6aa-527d4771cba0)
-  )
-
-  (global_label "CIPO" (shape input) (at 101.6 182.88 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 01d71b3b-e67d-44ca-b9f8-67e652edc26d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 108.3269 182.88 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Busy" (shape output) (at 269.24 114.3 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 03ecf8ca-0455-458c-b4bf-c68ef57e38fd)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 275.9063 114.3 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "ControllerRX" (shape input) (at 175.26 99.06 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 0900fd0d-cb3c-471a-9fc5-030aa0af1c48)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 189.4252 99.06 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Switch_Mute" (shape input) (at 97.79 104.14 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 139755cb-929b-4ef1-99fb-ac67acf6f2ec)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 84.048 104.14 0)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "nRESET" (shape input) (at 21.59 182.88 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 1471edf9-a0d4-4076-94ec-06239f331664)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 12.4443 182.88 0)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "Light3" (shape output) (at 274.32 148.59 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 1528a544-7ce4-4a3b-944f-a90f34ba46b1)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 282.4377 148.59 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "ControllerTX" (shape output) (at 191.77 96.52 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 17502264-35f9-4154-b229-534320edfde2)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 205.6328 96.52 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "ControllerRX" (shape input) (at 48.26 191.77 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 1ba30855-952a-4bae-9df2-293bd81f7ecc)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 62.4252 191.77 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "RTS1" (shape input) (at 95.25 106.68 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 1eb1a2ee-83ac-4fc5-af03-67558264c09c)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 88.3418 106.68 0)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "CTS1" (shape input) (at 95.25 109.22 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 38ec81e3-5066-4e3a-be7b-0af8a3780fde)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 88.3418 109.22 0)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "VBus" (shape input) (at 48.26 185.42 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 3a6eea99-2b5e-42b8-911f-99623e80bc0e)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 55.0473 185.42 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "ControllerRX2" (shape input) (at 173.99 116.84 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 3d6e3c31-73a2-4607-a4da-eb757c34fd42)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 189.3647 116.84 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "RTS1" (shape input) (at 143.51 189.23 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 43b3408b-e98a-4f9a-af3e-a590062b0118)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 150.4182 189.23 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "SPI_SCK" (shape input) (at 187.96 109.22 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 46f29c9a-14e4-4b51-b682-d09049eece73)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 198.013 109.22 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "ControllerTX" (shape input) (at 48.26 189.23 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 47c8e0c8-c399-4625-a766-4b51e8cffcdd)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 62.1228 189.23 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "TX1" (shape input) (at 147.32 153.67 270) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 4ac5b67e-f700-493c-a8c6-dd256c55c3d1)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 147.32 159.3082 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "Light1" (shape output) (at 101.6 140.97 270) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 4b30932e-9781-4ca2-8d1f-9ea1b6b35c6c)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 101.6 149.0877 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "SCL" (shape input) (at 267.97 85.09 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 5692b59d-c87b-4356-a7ef-279ecf176fb7)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 273.7292 85.09 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "CTS1" (shape input) (at 143.51 191.77 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 57c8cb56-2920-46a0-8e2a-7f3c307bf6af)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 150.4182 191.77 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "SPI_SCK" (shape output) (at 101.6 185.42 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 5a9e49d8-c470-4aa5-8355-36b40ba88219)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 111.653 185.42 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "GPIO0" (shape input) (at 181.61 121.92 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 5e7d9260-eace-4b0c-8f0e-6e27f5fc9b14)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 189.5464 121.92 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "ControllerVcc" (shape passive) (at 101.6 191.77 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 62108188-1674-4d13-99dc-30ed50f65936)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 115.599 191.77 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "ControllerTX2" (shape output) (at 189.23 114.3 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 662b295d-9529-45cd-87da-c18ac5a0db71)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 204.3023 114.3 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Light4" (shape output) (at 92.71 140.97 270) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 72b005c0-5d36-49a8-b14e-90c2bff500c4)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 92.71 149.0877 90)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "ControllerTX2" (shape input) (at 269.24 109.22 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 7d094b12-99be-41d6-a285-d1eca7495a9c)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 284.3123 109.22 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Light2" (shape output) (at 274.32 144.78 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 8310eea7-e658-478c-859e-95e612f4f72d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 282.4377 144.78 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Light4" (shape output) (at 274.32 152.4 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 8475ed2e-788b-438b-922e-5e8808f55adc)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 282.4377 152.4 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "GPIO0" (shape input) (at 21.59 176.53 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid 879019ac-5e66-4ceb-b214-9d342e107693)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 13.6536 176.53 0)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "RX1" (shape input) (at 143.51 182.88 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 9854e2dd-2038-48ac-ac5b-81e7809eae04)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 149.4506 182.88 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "nCS" (shape input) (at 189.23 111.76 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 9970be4a-a160-4c73-a2d1-f7d2aa23e0ac)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 195.1101 111.76 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "SCL" (shape output) (at 176.53 93.98 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid a05f3b7c-c340-4571-afd7-f9d90c04cee5)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 182.2892 93.98 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "ControllerRX2" (shape output) (at 269.24 111.76 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid a3b335af-5e7e-46e3-8ed8-219007c8b44a)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 284.6147 111.76 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Busy" (shape input) (at 170.18 119.38 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid a508e5cc-449f-4a3c-a211-b1e42b44ce24)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 176.8463 119.38 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Light1" (shape output) (at 274.32 140.97 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid aad9bf2e-cb74-4f20-9fa6-e2ded9361869)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 282.4377 140.97 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "VBus" (shape passive) (at 167.64 27.94 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid b4eef599-b4f0-4483-9fa2-45ebf8db51c3)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 26.67 3.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-  )
-  (global_label "nCS" (shape output) (at 101.6 189.23 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid b7f72da4-5e03-4274-b475-07ef149de1ad)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 107.4801 189.23 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "ControllerVcc" (shape passive) (at 193.04 27.94 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid b98c0f7d-8ba0-40fe-b1c5-b36399dbadf2)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 21.59 3.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-  )
-  (global_label "SDA" (shape bidirectional) (at 267.97 92.71 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid b9bd1edd-6d20-45c0-8c3c-917a0c01857b)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 274.7422 92.71 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Light3" (shape output) (at 95.25 140.97 270) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid bdb25a70-739b-4893-ad8d-751f68b15dea)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 95.25 149.0877 90)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "COPI" (shape output) (at 101.6 179.07 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid c85915ff-9a08-41ad-a8fc-5f0a0dcf2eb0)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 108.3269 179.07 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "RX1" (shape input) (at 144.78 153.67 270) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid cd959308-4b6e-4e3d-a438-746bbeabe5fc)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 144.78 159.6106 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "nRESET" (shape input) (at 97.79 93.98 180) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid d3acf90a-9e92-419f-9e48-887571e3170e)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 88.6443 93.98 0)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "CIPO" (shape output) (at 171.45 106.68 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid d5c76730-3eae-49e4-8b84-b3fcd022bb83)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 178.1769 106.68 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Vin" (shape passive) (at 175.26 19.05 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid d80da892-aaa1-44e2-a3e1-2cdc73b19558)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 26.67 3.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-  )
-  (global_label "Light2" (shape output) (at 99.06 140.97 270) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid da73302c-0766-4c38-a423-b40ee10ca9c3)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 99.06 149.0877 90)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "TX1" (shape input) (at 144.78 185.42 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid db7f2634-f079-43b3-9e9a-c844afd6daf2)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 150.4182 185.42 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Light0" (shape output) (at 274.32 137.16 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid df1c8572-f48c-4cbc-9947-6c34ee68e9d4)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 282.4377 137.16 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "COPI" (shape input) (at 190.5 91.44 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid e77a5962-251a-459a-91c1-bd23d55f8fd9)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 197.2269 91.44 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Switch_Mute" (shape bidirectional) (at 269.24 121.92 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid ea505d25-6ffd-4549-b3ad-fa99a75d2d97)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 283.9345 121.92 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "SDA" (shape bidirectional) (at 177.8 101.6 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid f1e0b9a0-1477-44af-a5e4-5d3afa1503ee)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 184.5722 101.6 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "Light0" (shape output) (at 105.41 140.97 270) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify right))
-    (uuid f8adaa0c-20e7-4763-acc5-27dfade791df)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 105.41 149.0877 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-
-  (symbol (lib_id "Device:D_Schottky") (at 53.34 27.94 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b4a83f)
-    (property "Reference" "D101" (at 53.34 25.4 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "Schottky 2A" (at 55.88 31.75 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:D_SMB_POLARITY" (at 53.34 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 53.34 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 53.34 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14996" (at 53.34 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "SS210" (at 53.34 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "MDD（Microdiode Electronics）" (at 53.34 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 53.34 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0343" (at 53.34 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "100V 850mV@2A 2A SMA(DO-214AC) Schottky Diodes ROHS" (at 53.34 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 53.34 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 53.34 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0f0e9217-f9db-40ba-8ef4-3f2faf8ba31e))
-    (pin "2" (uuid 33e7f40a-6bd6-4659-8f7c-1c0edb709159))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "D101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 36.83 39.37 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b4bd4b)
-    (property "Reference" "C101" (at 39.751 38.2016 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "39pF" (at 39.751 40.513 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 37.7952 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 36.83 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 36.83 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 36.83 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C107049" (at 36.83 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603JRNPO9BN390" (at 36.83 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 36.83 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.003" (at 36.83 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 39pF NP0 ±5% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 36.83 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 36.83 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 36.83 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d2fc921f-d8a1-4b9a-9be2-414911d5a1f2))
-    (pin "2" (uuid cb43aa9c-e1e2-428b-af4c-b56480f88e05))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C_Polarized") (at 55.88 36.83 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5acad)
-    (property "Reference" "C102" (at 58.8772 35.6616 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "47uF 16V" (at 58.8772 37.973 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4" (at 56.8452 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 55.88 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 55.88 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2895272" (at 55.88 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "KNSCHA" (at 55.88 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RVT47UF16V67RV0019" (at 55.88 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 55.88 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.038" (at 55.88 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS" (at 55.88 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 55.88 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 55.88 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 96e4920f-156e-4bf4-bd18-e1990a9a192a))
-    (pin "2" (uuid c3d8167c-d495-4cc3-862a-4c65ceaca228))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C_Polarized") (at 133.35 33.02 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5b741)
-    (property "Reference" "C109" (at 136.3472 31.8516 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "47uF 16V" (at 136.3472 34.163 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4" (at 134.3152 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 133.35 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 133.35 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2895272" (at 133.35 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "KNSCHA" (at 133.35 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RVT47UF16V67RV0019" (at 133.35 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 133.35 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.038" (at 133.35 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS" (at 133.35 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 133.35 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 133.35 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d23587eb-aed9-459b-a896-65e08a48a21c))
-    (pin "2" (uuid dcaa2c85-5054-4ab1-b9f8-6c10ef332b8b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C109") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 119.38 33.02 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b5d253)
-    (property "Reference" "C108" (at 122.301 31.8516 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 122.301 34.163 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 120.3452 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 119.38 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 119.38 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 119.38 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 119.38 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 119.38 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 119.38 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 119.38 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 119.38 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 119.38 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5b594103-960c-48b0-8512-a72269c0ed79))
-    (pin "2" (uuid 1bcfee51-8e7d-47c4-94ea-680539d4ce8b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C108") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+5V") (at 137.16 25.4 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b6f384)
-    (property "Reference" "#PWR0113" (at 137.16 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+5V" (at 137.541 21.0058 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 137.16 25.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 137.16 25.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b09cb8bb-37d2-42d3-bbca-5fa3891f8fb2))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0113") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:Barrel_Jack_Switch_SMT") (at 25.4 30.48 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062bbf172)
-    (property "Reference" "J101" (at 17.78 27.94 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "Barrel_Jack_Switch_SMT" (at 27.94 35.56 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:BarrelJack_CLIFF_FC681465S_SMT_Horizontal" (at 26.67 31.496 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.lcsc.com/datasheet/C319134.pdf   , https://tensility.s3.amazonaws.com/uploads/pdffiles/54-00164.pdf" (at 26.67 31.496 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 25.4 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C319134" (at 25.4 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "XKB Connectivity " (at 25.4 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "DC-005-5A-2.0-SMT" (at 25.4 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Power Barrel Connector Jack 2.10mm ID (0.083\"), 5.50mm OD (0.217\") Surface Mount, Right Angle" (at 25.4 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2" "Digikey" (at 25.4 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2 PN" "839-54-00164CT-ND" (at 25.4 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.205" (at 25.4 30.48 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "AssemblyType" "SMT" (at 25.4 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "54-00164" (at 25.4 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "Tensility International Corp" (at 25.4 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 229c2268-f7aa-4043-8f2b-e7565dcd0df5))
-    (pin "2" (uuid 82a590bd-071e-47b8-9cfa-65b3e782f1e1))
-    (pin "3" (uuid a2998a06-c7b5-4ea7-8855-e6e2c2b16112))
-    (pin "4" (uuid a0bf60d1-28fb-4db3-bd63-1cacb020bea6))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "J101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 69.85 38.1 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062bd2de4)
-    (property "Reference" "C105" (at 72.771 36.9316 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 72.771 39.243 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 70.8152 41.91 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 69.85 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 69.85 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 69.85 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 69.85 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 69.85 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 69.85 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 69.85 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 69.85 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 69.85 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 69.85 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 71befeab-219c-4b33-9202-ae3da6a4f459))
-    (pin "2" (uuid ffb17192-2476-4f56-9c03-0d5fd8f8911e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C105") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MountingHole_Pad_3.5mm") (at 217.17 147.32 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062ce9822)
-    (property "Reference" "H104" (at 219.71 146.0754 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "MountingHole_Pad_3.5mm" (at 217.17 148.59 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:MountingHole_3.5mm_Pad_Via" (at 217.17 147.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 217.17 147.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "NA" (at 217.17 147.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0" (at 217.17 147.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "MountingHole_Pad_3.5mm" (at 217.17 147.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 217.17 147.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 217.17 147.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 217.17 147.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 217.17 147.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 217.17 147.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 217.17 147.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0bb4a166-6c5e-4e20-a9bb-d297e640e277))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "H104") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MountingHole_Pad_3.5mm") (at 217.17 139.7 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062cea64d)
-    (property "Reference" "H103" (at 219.71 138.4554 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "MountingHole_Pad_3.5mm" (at 217.17 140.97 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:MountingHole_3.5mm_Pad_Via" (at 217.17 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 217.17 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "NA" (at 217.17 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0" (at 217.17 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "MountingHole_Pad_3.5mm" (at 217.17 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 217.17 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 217.17 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 217.17 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 217.17 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 217.17 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 217.17 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6c32e8f5-06f6-423c-9fac-ceecafde8819))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "H103") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MountingHole_Pad_3.5mm") (at 217.17 132.08 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062ceaa1a)
-    (property "Reference" "H102" (at 219.71 130.8354 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "MountingHole_Pad_3.5mm" (at 217.17 133.35 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:MountingHole_3.5mm_Pad_Via" (at 217.17 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 217.17 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "NA" (at 217.17 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0" (at 217.17 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "MountingHole_Pad_3.5mm" (at 217.17 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 217.17 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 217.17 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 217.17 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 217.17 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 217.17 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 217.17 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid adf671c6-4639-4878-af83-28a5550faebe))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "H102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MountingHole_Pad_3.5mm") (at 217.17 124.46 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062ceadbe)
-    (property "Reference" "H101" (at 219.71 123.2154 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "MountingHole_Pad_3.5mm" (at 217.17 125.73 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:MountingHole_3.5mm_Pad_Via" (at 217.17 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 217.17 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "NA" (at 217.17 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0" (at 217.17 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "MountingHole_Pad_3.5mm" (at 217.17 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 217.17 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 217.17 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 217.17 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 217.17 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 217.17 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 217.17 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7c2287a9-de27-4535-a4ed-d5a151b07cc6))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "H101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:22-23-2021") (at 156.21 24.13 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062d30624)
-    (property "Reference" "J102" (at 154.0002 23.1648 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "0.100_2Pin" (at 154.0002 25.4762 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical" (at 161.29 29.21 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811011511_Amphenol-ICC-68000-102HLF_C168673.pdf" (at 161.29 31.75 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "" (at 161.29 34.29 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "68000-102HLF" (at 161.29 36.83 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Connectors, Interconnects" (at 161.29 39.37 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Rectangular Connectors - Headers, Male Pins" (at 161.29 41.91 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "" (at 161.29 44.45 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "" (at 161.29 46.99 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "HEADER VERT 2POS 2.54MM" (at 161.29 49.53 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Amphenol ICC" (at 161.29 52.07 0)
-      (effects (font (size 0 0)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 161.29 54.61 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Assembly Type" "" (at 26.67 3.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 156.21 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C168673" (at 156.21 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.1458" (at 156.21 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 156.21 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 156.21 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 156.21 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1f6b0142-c2aa-44dd-b04e-11765d41538c))
-    (pin "2" (uuid bc069602-24df-4cc8-88d7-c1c1309a94b5))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "J102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 153.67 46.99 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062d74668)
-    (property "Reference" "R110" (at 152.4 41.91 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 153.67 44.45 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 153.67 45.212 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 153.67 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 153.67 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 153.67 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 153.67 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 153.67 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 153.67 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 153.67 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 153.67 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 153.67 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 153.67 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 998e46a6-8682-43ec-977c-7f4db27a6e1e))
-    (pin "2" (uuid cc0f4b34-edd9-4f5e-a8a6-4ea33b52af8d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R110") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:Polyfuse_Small") (at 43.18 27.94 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062d8df8e)
-    (property "Reference" "F101" (at 44.45 25.4 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "Polyfuse_Small_1A" (at 44.45 30.48 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Fuse:Fuse_0603_1608Metric" (at 38.1 29.21 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Datasheet" "~" (at 43.18 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Littelfuse" (at 43.18 27.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "0603L100SLYR" (at 43.18 27.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 43.18 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.2448" (at 43.18 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "6V 1A 50A -40℃~+85℃ 1.8A 40mΩ 300ms 120mΩ 0603 Resettable Fuses ROHS" (at 43.18 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 43.18 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C207017" (at 43.18 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 43.18 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 43.18 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8b2a4ac2-074b-4ce2-8a78-7ffdb383facf))
-    (pin "2" (uuid bda1ac1e-7e71-4814-b281-3ecae41b905d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "F101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:D_Schottky") (at 180.34 31.75 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062e0564a)
-    (property "Reference" "D104" (at 176.53 34.29 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "Schottky 2A" (at 175.26 36.83 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:D_SMB_POLARITY" (at 180.34 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 180.34 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14996" (at 180.34 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "SS210" (at 180.34 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "MDD（Microdiode Electronics）" (at 180.34 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 180.34 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0343" (at 180.34 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "100V 850mV@2A 2A SMA(DO-214AC) Schottky Diodes ROHS" (at 180.34 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 180.34 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 180.34 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d91d7632-b389-4bd6-a516-48722e24246d))
-    (pin "2" (uuid 412fde02-f505-4c27-ae66-dac15a30d6d6))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "D104") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:PWR_FLAG") (at 39.37 27.94 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062e136ff)
-    (property "Reference" "#FLG0101" (at 39.37 26.035 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "PWR_FLAG" (at 36.83 22.86 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 39.37 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 39.37 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f8ef2910-6c99-499f-ae5f-25daa228d114))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#FLG0101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:PWR_FLAG") (at 64.77 22.86 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062e14b5b)
-    (property "Reference" "#FLG0102" (at 64.77 20.955 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "PWR_FLAG" (at 68.58 17.78 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 64.77 22.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 64.77 22.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid befcd0a4-7037-400e-902a-2ef7425c4d24))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#FLG0102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 157.48 35.56 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062e2029a)
-    (property "Reference" "R106" (at 156.21 30.48 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 157.48 33.02 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 157.48 33.782 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 157.48 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DNI" (at 157.48 35.56 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "DNI" (at 157.48 35.56 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 157.48 35.56 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "DNI" (at 157.48 35.56 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "DNI" (at 157.48 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 157.48 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 157.48 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 157.48 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 157.48 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d8c82e7e-5ccc-4f05-88e7-5942e665ae20))
-    (pin "2" (uuid 65348679-815e-4d03-a9b9-7da3cc7474c4))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R106") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 189.23 38.1 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062e47436)
-    (property "Reference" "R107" (at 187.96 33.02 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 189.23 35.56 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 189.23 36.322 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 189.23 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DNI" (at 189.23 38.1 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "DNI" (at 189.23 38.1 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 189.23 38.1 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "DNI" (at 189.23 38.1 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "DNI" (at 189.23 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 189.23 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 189.23 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 189.23 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 189.23 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 746d59c9-9501-4157-abc1-12fa622f639b))
-    (pin "2" (uuid c66839fe-8684-4e0e-820a-bf7750aafc5c))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R107") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 262.89 45.72 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 02d99bf8-b6c4-4b56-af91-0f62d8b856dc)
-    (property "Reference" "#PWR0116" (at 262.89 52.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 262.89 50.8 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 262.89 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 262.89 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f27b3489-9063-4cba-b376-eb551d0fbe6c))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0116") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 60.96 24.13 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 03b31824-c9ec-4eb2-b379-23f077cd8439)
-    (property "Reference" "TP102" (at 53.34 17.78 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Vin" (at 53.34 20.32 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 66.04 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 66.04 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 60.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Red" (at 60.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 60.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 60.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 60.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 60.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 60.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 60.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 60.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c23b162a-fb9b-4474-8051-9ffe99fe9cd5))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 63.5 144.78 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 05933f9e-78ff-4c3e-83b5-04566a333f0c)
-    (property "Reference" "#PWR0104" (at 63.5 151.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 63.5 149.86 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 63.5 144.78 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 63.5 144.78 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid edf6daf8-818b-4bd3-b964-c0a324e8f214))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0104") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 209.55 96.52 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 05b874ab-3615-4699-a39f-952859f8a8e5)
-    (property "Reference" "TP404" (at 209.55 90.17 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "U0_RX" (at 210.82 92.71 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 214.63 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 214.63 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 209.55 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 209.55 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 209.55 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 209.55 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 209.55 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 209.55 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 209.55 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 209.55 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 209.55 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7645220d-4394-4b67-93b5-7fa3109751ef))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP404") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP108") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Regulator_Linear:AMS1117-3.3") (at 251.46 34.29 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0668f098-e577-4234-8711-82af43e1b67a)
-    (property "Reference" "U103" (at 251.46 27.94 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "AMS1117-3.3" (at 251.46 30.48 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2" (at 251.46 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "http://www.advanced-monolithic.com/pdf/ds1117.pdf" (at 254 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 251.46 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "72dB@(120Hz) 1A Fixed 3.3V Positive electrode SOT-223 Voltage Regulators - Linear, Low Drop Out (LDO) Regulators ROHS" (at 251.46 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C6186" (at 251.46 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "AMS1117-3.3" (at 251.46 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Advanced Monolithic Systems" (at 251.46 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.15" (at 251.46 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 251.46 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 251.46 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 251.46 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 371a81b3-dee8-4fea-9d5d-b6c6c46a3ffc))
-    (pin "2" (uuid 13ca2af2-93f6-4f3a-8a91-68ebb11e07e1))
-    (pin "3" (uuid 93b041b5-4c59-4dc0-b2f3-b792fec1424e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "U103") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 127 154.94 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0e172c51-95e4-4b73-b008-527e1140a069)
-    (property "Reference" "R112" (at 124.46 155.575 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 129.54 155.575 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 125.222 154.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 127 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 127 154.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 127 154.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 127 154.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 127 154.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 127 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 127 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 127 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 127 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 127 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ab733aa0-c897-4c3a-ab8f-105bdd2a9379))
-    (pin "2" (uuid a129ac10-b47e-4e91-b580-cfe72fb6fa53))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R112") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 251.46 45.72 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0f14fc8e-2c36-4840-b6d9-d3664319c54d)
-    (property "Reference" "#PWR0115" (at 251.46 52.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 251.46 50.8 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 251.46 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 251.46 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 87e844ce-68a4-4fb5-8956-dd08b92ff65a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0115") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 182.88 114.3 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0f8fe905-c6c5-4324-a449-9adb06b5a34f)
-    (property "Reference" "R304" (at 181.61 112.395 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "39R" (at 187.325 113.03 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 182.88 112.522 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 182.88 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 182.88 114.3 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C325713" (at 182.88 114.3 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 182.88 114.3 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC0603391%N" (at 182.88 114.3 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "100mW ±1% 39Ω 0603 Chip Resistor - Surface Mount ROHS" (at 182.88 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 182.88 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0027" (at 182.88 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 182.88 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 182.88 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c6ac4148-1aee-4e15-a0ce-1f35bce7b13a))
-    (pin "2" (uuid 0defed48-ba4c-4613-9f6e-8c36f22bae49))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R304") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R116") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+3.3V") (at 17.78 88.9 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 125bb5c2-64b0-4bec-8c00-3ee46b8587ed)
-    (property "Reference" "#PWR09" (at 17.78 92.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+3.3V" (at 17.78 83.82 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 17.78 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 17.78 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cf08f323-bd44-415f-8d20-567630d8c6c6))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR09") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 73.66 181.61 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 12a06a26-cc67-4997-b99c-46146aca26c8)
-    (property "Reference" "R1009" (at 72.39 176.53 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1R0" (at 73.66 179.07 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 73.66 179.832 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 73.66 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 73.66 181.61 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 73.66 181.61 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 73.66 181.61 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 73.66 181.61 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 73.66 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 73.66 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 73.66 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 73.66 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 73.66 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 57bd9ec0-2090-4b66-97d0-e890e280c9cd))
-    (pin "2" (uuid bd84431a-4e4c-46ff-bb08-b5a910b8c247))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R1009") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:ESP32-WROOM-32D-PINORDER") (at 135.89 109.22 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 137f564a-c1ab-4aaf-b07c-443dc9d45715)
-    (property "Reference" "U102" (at 114.3 80.01 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "ESP32-WROOM-32E-N4" (at 114.3 81.28 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:ESP32-WROOM-32D" (at 152.4 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32d_esp32-wroom-32u_datasheet_en.pdf" (at 128.27 107.95 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "3.42" (at 135.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 135.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C701341" (at 135.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "ESP32-WROOM-32E-N4" (at 135.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Espressif Systems" (at 135.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "SMD,18x25.5mm WiFi Modules ROHS" (at 135.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 135.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 135.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 135.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1039851d-ece4-4841-9798-a1bbb926fa80))
-    (pin "10" (uuid 3c21ada1-88fe-4641-9f06-5daff57353b9))
-    (pin "11" (uuid 8e3b56eb-f9fa-40c2-bc2f-04c34955e4c2))
-    (pin "12" (uuid b5e6624d-68dc-479b-b6a8-167ad75a612a))
-    (pin "13" (uuid 161d5961-dfaf-4fe3-871f-34fa27e9f4de))
-    (pin "14" (uuid befef87e-fb9d-4462-8157-b0e1823ae264))
-    (pin "15" (uuid 8d94697a-7d41-485e-a6f1-079a1ee37e41))
-    (pin "16" (uuid edc07a6b-6c70-44bf-b30f-89cfc0180f30))
-    (pin "17" (uuid b3b968d1-d5e2-44b9-a3ee-ec67f13b23b3))
-    (pin "18" (uuid 22d83693-db63-49cb-937f-afda87ccd8da))
-    (pin "19" (uuid 951ff812-3dc5-42be-9253-99e4c4366937))
-    (pin "2" (uuid 9c9372a6-4977-4022-979e-4360a0cf7490))
-    (pin "20" (uuid 5866623c-245b-4fcd-8861-50fef0747777))
-    (pin "21" (uuid a64cd5c7-4b16-4ee4-962c-c16f9101e8c1))
-    (pin "22" (uuid 416e6d3f-95a9-44e6-8372-c9dbffde81c1))
-    (pin "23" (uuid d2dc7485-1b1d-4550-9b53-9fc24728e1a8))
-    (pin "24" (uuid 14a60c64-2ac1-4040-a6e2-20c6205d8bd7))
-    (pin "25" (uuid 4270eb97-1629-44a7-88e5-d5058c3746cc))
-    (pin "26" (uuid e68d19b3-e921-4114-823c-637b9278e8c1))
-    (pin "27" (uuid c8da9217-381b-40b2-bc52-2293d9212ca7))
-    (pin "28" (uuid 4af5e87b-4861-4b50-933d-b61b223d0938))
-    (pin "29" (uuid a531d93d-36b1-4ecc-a1a4-fbe5d6f0849b))
-    (pin "3" (uuid 6a0544ea-01f1-4ef6-85f5-51450c6a54a5))
-    (pin "30" (uuid 07d27aa8-c9b5-4dd4-a4ff-0e5be3081c03))
-    (pin "31" (uuid 06bc3cd9-5124-4271-9247-4ff7c63e62de))
-    (pin "32" (uuid 00d4181f-3739-4e2f-b315-0e1fb5c2b4ca))
-    (pin "33" (uuid 8e02ef48-4c00-414b-8cae-f1a9b4d80919))
-    (pin "34" (uuid d87df385-3c52-4942-a125-2cc2d9483179))
-    (pin "35" (uuid 5dbb7c21-fe34-4569-ba55-1e9cfa49c3c0))
-    (pin "36" (uuid c76f72f4-0cef-4c1d-9a3e-b45d1b896c19))
-    (pin "37" (uuid 4a124e09-5bc2-49f8-a8c2-107e35b2fbc3))
-    (pin "38" (uuid e92ed94c-7fb2-4f55-a694-a0fb3bee022a))
-    (pin "39" (uuid ef7216d3-4fd6-4fb4-8ac7-c20301b37fa5))
-    (pin "4" (uuid 832542a5-4677-416a-a612-955de33b6709))
-    (pin "5" (uuid 52057ec7-b3b2-4fa9-9f52-4f4920b6cdeb))
-    (pin "6" (uuid 0ae7a78d-1275-43c9-a58b-50f622040e43))
-    (pin "7" (uuid 3c041688-92a0-49c6-80a9-05fe69b210f8))
-    (pin "8" (uuid 471e87c7-23e6-4283-8ad0-7ac3b4efeecb))
-    (pin "9" (uuid 7f92bc99-6599-4b4e-9081-3a8d97772ba2))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "U102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 185.42 91.44 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 1572af9d-ac0f-4e2c-b81d-da9ba8e38938)
-    (property "Reference" "R304" (at 183.515 89.535 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "39R" (at 189.865 90.17 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 185.42 89.662 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 185.42 91.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 185.42 91.44 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C325713" (at 185.42 91.44 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 185.42 91.44 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC0603391%N" (at 185.42 91.44 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "100mW ±1% 39Ω 0603 Chip Resistor - Surface Mount ROHS" (at 185.42 91.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 185.42 91.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0027" (at 185.42 91.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 185.42 91.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 185.42 91.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 94e37146-b9f1-4203-9ef4-e4f0c7015c1d))
-    (pin "2" (uuid c63ff8eb-18a8-486d-84e6-571290035277))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R304") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R113") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 38.1 66.04 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 15a449fb-5566-4fb3-b957-f28bd7459cdc)
-    (property "Reference" "#PWR0129" (at 38.1 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 38.1 71.12 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 38.1 66.04 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 38.1 66.04 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 53a97304-f46a-4c08-993f-18700c0ecb2d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0129") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:D_Schottky") (at 92.71 63.5 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 168ceaa1-180b-4b94-b2b0-2b2776f0d037)
-    (property "Reference" "D103" (at 92.71 57.9882 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "Schottky 2A" (at 92.71 60.2996 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:D_SMB_POLARITY" (at 92.71 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 92.71 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 92.71 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14996" (at 92.71 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "SS210" (at 92.71 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "MDD（Microdiode Electronics）" (at 92.71 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 92.71 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0343" (at 92.71 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "100V 850mV@2A 2A SMA(DO-214AC) Schottky Diodes ROHS" (at 92.71 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 92.71 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 92.71 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fe2a2e0e-39de-47d1-b6f3-ffb758f42bf0))
-    (pin "2" (uuid 20fb4fa8-d664-4249-8479-4d4c1f35f23c))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "D103") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 234.95 45.72 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 16e9960e-753d-48be-9df4-256b47766d81)
-    (property "Reference" "#PWR0112" (at 234.95 52.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 234.95 50.8 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 234.95 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 234.95 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20b163c0-a727-4257-b600-8977445bc206))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0112") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:PWR_FLAG") (at 238.76 27.94 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 183463d1-c33a-4a24-bbaf-f9d956990224)
-    (property "Reference" "#FLG0104" (at 238.76 26.035 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "PWR_FLAG" (at 241.935 24.765 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 238.76 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 238.76 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 28700eea-a725-49e8-9531-2ee7065b9ae2))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#FLG0104") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector_Generic:Conn_01x14") (at 106.68 104.14 0) (mirror y) (unit 1)
-    (in_bom no) (on_board yes) (dnp yes)
-    (uuid 19998d8d-ff7e-4974-8b3e-35aeab9399ae)
-    (property "Reference" "J104" (at 109.855 83.82 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Conn_01x14 1mm" (at 112.395 85.725 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Connector_PinSocket_1.00mm:PinSocket_1x14_P1.00mm_Vertical" (at 106.68 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 106.68 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 106.68 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2881659" (at 106.68 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "X1311WV-10J-C18D27" (at 106.68 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "XKB Connection" (at 106.68 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 106.68 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.25" (at 106.68 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Gold 250V 1A Policy 1mm 14P 260℃ -40℃~+105℃ 1.27mm Single Row Black Brass 1x14P 1.27mm Plugin,P=1.27mm Pin Headers ROHS" (at 106.68 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 106.68 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 106.68 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cdc7925-6fc3-4466-932a-c3ca0b8b3f4a))
-    (pin "10" (uuid d0b93e49-6580-4a14-9cf7-9fa0e6b5387c))
-    (pin "11" (uuid 62dd146f-7c2e-4902-a145-d4b48cf59ba6))
-    (pin "12" (uuid e29955ca-6275-45d3-9fb5-3d69953ea2eb))
-    (pin "13" (uuid 46d295a1-18b0-4d6c-8f9d-5c951e7dea50))
-    (pin "14" (uuid 45223f3a-ebce-4341-bad5-59f2aabc94c5))
-    (pin "2" (uuid f9c6eb7a-d131-4ec2-838f-295e05fe2d62))
-    (pin "3" (uuid 94c65481-d676-437f-9db5-6ebb6cbd8f07))
-    (pin "4" (uuid 943c4c10-03ac-486f-b576-86fe8998a1d9))
-    (pin "5" (uuid 16b84e3a-adcc-4da6-bcd2-4cceb42bf890))
-    (pin "6" (uuid e46e0355-6d6f-417c-8d47-c00502ed25fa))
-    (pin "7" (uuid 82ec21bf-74bd-4cb8-b375-23bacbd0b2c3))
-    (pin "8" (uuid f134d536-e7d0-4d04-b44c-2236b254295e))
-    (pin "9" (uuid 733e788d-9493-4ac1-a017-5b9d3c661674))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "J104") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 46.99 132.08 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1b39393c-8bbd-4590-ab4f-0be891153637)
-    (property "Reference" "#PWR0105" (at 46.99 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 46.99 137.16 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 46.99 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 46.99 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6850522c-3cbb-4bed-b33f-f57810e0371c))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0105") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 205.74 152.4 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 24843ded-cb99-4ffd-aa9a-ade99421a212)
-    (property "Reference" "TP106" (at 196.85 149.86 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "TP_GND" (at 198.12 152.4 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 210.82 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://lcsc.com/datasheet/lcsc_datasheet_2504101957_ronghe-RH-5116_C5199806.pdf" (at 210.82 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 205.74 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Green" (at 205.74 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 205.74 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199806" (at 205.74 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5116" (at 205.74 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 205.74 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.4" (at 205.74 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 205.74 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 205.74 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 73de3f8d-5385-4d12-a6a5-b9721b0a9a00))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP106") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:SWITCH_TACTILE_SPST-NO_0.05A_24V") (at 50.8 63.5 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 266d135f-2a5e-48fa-8409-76ce7a9511a7)
-    (property "Reference" "S101" (at 50.8 58.42 0)
-      (effects (font (size 1.524 1.524)))
-    )
-    (property "Value" "SWITCH_TACTILE_SPST-NO_0.05A_24V" (at 62.23 67.945 0)
-      (effects (font (size 1.524 1.524)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:Switch_Tactile_THT_6x6mm" (at 45.72 58.42 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.te.com/commerce/DocumentDelivery/DDEController?Action=srchrtrv&DocNm=1825910&DocType=Customer+Drawing&DocLang=English" (at 45.72 55.88 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 50.8 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C592731" (at 50.8 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2" "Digikey" (at 50.8 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2 PN" "450-1804-ND" (at 45.72 53.34 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "TE Connectivity ALCOSWITCH Switches" (at 45.72 35.56 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "TE Connectivity 1825910-7" (at 45.72 50.8 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Switches" (at 45.72 48.26 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Tactile Switches" (at 45.72 45.72 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "https://www.te.com/commerce/DocumentDelivery/DDEController?Action=srchrtrv&DocNm=1825910&DocType=Customer+Drawing&DocLang=English" (at 45.72 43.18 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/te-connectivity-alcoswitch-switches/1825910-7/450-1804-ND/1731414" (at 45.72 40.64 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" " Red Round Button SPST Through Hole Without Bracket Plugin-4P,6x6mm Tactile Switches ROHS" (at 45.72 38.1 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 45.72 33.02 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Assembly Type" "" (at 190.5 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 50.8 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0315" (at 50.8 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 50.8 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "YE" (at 50.8 63.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e05ad340-ea4c-4c78-a585-89858fb11aba))
-    (pin "2" (uuid 05130eb2-5047-4560-964c-1cb844f79165))
-    (pin "3" (uuid c23e6353-c9f2-4a2b-b17b-43651c7e5f76))
-    (pin "4" (uuid 8a48fd55-89e8-40f6-a8c2-fe94ce0d201f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "S101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+5V") (at 66.04 181.61 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 2cb0c264-c7da-4408-beeb-80c784af4a4e)
-    (property "Reference" "#PWR029" (at 66.04 185.42 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+5V" (at 66.421 177.2158 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 66.04 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 66.04 181.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cff28e41-befe-4d51-9f2d-9088816c050e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR029") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:RotaryEncoder_Switch_MP") (at 63.5 137.16 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2d22c134-87c7-42ed-88e6-9d6c1476c55d)
-    (property "Reference" "SW101" (at 63.5 127 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "RotaryEncoder_Switch" (at 63.5 129.54 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:RotaryEncoder_Alps_EC12E-Switch_Vertical_H20mm_MP1_MP2" (at 59.69 133.096 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 63.5 130.556 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 63.5 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C202365" (at 63.5 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "EC11E18244AU" (at 63.5 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ALPSALPINE" (at 63.5 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Plugin Rotary Encoders ROHS" (at 63.5 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 63.5 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "1.9830" (at 63.5 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 63.5 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 63.5 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "A" (uuid 0a0f863f-6598-4e05-9a1e-64899af37642))
-    (pin "B" (uuid 8de56ed2-23a6-4b75-94c0-10f0d6b88127))
-    (pin "C" (uuid d7b8e011-aac4-46e4-b6a8-884fa4076909))
-    (pin "MP1" (uuid 362f55b0-e508-426d-bfff-79d350dea30c))
-    (pin "MP2" (uuid 4b993437-c2b8-4b49-b861-2493f7a423e1))
-    (pin "S1" (uuid 5f3de26f-0f6f-46e3-b0d8-90c2a8d16b9b))
-    (pin "S2" (uuid 247ffd4a-874b-44d6-852c-5483b8d6835c))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "SW101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 133.35 38.1 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 37122510-85b3-46ae-bb5e-3623ec743e3e)
-    (property "Reference" "#PWR0110" (at 133.35 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 133.35 43.18 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 133.35 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 133.35 38.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e5da7dd2-1038-4a20-b25d-796721f3de4f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0110") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE") (at 171.45 46.99 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 3e876305-79cd-463a-96b4-0d620e9c8923)
-    (property "Reference" "D105" (at 168.91 40.64 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "LED_T1.75_CLEAR_RED" (at 161.29 44.45 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial" (at 176.53 41.91 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 176.53 39.37 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "160-1682-ND" (at 176.53 36.83 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "LTL2R3KEK" (at 176.53 34.29 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Optoelectronics" (at 176.53 31.75 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "LED Indication - Discrete" (at 176.53 29.21 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf" (at 176.53 26.67 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTL2R3KEK/160-1682-ND/573572" (at 176.53 24.13 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "LED RED CLEAR T-1 3/4 T/H" (at 176.53 21.59 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Lite-On Inc." (at 176.53 19.05 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 176.53 16.51 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "HAND" (at 171.45 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.36000" (at 171.45 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "DigiKey" (at 171.45 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "160-1682-ND" (at 171.45 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 171.45 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 171.45 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1f7d33e9-005f-45d9-8f7e-335d19791632))
-    (pin "2" (uuid bb070393-7525-4d50-a357-df94bc162c48))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "D105") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 36.83 45.72 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 42ecfc98-9883-445f-bd27-ef691ebff291)
-    (property "Reference" "#PWR0101" (at 36.83 52.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 36.83 50.8 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 36.83 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 36.83 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4885c7b1-abc2-4646-b0f3-b31f3adaa271))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 275.59 30.48 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 5044db84-34b3-4eab-b77f-3f308b8ca5b4)
-    (property "Reference" "TP100" (at 266.7 29.21 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "TP+3.3V" (at 266.065 27.305 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 280.67 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 280.67 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 275.59 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings ROHS red" (at 275.59 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 275.59 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 275.59 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 275.59 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 275.59 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 275.59 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 275.59 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 275.59 30.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 318e08ae-0d48-4c75-8aa1-7357c5dba08d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP100") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 69.85 82.55 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 59298252-48dd-4932-bc6c-780d9663f9aa)
-    (property "Reference" "#PWR0128" (at 69.85 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 69.85 86.36 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 69.85 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 69.85 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ca300708-3732-48d9-8901-4eacbeda780a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0128") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 220.98 34.29 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 65c82507-c4d0-41f1-9f43-d596c106d24e)
-    (property "Reference" "R1002" (at 219.71 29.21 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1R0" (at 220.98 31.75 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 220.98 32.512 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 220.98 34.29 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 220.98 34.29 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 220.98 34.29 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 220.98 34.29 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 220.98 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 220.98 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 220.98 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 220.98 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 220.98 34.29 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6cb98129-7350-4b7d-9442-da21737d5e4a))
-    (pin "2" (uuid 91e6f038-bd4e-44dd-af26-10f31e66d828))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R1002") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C_Polarized") (at 273.05 39.37 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 67c6cbdd-425c-46ac-80be-6f2fcedfd1b9)
-    (property "Reference" "C118" (at 273.05 37.465 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "47uF 16V" (at 269.875 41.91 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4" (at 274.0152 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 273.05 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 273.05 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2895272" (at 273.05 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "KNSCHA" (at 273.05 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RVT47UF16V67RV0019" (at 273.05 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 273.05 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.038" (at 273.05 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS" (at 273.05 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 273.05 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 273.05 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 83699e6d-b9f2-4c10-8f58-9040a8cf056f))
-    (pin "2" (uuid e2e32b4e-2db7-4ead-8191-254d7f18c63e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C118") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 210.82 125.73 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 6b215cc4-eab0-4d50-89f8-6b9eedf3d0f6)
-    (property "Reference" "TP104" (at 201.93 123.19 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "TP_GND" (at 203.2 125.73 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 215.9 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://lcsc.com/datasheet/lcsc_datasheet_2504101957_ronghe-RH-5116_C5199806.pdf" (at 215.9 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 210.82 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Green" (at 210.82 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 210.82 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199806" (at 210.82 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5116" (at 210.82 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 210.82 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.4" (at 210.82 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 210.82 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 210.82 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d06d5bed-92be-4a0e-b34c-c056ee0f38e8))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP104") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 26.67 44.45 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 6cc8777f-5263-40b5-b3ae-869d93312c98)
-    (property "Reference" "TP101" (at 17.78 41.91 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "TP_GND" (at 19.05 44.45 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 31.75 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://lcsc.com/datasheet/lcsc_datasheet_2504101957_ronghe-RH-5116_C5199806.pdf" (at 31.75 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 26.67 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Green" (at 26.67 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 26.67 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199806" (at 26.67 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5116" (at 26.67 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 26.67 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.4" (at 26.67 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 26.67 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 26.67 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c3416f5e-b747-417c-aab6-4bf396138338))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 33.02 80.01 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 6d3fefdf-595c-41a4-8deb-dbdb5acf7deb)
-    (property "Reference" "TP109" (at 22.86 72.39 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "3v3Controller" (at 22.86 74.93 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 38.1 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 33.02 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings ROHS red" (at 33.02 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 33.02 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 33.02 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 33.02 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 33.02 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 33.02 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 33.02 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 33.02 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8e2cb42a-ee25-4380-894a-3c0bdffc149d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP109") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 194.31 139.7 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 6ea77d10-53f4-4f4f-a3a3-61785fb66c22)
-    (property "Reference" "#PWR0121" (at 194.31 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 194.31 143.51 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 194.31 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 194.31 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid abb3624d-b48c-4fc5-9fad-d3fde2824cb8))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0121") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 121.92 27.94 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 6fcee3b3-4e61-4f69-8b79-bd71e045ce39)
-    (property "Reference" "TP103" (at 114.3 21.59 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "+5V" (at 114.3 24.13 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 127 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 127 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 121.92 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Red" (at 121.92 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 121.92 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 121.92 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 121.92 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 121.92 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 121.92 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 121.92 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 121.92 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 988bf460-6c8a-4069-86ec-87b3793250b0))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP103") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+5V") (at 214.63 29.21 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 721ad4bd-c8e1-4e96-ac7a-3aa5a78f8c72)
-    (property "Reference" "#PWR010" (at 214.63 33.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+5V" (at 215.011 24.8158 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 214.63 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 214.63 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5c278aba-f8cc-491a-bcb0-a25aaa1f9276))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR010") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 207.01 139.7 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 794165ea-19a1-448d-bfeb-ad99d7e04cf7)
-    (property "Reference" "TP105" (at 198.12 137.16 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "TP_GND" (at 199.39 139.7 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 212.09 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://lcsc.com/datasheet/lcsc_datasheet_2504101957_ronghe-RH-5116_C5199806.pdf" (at 212.09 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 207.01 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Green" (at 207.01 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 207.01 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199806" (at 207.01 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5116" (at 207.01 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 207.01 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.4" (at 207.01 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 207.01 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 207.01 139.7 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f27ee2fa-d333-4b92-958d-b40d15c83c00))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP105") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 68.58 60.96 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 798ccfae-855f-4652-a3d9-503dded1a8cf)
-    (property "Reference" "R503" (at 69.85 63.5 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 69.215 59.055 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 68.58 59.182 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 68.58 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 68.58 60.96 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 68.58 60.96 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 68.58 60.96 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 68.58 60.96 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 68.58 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 68.58 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 68.58 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 68.58 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 68.58 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 45d072c3-e244-459d-8905-2baf63553821))
-    (pin "2" (uuid 9b98c379-7822-48bf-8a9a-52da72e4ad12))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R1008") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:22-23-2021") (at 187.96 24.13 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 79fdcc27-ab28-484e-9b1b-7dd46c19f085)
-    (property "Reference" "J103" (at 185.7502 23.1648 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "0.100_2Pin" (at 185.7502 25.4762 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical" (at 193.04 29.21 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811011511_Amphenol-ICC-68000-102HLF_C168673.pdf" (at 193.04 31.75 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "" (at 193.04 34.29 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "68000-102HLF" (at 193.04 36.83 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Connectors, Interconnects" (at 193.04 39.37 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Rectangular Connectors - Headers, Male Pins" (at 193.04 41.91 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "" (at 193.04 44.45 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "" (at 193.04 46.99 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "HEADER VERT 2POS 2.54MM" (at 193.04 49.53 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Amphenol ICC" (at 193.04 52.07 0)
-      (effects (font (size 0 0)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 193.04 54.61 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Assembly Type" "" (at 58.42 3.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 187.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C168673" (at 187.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.1458" (at 187.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 187.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 187.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 187.96 24.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 93e5881a-b7c6-4f08-855a-4d2bd03c6111))
-    (pin "2" (uuid 24a182ed-8c4a-4080-8903-f5e84803d23b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "J103") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 69.85 43.18 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7fd18220-c259-4dc7-931e-dd237c1f3be2)
-    (property "Reference" "#PWR0106" (at 69.85 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 69.85 48.26 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 69.85 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 69.85 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0d66e0ea-964e-4958-bc00-29967ad4fdbb))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0106") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:SWITCH_TACTILE_SPST-NO_0.05A_24V") (at 185.42 137.16 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 7febda9f-67e6-4743-8068-bbe7a5d7f813)
-    (property "Reference" "S102" (at 185.42 131.445 0)
-      (effects (font (size 1.524 1.524)))
-    )
-    (property "Value" "SWITCH_TACTILE_SPST-NO_0.05A_24V" (at 175.26 146.05 0)
-      (effects (font (size 1.524 1.524)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:Switch_Tactile_THT_6x6mm" (at 190.5 132.08 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://jlcpcb.com/api/file/downloadByFileSystemAccessId/8588949677001068544" (at 190.5 129.54 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 185.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C592731" (at 185.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2" "Digikey" (at 185.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2 PN" "" (at 190.5 127 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "TE Connectivity ALCOSWITCH Switches" (at 190.5 109.22 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "TE Connectivity 1825910-7" (at 190.5 124.46 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Switches" (at 190.5 121.92 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Tactile Switches" (at 190.5 119.38 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "" (at 190.5 116.84 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "" (at 190.5 114.3 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" " Red Round Button SPST Through Hole Without Bracket Plugin-4P,6x6mm Tactile Switches ROHS" (at 190.5 111.76 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 190.5 106.68 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Assembly Type" "" (at 45.72 205.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 185.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0315" (at 185.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 185.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 185.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0242e060-10ab-4f20-a0d2-56a4c07056a6))
-    (pin "2" (uuid 64c8221a-1c97-4fc7-860e-68fc8972a8d0))
-    (pin "3" (uuid 3fe0f8e5-0b32-483e-ae84-c365724a6ef3))
-    (pin "4" (uuid 7e2b2d8c-4c8f-4dd2-b4a4-1624e69cb37f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "S102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C_Polarized") (at 234.95 39.37 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 84f3bc42-79cd-4400-a072-998a54c42d2f)
-    (property "Reference" "C115" (at 229.87 37.465 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "47uF 16V" (at 229.87 41.91 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4" (at 235.9152 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 234.95 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 234.95 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2895272" (at 234.95 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "KNSCHA" (at 234.95 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RVT47UF16V67RV0019" (at 234.95 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 234.95 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.038" (at 234.95 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS" (at 234.95 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 234.95 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 234.95 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 16ba6190-b069-40db-8fad-e35c3b2c2ef8))
-    (pin "2" (uuid 97cc104b-4603-4eac-99b7-ad536fd5d0cb))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C115") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 93.98 71.12 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 8637aaad-045f-4106-9915-db2015f5b18a)
-    (property "Reference" "R102" (at 92.71 66.04 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "10K" (at 93.98 68.58 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 93.98 69.342 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 93.98 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 93.98 71.12 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269701" (at 93.98 71.12 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 93.98 71.12 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 10K F N" (at 93.98 71.12 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS" (at 93.98 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 93.98 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 93.98 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 93.98 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 93.98 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7f41fe8b-cc3d-4609-8b97-185e1ce644d1))
-    (pin "2" (uuid ef72773c-dbf0-4e1c-a6f9-7b5d28c65f2a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 182.88 109.22 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 87bdaf45-4073-43ee-9cac-5f75127f0fe0)
-    (property "Reference" "R304" (at 180.975 107.315 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "39R" (at 187.325 107.315 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 182.88 107.442 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 182.88 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 182.88 109.22 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C325713" (at 182.88 109.22 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 182.88 109.22 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC0603391%N" (at 182.88 109.22 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "100mW ±1% 39Ω 0603 Chip Resistor - Surface Mount ROHS" (at 182.88 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 182.88 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0027" (at 182.88 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 182.88 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 182.88 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e7ddc178-7028-45e1-95b3-dff138da1ecc))
-    (pin "2" (uuid dfd14756-5cf5-4dfb-9e49-f906a9e31fd1))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R304") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R114") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+3.3V") (at 280.67 31.75 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 881339e1-741b-4511-a4fe-6adc8adbccf5)
-    (property "Reference" "#PWR06" (at 280.67 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+3.3V" (at 280.67 26.67 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 280.67 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 280.67 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 54dd7169-10e5-42c6-b354-1f0bc0de8303))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR06") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 55.88 43.18 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8b8727a9-48f3-49b9-bd0e-69c4c49ff2cb)
-    (property "Reference" "#PWR0102" (at 55.88 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 55.88 48.26 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 55.88 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 55.88 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 71a24f56-ce8c-4af2-be1a-331a3ea4824b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 121.92 146.05 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8ba5cfbb-08fa-4867-82a4-9a54ce27c25c)
-    (property "Reference" "#PWR0123" (at 121.92 152.4 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 121.92 151.13 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 121.92 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 121.92 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3af0574c-957c-4012-b560-8e74b3abc355))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0123") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 68.58 95.25 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 8f12a267-68e5-4722-bab1-19d5ad973cfe)
-    (property "Reference" "R1005" (at 71.755 93.98 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "10K" (at 71.12 91.44 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 70.358 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 68.58 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 68.58 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269701" (at 68.58 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 68.58 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 10K F N" (at 68.58 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS" (at 68.58 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 68.58 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 68.58 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 68.58 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 68.58 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 903f504c-d4ed-443a-8680-0b51f6db1b05))
-    (pin "2" (uuid 2097108e-65c1-4773-b69c-dd269a4e8022))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R1005") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:PWR_FLAG") (at 26.67 49.53 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 90cd1e96-678c-4489-98a1-275de43edbac)
-    (property "Reference" "#FLG0103" (at 26.67 47.625 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "PWR_FLAG" (at 21.59 49.53 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 26.67 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 26.67 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9e3ad0fe-1da0-4046-b39f-bd60505283ca))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#FLG0103") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 273.05 45.72 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 90fca9c5-6a96-4dc1-b8f3-eac4656434f8)
-    (property "Reference" "#PWR0117" (at 273.05 52.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 273.05 50.8 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 273.05 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 273.05 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3be56ae8-44b5-427f-a2e7-fa1b5416d040))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0117") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:ToolingHole_Pad_1.152mm") (at 212.09 109.22 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 916b5fe5-ce69-4f85-a56e-fce0e7ca1b42)
-    (property "Reference" "T102" (at 214.63 107.95 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "ToolingHole_Pad_1.152mm" (at 214.63 110.49 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:JLC_ToolingHole_0576mm" (at 212.09 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 212.09 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "ToolingHole_Pad_1.152mm" (at 212.09 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 212.09 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "NA" (at 212.09 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0" (at 212.09 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 212.09 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 212.09 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 212.09 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 212.09 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 212.09 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "T102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff") (at 165.1 62.23 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 9df02aba-ac24-40d4-aded-7ee5c2a5a8e2)
-    (property "Reference" "MF103" (at 162.56 66.04 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff" (at 148.59 66.675 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff" (at 165.1 62.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 165.1 62.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 165.1 62.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 165.1 62.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "NA" (at 165.1 62.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 165.1 62.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 165.1 62.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 165.1 62.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 165.1 62.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 165.1 62.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "MF103") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+3.3V") (at 271.78 80.01 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a1fb9b24-7df1-484c-8e2c-64a6c4a210bb)
-    (property "Reference" "#PWR017" (at 271.78 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+3.3V" (at 271.78 74.93 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 271.78 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 271.78 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 49b3ab0e-5f1f-486b-8066-e5c0186e3a44))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR017") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 236.22 29.21 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid a5aa7d82-6141-43c3-9469-ed3067c0414a)
-    (property "Reference" "+5esp32" (at 227.33 27.94 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "+5esp32" (at 226.695 26.035 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 241.3 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 241.3 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 236.22 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings ROHS red" (at 236.22 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 236.22 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 236.22 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 236.22 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 236.22 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 236.22 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 236.22 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 236.22 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7c8f11ee-2f40-4bae-8960-59024009b31e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "+5esp32") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C_Polarized") (at 35.56 97.79 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid a9fba72b-f340-4379-9620-616229b6e10d)
-    (property "Reference" "C106" (at 38.5572 96.6216 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "47uF 16V" (at 38.5572 98.933 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4" (at 36.5252 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 35.56 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 35.56 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2895272" (at 35.56 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "KNSCHA" (at 35.56 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RVT47UF16V67RV0019" (at 35.56 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 35.56 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.038" (at 35.56 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS" (at 35.56 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 35.56 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 35.56 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 43ee1e55-2afd-4659-8478-10481b5147d2))
-    (pin "2" (uuid 84eddc2b-3bc3-4534-aab9-aa8516e0bae8))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C106") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 210.82 153.67 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid ab5792bd-6812-40c8-ba40-69beaa4aa88f)
-    (property "Reference" "#PWR0119" (at 210.82 160.02 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 210.82 157.48 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 210.82 153.67 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 210.82 153.67 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ca9c30fe-8525-4d6b-b90d-218f4ac22e62))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0119") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:ToolingHole_Pad_1.152mm") (at 212.09 114.3 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ad481afe-48ab-4371-bd6e-3b67d2bf0a7e)
-    (property "Reference" "T103" (at 214.63 113.03 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "ToolingHole_Pad_1.152mm" (at 214.63 115.57 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:JLC_ToolingHole_0576mm" (at 212.09 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 212.09 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "ToolingHole_Pad_1.152mm" (at 212.09 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 212.09 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "NA" (at 212.09 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0" (at 212.09 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 212.09 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 212.09 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 212.09 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 212.09 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 212.09 114.3 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "T103") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:IEC_power_polarity_symbols_barrel_jack_Center_positive") (at 26.67 20.32 0) (unit 1)
-    (in_bom no) (on_board yes) (dnp no)
-    (uuid af02160a-1dc0-422b-9983-7515b0051d56)
-    (property "Reference" "SYM102" (at 19.05 22.86 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "IEC_power_polarity_symbols_barrel_jack_Center_positive" (at 26.5176 27.6352 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:Symbol_Barrel_Polarity_Center_Positive" (at 26.2382 25.6794 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 26.67 22.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Enable" "0" (at 26.67 22.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "NA" (at 26.67 20.32 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "SYM102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 54.61 95.25 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid b226c008-308e-4e0f-adf3-ed92220a4232)
-    (property "Reference" "R1003" (at 57.15 93.98 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "10K" (at 56.515 91.44 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 56.388 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 54.61 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 54.61 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269701" (at 54.61 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 54.61 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 10K F N" (at 54.61 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS" (at 54.61 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 54.61 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 54.61 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 54.61 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 54.61 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e2122e37-ab96-43c7-b9cb-d816b9f7d2b5))
-    (pin "2" (uuid 428a1554-ab24-400d-b3e9-964c5507ca3d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R1003") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 21.59 97.79 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid b6564852-fea1-427d-ad1e-f734f17f42f1)
-    (property "Reference" "C103" (at 24.511 96.6216 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 24.511 98.933 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 22.5552 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 21.59 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 21.59 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 21.59 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 21.59 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 21.59 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 21.59 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 21.59 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 21.59 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 21.59 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 21.59 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f308ff70-34f2-416a-8a92-f8d682669e23))
-    (pin "2" (uuid 14d47031-7e05-4c86-8382-1775cd7f51f5))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C103") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 173.99 111.76 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid b838f180-0fde-4563-8eeb-8c4d68e0df09)
-    (property "Reference" "R304" (at 172.085 109.855 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "39R" (at 178.435 111.125 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 173.99 109.982 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 173.99 111.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 173.99 111.76 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C325713" (at 173.99 111.76 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 173.99 111.76 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC0603391%N" (at 173.99 111.76 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "100mW ±1% 39Ω 0603 Chip Resistor - Surface Mount ROHS" (at 173.99 111.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 173.99 111.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0027" (at 173.99 111.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 173.99 111.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 173.99 111.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 86e1a56a-df97-47b0-8471-a5c35747626a))
-    (pin "2" (uuid ec73be01-c7a7-42ac-93ce-2b3d88353e15))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R304") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R115") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 77.47 78.74 0) (unit 1)
-    (in_bom no) (on_board yes) (dnp yes)
-    (uuid b8bbdaed-02a0-4430-b962-e7f00239ddab)
-    (property "Reference" "C1100" (at 80.391 77.5716 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 80.391 79.883 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 78.4352 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 77.47 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 77.47 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 77.47 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 77.47 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 77.47 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 77.47 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 77.47 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 77.47 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 77.47 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 77.47 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d712931f-8b1b-48d1-8f96-2e06b15672df))
-    (pin "2" (uuid 0889e78c-0874-4e17-9a0e-aba1160b8718))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C1100") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 60.96 95.25 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid b96c4198-a7e7-4e44-b939-3719ceb9f4a2)
-    (property "Reference" "R1004" (at 63.5 93.98 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "10K" (at 62.865 91.44 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 62.738 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 60.96 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 60.96 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269701" (at 60.96 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 60.96 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 10K F N" (at 60.96 95.25 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS" (at 60.96 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 60.96 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 60.96 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 60.96 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 60.96 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fcd2dcc5-5dd0-454d-b0cf-b7838a5558d5))
-    (pin "2" (uuid 34daedc0-1a27-4c9a-8133-45fba1d0efa6))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R1004") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 21.59 104.14 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bd84f948-5f60-4956-8f01-e84c2b79c164)
-    (property "Reference" "#PWR0127" (at 21.59 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 21.59 109.22 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 21.59 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 21.59 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 585d2ee0-1543-48cf-a486-ca998d47642d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0127") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:ToolingHole_Pad_1.152mm") (at 212.09 104.14 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bead3382-a521-450d-879d-3affa501f4fd)
-    (property "Reference" "T101" (at 214.63 102.87 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "ToolingHole_Pad_1.152mm" (at 214.63 105.41 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:JLC_ToolingHole_0576mm" (at 212.09 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 212.09 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "ToolingHole_Pad_1.152mm" (at 212.09 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "NA" (at 212.09 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "NA" (at 212.09 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0" (at 212.09 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 212.09 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 212.09 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "NA" (at 212.09 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "NA" (at 212.09 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "NA" (at 212.09 104.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "T101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 173.99 87.63 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid c033703d-d785-43dd-aa45-0442680789d6)
-    (property "Reference" "#PWR0120" (at 173.99 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 173.99 86.36 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 173.99 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 173.99 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c6b58b49-c34e-4012-984d-d72f2fd09370))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0120") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Regulator_Linear:LM7805_TO220") (at 78.74 27.94 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c7a20d25-3819-4e4f-aecf-c5b601fc3576)
-    (property "Reference" "U101" (at 78.74 20.32 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "LM7805_TO220" (at 78.74 22.86 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Package_TO_SOT_THT:TO-220-3_Horizontal_TabDown" (at 78.74 22.225 0)
-      (effects (font (size 1.27 1.27) italic) hide)
-    )
-    (property "Datasheet" "https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF" (at 78.74 29.21 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Assembly Type" "" (at 78.74 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.1164" (at 78.74 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "LM7805 TO220" (at 78.74 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 78.74 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2977083" (at 78.74 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "HANSCHIP semiconductor" (at 78.74 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "LM7805CTG" (at 78.74 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 78.74 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 78.74 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 78.74 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bfeccbd2-9c90-4f86-b1e9-82552dc56bd3))
-    (pin "2" (uuid eeecfda6-2658-4a64-8909-133952a74778))
-    (pin "3" (uuid 51051325-ef38-4c06-8825-ecee5582bd84))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "U101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 180.34 46.99 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid ca204aee-451a-4a77-88f7-42413d68c35a)
-    (property "Reference" "#PWR0111" (at 180.34 53.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 180.34 50.8 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 180.34 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 180.34 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid aabe9b39-1a2d-4f4c-bbba-e87ae123cdd1))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0111") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+3.3V") (at 71.12 189.23 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid cc264b60-a673-44ec-aad1-2559d7122d98)
-    (property "Reference" "#PWR033" (at 71.12 193.04 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+3.3V" (at 71.12 184.15 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 71.12 189.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 71.12 189.23 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 897f175e-4de2-449d-804e-58d7fe103cbe))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR033") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector_Generic:Conn_01x14") (at 166.37 106.68 0) (mirror x) (unit 1)
-    (in_bom no) (on_board yes) (dnp yes)
-    (uuid ccc5c21d-bbdb-4218-9911-1637c2405155)
-    (property "Reference" "J106" (at 162.56 124.46 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "Conn_01x14 1mm" (at 158.75 125.73 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Connector_PinSocket_1.00mm:PinSocket_1x14_P1.00mm_Vertical" (at 166.37 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 166.37 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 166.37 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2881659" (at 166.37 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "X1311WV-14J-C18D27" (at 166.37 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "XKB Connection" (at 166.37 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 166.37 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.25" (at 166.37 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Gold 250V 1A Policy 1mm 14P 260℃ -40℃~+105℃ 1.27mm Single Row Black Brass 1x14P 1.27mm Plugin,P=1.27mm Pin Headers ROHS" (at 166.37 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 166.37 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 166.37 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8af64f5f-3e86-492a-91a0-6dc5a0c75a52))
-    (pin "10" (uuid fc9b606d-0d2d-4f8e-841b-3b9a996023e4))
-    (pin "11" (uuid ce23c009-6bbf-4dd9-bc9e-64824fb82f9e))
-    (pin "12" (uuid 811e8506-8cfc-4842-994c-1d5adaeec7cd))
-    (pin "13" (uuid 549dd483-eaa5-45ad-8b65-509db6c301e3))
-    (pin "14" (uuid 0b319388-48de-42e3-b0a4-1b6d31d2dba8))
-    (pin "2" (uuid afa0ee6d-d7c5-4458-afe1-f1fc3d974ffb))
-    (pin "3" (uuid 64f898c7-e393-4ec2-99ce-a0bdd2df01f7))
-    (pin "4" (uuid 71fdabfa-a4b1-4816-83bf-0446276c28da))
-    (pin "5" (uuid 69873f2d-6061-4740-bbf6-bab10410adc7))
-    (pin "6" (uuid 9acde1de-c9c3-416d-ad98-9aaaefa4a26b))
-    (pin "7" (uuid c6cf6f58-3791-4394-9631-d48bd8e46312))
-    (pin "8" (uuid 59460493-f40d-4150-81a8-76f370f25c13))
-    (pin "9" (uuid 64e9670c-38ad-454c-9283-fbeafb41d8a4))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "J106") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 262.89 39.37 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid d42e8152-7a45-41ea-8903-ae569f4506e9)
-    (property "Reference" "C117" (at 263.525 37.465 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 262.89 41.91 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 263.8552 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 262.89 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 262.89 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 262.89 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 262.89 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 262.89 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 262.89 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 262.89 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 262.89 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 262.89 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 262.89 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ff4aa2e0-bcf4-417b-9a2f-093ade36954c))
-    (pin "2" (uuid c7548490-9f21-4b66-9055-25a2a710411c))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C117") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 119.38 39.37 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d43620d5-e7be-4acf-a7a5-13079883af4f)
-    (property "Reference" "#PWR0109" (at 119.38 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 119.38 44.45 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 119.38 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 119.38 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c2e22335-53b1-4b82-b65f-beb7c19577b5))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0109") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 73.66 142.24 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d9522071-9319-4f52-94dc-cca5183c1348)
-    (property "Reference" "#PWR0124" (at 73.66 148.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 73.66 147.32 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 73.66 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 73.66 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4c1f235a-096e-4bf2-b3c3-734e13d78e97))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0124") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 242.57 45.72 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid da1cc4f2-6e38-4a10-aaa9-6ef271f808a9)
-    (property "Reference" "#PWR0114" (at 242.57 52.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 242.57 50.8 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 242.57 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 242.57 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0574681c-bc62-4c8a-a7e6-2c82b4099b13))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0114") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:LED") (at 119.38 162.56 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid da9cd113-25ad-4795-8944-9694c65af45b)
-    (property "Reference" "D106" (at 114.3 162.56 90)
-      (effects (font (size 1.524 1.524)))
-    )
-    (property "Value" "RED 0603" (at 110.49 165.1 90)
-      (effects (font (size 1.524 1.524)))
-    )
-    (property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder" (at 119.38 162.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://jlcpcb.com/api/file/downloadByFileSystemAccessId/8550723991833485312" (at 119.38 162.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 119.38 162.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2286" (at 129.54 157.48 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "KT-0603R" (at 132.08 157.48 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Optoelectronics" (at 134.62 157.48 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "LED Indication - Discrete" (at 137.16 157.48 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "LED RED CLEAR SMD" (at 144.78 157.48 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Hubei KENTO Elec" (at 147.32 157.48 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 149.86 157.48 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "" (at 3.81 297.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "DK_Detail_Page" "" (at 3.81 297.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Digi-Key_PN" "" (at 3.81 297.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 119.38 162.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0054" (at 119.38 162.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 119.38 162.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 119.38 162.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid baac8584-f085-4add-8a97-70caeea4d917))
-    (pin "2" (uuid 0a1c02fc-5b29-4f5a-83ca-6c9d9d856055))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "D106") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 139.7 166.37 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid dbedd4ab-021a-4bf2-911b-113b12696aeb)
-    (property "Reference" "#PWR0122" (at 139.7 172.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 139.7 170.18 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 139.7 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 139.7 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a7a5fe0b-9b5d-42d4-96b8-ac040a9d9de1))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0122") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:PWR_FLAG") (at 36.83 87.63 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid dd0f2474-74e7-42d0-9048-8f277070039f)
-    (property "Reference" "#FLG01" (at 36.83 85.725 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "PWR_FLAG" (at 39.37 83.82 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 36.83 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 36.83 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 23d19e7e-1ada-4433-9737-6629603b92c9))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#FLG01") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 78.74 40.64 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid dd53f014-c116-430a-ba29-b9e594d30d52)
-    (property "Reference" "#PWR0107" (at 78.74 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 78.74 45.72 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 78.74 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 78.74 40.64 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e82e1450-1873-4341-8da7-cb844319dcd1))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0107") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 93.98 88.9 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid dfc5c5f9-8104-4bdf-b9ea-bc0de02c7466)
-    (property "Reference" "#PWR0118" (at 87.63 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 90.17 88.9 90)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Footprint" "" (at 93.98 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 93.98 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 773373fe-ea03-412a-a746-8c2a232cbd6b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0118") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Graphic:Logo_Open_Hardware_Small") (at 266.7 173.99 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e3c9b7d8-fadd-427c-88e4-717973e7bc41)
-    (property "Reference" "SYM101" (at 266.7 167.005 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "Logo_Open_Hardware_Small" (at 266.7 179.705 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Symbol:OSHW-Logo2_7.3x6mm_SilkScreen" (at 266.7 173.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 266.7 173.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "NA" (at 266.7 173.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "SYM101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+3.3V") (at 243.84 123.19 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid e4549564-5f3e-4be1-a322-c2a5a8e1cc6a)
-    (property "Reference" "#PWR0103" (at 243.84 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+3.3V" (at 243.84 118.11 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 243.84 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 243.84 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1453901b-452e-4cec-8545-173b022e8d95))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0103") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+3.3V") (at 52.07 180.34 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e65cc6c9-6b99-44bd-a037-206336e75b4e)
-    (property "Reference" "#PWR025" (at 52.07 184.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+3.3V" (at 52.07 175.26 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 52.07 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 52.07 180.34 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6137dbb5-e484-4cb4-8ee3-fe46bd52b4fb))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR025") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 242.57 39.37 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid e7f390f1-4d6d-44f9-84de-4b6e89995fa9)
-    (property "Reference" "C116" (at 238.76 37.465 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 238.125 41.91 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 243.5352 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 242.57 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 242.57 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 242.57 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 242.57 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 242.57 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 242.57 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 242.57 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 242.57 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 242.57 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 242.57 39.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4805a021-81e2-4005-973f-3e80e3166329))
-    (pin "2" (uuid ab7ebe8a-9d3e-454b-8ef7-a169e298b83a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C116") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 35.56 102.87 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f24af445-7dd2-4117-a01a-88edb3e2d25c)
-    (property "Reference" "#PWR0126" (at 35.56 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 35.56 107.95 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 35.56 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 35.56 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c18098ca-a1e3-4e59-9a63-7033c46c9f8c))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0126") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 29.21 88.9 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid f34148cc-2b6e-4056-bea3-b7baeb7c0cd2)
-    (property "Reference" "R101" (at 27.94 83.82 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1R0" (at 29.21 86.36 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 29.21 87.122 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 29.21 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 29.21 88.9 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 29.21 88.9 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 29.21 88.9 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 29.21 88.9 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 29.21 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 29.21 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 29.21 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 29.21 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 29.21 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8c7ad06e-33a0-4187-917f-f9d41d9f9dac))
-    (pin "2" (uuid 6a61dc60-afba-4a98-8262-46b7773eb64d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector_Generic:Conn_01x10") (at 134.62 143.51 90) (mirror x) (unit 1)
-    (in_bom no) (on_board yes) (dnp yes)
-    (uuid f4976296-dca4-4db7-9215-2f391dd01491)
-    (property "Reference" "J107" (at 121.285 136.525 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "Conn_01x10 1mm" (at 117.475 138.43 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Connector_PinSocket_1.00mm:PinSocket_1x10_P1.00mm_Vertical" (at 134.62 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 134.62 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 134.62 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2881655" (at 134.62 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "X1311WV-10J-C18D27" (at 134.62 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "XKB Connection" (at 134.62 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 134.62 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.19" (at 134.62 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Gold 250V 1A Policy 1mm 10P 260℃ -40℃~+105℃ 1.27mm Single Row Black Brass 1.27mm 1x10P Plugin,P=1.27mm Pin Headers ROHS" (at 134.62 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 134.62 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 134.62 143.51 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 37f7fb90-ad0b-4e3c-9fe4-a8006992498f))
-    (pin "10" (uuid 2f3f7a7e-f558-4bfc-b14d-aa1342d86807))
-    (pin "2" (uuid 35219702-ab48-4a80-8f39-f853fe322565))
-    (pin "3" (uuid 5aa312cc-a622-4027-8b91-f16ca6ab1784))
-    (pin "4" (uuid beb565c6-4b24-46b3-8a6f-008553bb07c1))
-    (pin "5" (uuid c5b97d97-15f6-4af1-9267-39ce17b124e6))
-    (pin "6" (uuid 6084c551-2162-408d-9f26-3a595603bffe))
-    (pin "7" (uuid 65b3bfb8-8d5f-45d5-a83c-c56728f446c2))
-    (pin "8" (uuid fefaa4d4-e08e-45f2-87e2-af596c97d5ec))
-    (pin "9" (uuid 0800b58a-7431-47ec-920f-816b89e599f2))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "J107") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 52.07 144.78 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f8a3f7a7-0d17-4f1e-8fea-40598cf13a18)
-    (property "Reference" "#PWR0125" (at 52.07 151.13 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 52.07 149.86 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 52.07 144.78 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 52.07 144.78 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b2dd32f4-a0fb-4490-a3fa-ad82e2655f93))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0125") (unit 1)
-        )
-      )
-    )
-  )
-
-  (sheet (at 247.65 134.62) (size 19.05 22.86)
-    (stroke (width 0) (type solid))
-    (fill (color 0 0 0 0.0000))
-    (uuid 00000000-0000-0000-0000-000062b3ac2f)
-    (property "Sheetname" "AlarmLights5" (at 247.65 133.9084 0)
-      (effects (font (size 1.27 1.27)) (justify left bottom))
-    )
-    (property "Sheetfile" "AlarmLights5.kicad_sch" (at 247.65 157.48 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (pin "Light0" input (at 266.7 137.16 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid b7f9f08e-a453-417d-85cd-91825edfc9b0)
-    )
-    (pin "Light1" input (at 266.7 140.97 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid ba1bbb93-b94f-41b4-861f-8fb7e09eba15)
-    )
-    (pin "Light2" input (at 266.7 144.78 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 10fb35f8-7b5d-4518-9439-2cab6d8c7b39)
-    )
-    (pin "Light3" input (at 266.7 148.59 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid a91aa7ce-44b2-4424-a92e-87642fc220ca)
-    )
-    (pin "Light4" input (at 266.7 152.4 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 06e674d6-f1d0-4124-a9e9-d2e78a8f61c6)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf" (page "6"))
-      )
-    )
-  )
-
-  (sheet (at 246.38 74.93) (size 19.05 21.59)
-    (stroke (width 0) (type solid))
-    (fill (color 0 0 0 0.0000))
-    (uuid 00000000-0000-0000-0000-000062b871ee)
-    (property "Sheetname" "LCD And I2C Interface" (at 246.38 74.2184 0)
-      (effects (font (size 1.27 1.27)) (justify left bottom))
-    )
-    (property "Sheetfile" "LCD And I2C Interface.kicad_sch" (at 246.38 97.155 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (pin "SCL" input (at 265.43 85.09 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 45416589-0bcb-4ff0-8a40-2cb2b33993c3)
-    )
-    (pin "SDA" bidirectional (at 265.43 92.71 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid c0e7b28b-397d-45dc-ae6b-c8e17de3b2cc)
-    )
-    (pin "3V3Raw" input (at 265.43 80.01 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 6fbd0c59-d8ec-40ee-b82c-28ffa5eb7aa8)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf" (page "4"))
-      )
-    )
-  )
-
-  (sheet (at 77.47 173.99) (size 22.86 20.32) (fields_autoplaced)
-    (stroke (width 0) (type solid))
-    (fill (color 0 0 0 0.0000))
-    (uuid 00000000-0000-0000-0000-000062b93801)
-    (property "Sheetname" "SPI Peripherial" (at 77.47 173.2784 0)
-      (effects (font (size 1.27 1.27)) (justify left bottom))
-    )
-    (property "Sheetfile" "SPI Peripherial.kicad_sch" (at 77.47 194.2596 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (pin "COPI" input (at 100.33 179.07 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid efcf6732-1888-4421-b3b1-afa02fcf7d95)
-    )
-    (pin "CIPO" output (at 100.33 182.88 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 81f4bf45-023f-49fc-a768-13d5b638dd56)
-    )
-    (pin "SCK" input (at 100.33 185.42 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 6606d53d-3aa5-48e9-9029-b5037d3c81b6)
-    )
-    (pin "nCS" input (at 100.33 189.23 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 7cceff3a-0829-4914-8e97-a01cddbdca44)
-    )
-    (pin "ControllerVcc" passive (at 100.33 191.77 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid bf550a5e-b09a-4f7a-8b1b-ea2cfb853db2)
-    )
-    (pin "5VRaw" input (at 77.47 181.61 180)
-      (effects (font (size 1.27 1.27)) (justify left))
-      (uuid 2d45e052-ba37-45ea-a766-63aae880be5b)
-    )
-    (pin "3V3Raw" input (at 77.47 189.23 180)
-      (effects (font (size 1.27 1.27)) (justify left))
-      (uuid ba2cb794-4092-4a30-8846-4fd19b7377a4)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf" (page "3"))
-      )
-    )
-  )
-
-  (sheet (at 24.13 173.99) (size 22.86 20.32) (fields_autoplaced)
-    (stroke (width 0) (type solid))
-    (fill (color 0 0 0 0.0000))
-    (uuid 00000000-0000-0000-0000-000062bc4e7e)
-    (property "Sheetname" "USB_UART" (at 24.13 173.2784 0)
-      (effects (font (size 1.27 1.27)) (justify left bottom))
-    )
-    (property "Sheetfile" "USB_UART.kicad_sch" (at 24.13 194.2596 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (pin "ControllerRX" output (at 46.99 191.77 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid d1acbca9-d31c-4537-adb6-02d51a612713)
-    )
-    (pin "ControllerTX" input (at 46.99 189.23 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 113d56c0-8c37-4dea-8f83-e264538b6b37)
-    )
-    (pin "VBus" passive (at 46.99 185.42 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid e04aad36-a95b-4223-b7d2-1a32234dbf22)
-    )
-    (pin "GPIO0" passive (at 24.13 176.53 180)
-      (effects (font (size 1.27 1.27)) (justify left))
-      (uuid f42818b5-6af6-41f6-baec-5029550abe99)
-    )
-    (pin "nRESET" passive (at 24.13 182.88 180)
-      (effects (font (size 1.27 1.27)) (justify left))
-      (uuid 87df5e5f-e804-4eb3-8075-68b2bc64aa9b)
-    )
-    (pin "3v3" input (at 46.99 180.34 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 146aa4ba-4b23-457e-957b-64722b102d46)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf" (page "2"))
-      )
-    )
-  )
-
-  (sheet (at 246.38 106.68) (size 20.32 19.05)
-    (stroke (width 0) (type solid))
-    (fill (color 0 0 0 0.0000))
-    (uuid 00000000-0000-0000-0000-000062dd8e5f)
-    (property "Sheetname" "AlarmAudio" (at 246.38 105.9684 0)
-      (effects (font (size 1.27 1.27)) (justify left bottom))
-    )
-    (property "Sheetfile" "AlarmAudio.kicad_sch" (at 246.38 126.365 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (pin "Switch_Mute" input (at 266.7 121.92 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid d81bef48-b4c9-47c6-9081-8dc659c51945)
-    )
-    (pin "ControllerTX" input (at 266.7 109.22 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid d6cd7013-25a0-4e3e-b10a-8678ce882e59)
-    )
-    (pin "ControllerRX" output (at 266.7 111.76 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid fb122c6f-2188-492f-9ac3-4c66786af0db)
-    )
-    (pin "Busy" output (at 266.7 114.3 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 6b08f541-ae59-45a0-bf6b-674bbb8e1f1f)
-    )
-    (pin "3v3" input (at 246.38 123.19 180)
-      (effects (font (size 1.27 1.27)) (justify left))
-      (uuid d260c05c-8029-4ec2-8369-5e5c0185992f)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf" (page "5"))
-      )
-    )
-  )
-
-  (sheet (at 118.11 173.99) (size 22.86 20.32) (fields_autoplaced)
-    (stroke (width 0.1524) (type solid))
-    (fill (color 0 0 0 0.0000))
-    (uuid b048976a-3284-45ec-9285-06d31a0a2b0c)
-    (property "Sheetname" "RS232" (at 118.11 173.2784 0)
-      (effects (font (size 1.27 1.27)) (justify left bottom))
-    )
-    (property "Sheetfile" "RS232.kicad_sch" (at 118.11 194.2596 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (pin "RTS1" input (at 140.97 189.23 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 3bfbd16f-1241-406d-854b-93609e8b0b4f)
-    )
-    (pin "CTS1" input (at 140.97 191.77 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid d67828c3-0660-4e06-aeca-8579151bcc00)
-    )
-    (pin "RX1" input (at 140.97 182.88 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid 0e548740-d2f6-4c25-b005-dcd4afa4c741)
-    )
-    (pin "TX1" input (at 140.97 185.42 0)
-      (effects (font (size 1.27 1.27)) (justify right))
-      (uuid e8c9ce56-9dcf-4a9e-b373-e2ef5accd0e0)
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf" (page "7"))
-      )
-    )
-  )
-
-  (sheet (at 152.4 173.99) (size 22.86 20.32) (fields_autoplaced)
-    (stroke (width 0.1524) (type solid))
-    (fill (color 0 0 0 0.0000))
-    (uuid b8d8fd1d-0a30-4b7d-ac57-549b73ec2592)
-    (property "Sheetname" "Enclosure Sheet" (at 152.4 173.2784 0)
-      (effects (font (size 1.27 1.27)) (justify left bottom))
-    )
-    (property "Sheetfile" "Enclosure.kicad_sch" (at 152.4 194.2596 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf" (page "8"))
-      )
-    )
-  )
-
-  (sheet_instances
-    (path "/" (page "1"))
-  )
+(kicad_sch
+	(version 20251012)
+	(generator "eeschema")
+	(generator_version "9.99")
+	(uuid "412a327d-1ee3-473e-bc00-1545004b7edf")
+	(paper "A4")
+	(title_block
+		(title "KRAKE_PCB")
+		(date "2025-07-18")
+		(rev "2.0")
+		(company "PublicInvention")
+		(comment 1 "GNU Affero General Public License v3.0")
+		(comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
+		(comment 3 "https://github.com/PubInv/krake")
+		(comment 4 "Inherited from the GPAD")
+	)
+	(lib_symbols
+		(symbol "Connector:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 5.08 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 5.08 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Connector_Generic:Conn_01x10"
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "J"
+				(at 0 12.7 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x10"
+				(at 0 -15.24 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x10, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Conn_01x10_1_1"
+				(rectangle
+					(start -1.27 11.43)
+					(end 1.27 -13.97)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(rectangle
+					(start -1.27 10.287)
+					(end 0 10.033)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 7.747)
+					(end 0 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 5.207)
+					(end 0 4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -7.493)
+					(end 0 -7.747)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -10.033)
+					(end 0 -10.287)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -12.573)
+					(end 0 -12.827)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 10.16 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -12.7 0)
+					(length 3.81)
+					(name "Pin_10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 7.62 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 5.08 0)
+					(length 3.81)
+					(name "Pin_3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 3.81)
+					(name "Pin_4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -5.08 0)
+					(length 3.81)
+					(name "Pin_7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -7.62 0)
+					(length 3.81)
+					(name "Pin_8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -10.16 0)
+					(length 3.81)
+					(name "Pin_9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Connector_Generic:Conn_01x14"
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "J"
+				(at 0 17.78 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x14"
+				(at 0 -20.32 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x14, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Conn_01x14_1_1"
+				(rectangle
+					(start -1.27 16.51)
+					(end 1.27 -19.05)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(rectangle
+					(start -1.27 15.367)
+					(end 0 15.113)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 12.827)
+					(end 0 12.573)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 10.287)
+					(end 0 10.033)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 7.747)
+					(end 0 7.493)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 5.207)
+					(end 0 4.953)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -7.493)
+					(end 0 -7.747)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -10.033)
+					(end 0 -10.287)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -12.573)
+					(end 0 -12.827)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -15.113)
+					(end 0 -15.367)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -17.653)
+					(end 0 -17.907)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 15.24 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -7.62 0)
+					(length 3.81)
+					(name "Pin_10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -10.16 0)
+					(length 3.81)
+					(name "Pin_11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -12.7 0)
+					(length 3.81)
+					(name "Pin_12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -15.24 0)
+					(length 3.81)
+					(name "Pin_13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -17.78 0)
+					(length 3.81)
+					(name "Pin_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 12.7 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 10.16 0)
+					(length 3.81)
+					(name "Pin_3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 7.62 0)
+					(length 3.81)
+					(name "Pin_4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 5.08 0)
+					(length 3.81)
+					(name "Pin_5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 3.81)
+					(name "Pin_6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -5.08 0)
+					(length 3.81)
+					(name "Pin_9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C_Polarized"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C_Polarized"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Polarized capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "CP_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_Polarized_0_1"
+				(rectangle
+					(start -2.286 0.508)
+					(end 2.286 1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 2.286) (xy -0.762 2.286)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 2.794) (xy -1.27 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 2.286 -0.508)
+					(end -2.286 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(symbol "C_Polarized_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:D_Schottky"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "D_Schottky"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Schottky diode"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "diode Schottky"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "D_Schottky_0_1"
+				(polyline
+					(pts
+						(xy -1.905 0.635) (xy -1.905 1.27) (xy -1.27 1.27) (xy -1.27 -1.27) (xy -0.635 -1.27) (xy -0.635 -0.635)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 1.27) (xy 1.27 -1.27) (xy -1.27 0) (xy 1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "D_Schottky_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:LED"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "LED"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Light emitting diode"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "LED diode"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "LED_0_1"
+				(polyline
+					(pts
+						(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 0) (xy 1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "LED_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:Polyfuse_Small"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "F"
+				(at -1.905 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Polyfuse_Small"
+				(at 1.905 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 1.27 -5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resettable fuse, polymeric positive temperature coefficient, small symbol"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "resettable fuse PTC PPTC polyfuse polyswitch"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "*polyfuse* *PTC*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Polyfuse_Small_0_1"
+				(polyline
+					(pts
+						(xy -1.016 1.27) (xy -1.016 0.762) (xy 1.016 -0.762) (xy 1.016 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -0.508 1.27)
+					(end 0.508 -1.27)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0 -2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "Polyfuse_Small_1_1"
+				(pin passive line
+					(at 0 2.54 270)
+					(length 0.635)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -2.54 90)
+					(length 0.635)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GND_1"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND_1"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_1_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:22-23-2021"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "J"
+				(at -2.54 1.27 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Value" "22-23-2021"
+				(at 1.27 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Connector_Molex:Molex_KK-254_AE-6410-02A_1x02_P2.54mm_Vertical"
+				(at 5.08 5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf"
+				(at 5.08 7.62 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Description" "CONN HEADER VERT 2POS 2.54MM"
+				(at 5.08 25.4 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Digi-Key_PN" "WM4200-ND"
+				(at 5.08 10.16 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "MPN" "22-23-2021"
+				(at 5.08 12.7 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Category" "Connectors, Interconnects"
+				(at 5.08 15.24 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Family" "Rectangular Connectors - Headers, Male Pins"
+				(at 5.08 17.78 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Datasheet_Link" "https://media.digikey.com/pdf/Data%20Sheets/Molex%20PDFs/A-6373-N_Series_Dwg_2010-12-03.pdf"
+				(at 5.08 20.32 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Detail_Page" "/product-detail/en/molex/22-23-2021/WM4200-ND/26667"
+				(at 5.08 22.86 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Manufacturer" "Molex"
+				(at 5.08 27.94 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Status" "Active"
+				(at 5.08 30.48 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Assembly Type" "HAND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "WM4200-ND KK 6373"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "22-23-2021_1_1"
+				(rectangle
+					(start -1.27 0)
+					(end 3.81 -2.54)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(rectangle
+					(start -0.254 -1.143)
+					(end 0.254 -1.651)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start 2.286 -1.143)
+					(end 2.794 -1.651)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(pin passive line
+					(at 0 2.54 270)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 2.54 270)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:Barrel_Jack_Switch_SMT"
+			(pin_names
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "J"
+				(at 0 5.334 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Barrel_Jack_Switch_SMT"
+				(at 1.27 -6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:BarrelJack_CLIFF_FC681465S_SMT_Horizontal"
+				(at 1.27 -1.016 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://tensility.s3.amazonaws.com/uploads/pdffiles/54-00164.pdf"
+				(at 1.27 -1.016 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "DC Barrel Jack with an internal switch and a mounting pin"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "JLCPCB"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "C319134"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer" "XKB Connectivity / Tensility International Corp"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN" "DC-005-5A-2.0-SMT / 54-00164"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 2" "Digikey"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 2 PN" "839-54-00164CT-ND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "0.205"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "DC power barrel jack connector"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "BarrelJack*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Barrel_Jack_Switch_SMT_0_1"
+				(rectangle
+					(start -5.08 3.81)
+					(end 5.08 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.81 -2.54) (xy -2.54 -2.54) (xy -1.27 -1.27) (xy 0 -2.54) (xy 2.54 -2.54) (xy 5.08 -2.54)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -3.302 1.905)
+					(mid -3.9343 2.54)
+					(end -3.302 3.175)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -3.302 1.905)
+					(mid -3.9343 2.54)
+					(end -3.302 3.175)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -2.286) (xy 1.905 -1.651)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 3.683 3.175)
+					(end -3.302 1.905)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 5.08 5.08) (xy 4.318 5.08) (xy 4.318 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 5.08 2.54) (xy 3.81 2.54)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 5.08 0) (xy 1.27 0) (xy 1.27 -2.286) (xy 0.635 -1.651)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "Barrel_Jack_Switch_SMT_1_1"
+				(pin passive line
+					(at 7.62 2.54 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -2.54 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 0 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 5.08 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:ESP32-WROOM-32D-PINORDER"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "U?"
+				(at -4.3941 31.75 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "ESP32-WROOM-32D"
+				(at -4.3941 29.21 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "RF_Module:ESP32-WROOM-32D"
+				(at 12.7 -25.4 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32d_esp32-wroom-32u_datasheet_en.pdf"
+				(at 17.78 -7.62 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "RF Module, ESP32-D0WD SoC, Wi-Fi 802.11b/g/n, Bluetooth, BLE, 32-bit, 2.7-3.6V, onboard antenna, SMD"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "3.42"
+				(at -6.35 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "JLCPCB"
+				(at -6.35 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "C473012"
+				(at -6.35 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN" "ESP32-WROOM-32D-N4"
+				(at -6.35 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer" "Espressif Systems"
+				(at -6.35 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "RF Radio BT ESP ESP32 Espressif onboard PCB antenna"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "ESP32?WROOM?32D*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "ESP32-WROOM-32D-PINORDER_0_1"
+				(rectangle
+					(start -19.05 26.67)
+					(end 19.05 -24.13)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+			)
+			(symbol "ESP32-WROOM-32D-PINORDER_1_1"
+				(pin power_in line
+					(at -21.59 20.32 0)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 -2.54 0)
+					(length 2.54)
+					(name "GPIO25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 -5.08 0)
+					(length 2.54)
+					(name "GPIO26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 -7.62 0)
+					(length 2.54)
+					(name "GPIO27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 -10.16 0)
+					(length 2.54)
+					(name "GPIO14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 -12.7 0)
+					(length 2.54)
+					(name "GPIO12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at -11.43 -26.67 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -8.89 -26.67 90)
+					(length 2.54)
+					(name "GPIO13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -6.35 -26.67 90)
+					(length 2.54)
+					(name "SHD/SD2/GPIO9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -3.81 -26.67 90)
+					(length 2.54)
+					(name "SWP/SD3/GPIO10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -1.27 -26.67 90)
+					(length 2.54)
+					(name "SCS/CMD/GPIO11/U1RTS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at -21.59 17.78 0)
+					(length 2.54)
+					(name "VDD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 1.27 -26.67 90)
+					(length 2.54)
+					(name "SCK/CLK/GPIO6/U1CTS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 3.81 -26.67 90)
+					(length 2.54)
+					(name "SDO/SD0/GPIO7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 6.35 -26.67 90)
+					(length 2.54)
+					(name "SDI/SD1/GPIO8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 8.89 -26.67 90)
+					(length 2.54)
+					(name "GPIO15/U1RXD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 11.43 -26.67 90)
+					(length 2.54)
+					(name "GPIO2/U1TXD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -12.7 180)
+					(length 2.54)
+					(name "GPIO0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -10.16 180)
+					(length 2.54)
+					(name "GPIO4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -7.62 180)
+					(length 2.54)
+					(name "RX2/GPIO16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -5.08 180)
+					(length 2.54)
+					(name "TX2/GPIO17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -2.54 180)
+					(length 2.54)
+					(name "GPIO5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -21.59 15.24 0)
+					(length 2.54)
+					(name "EN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 0 180)
+					(length 2.54)
+					(name "GPIO18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 2.54 180)
+					(length 2.54)
+					(name "GPIO19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "31"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 21.59 5.08 180)
+					(length 2.54)
+					(name "DO_NOT_CONNECT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "32"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 7.62 180)
+					(length 2.54)
+					(name "GPIO21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "33"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 10.16 180)
+					(length 2.54)
+					(name "RXD0/GPIO3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 12.7 180)
+					(length 2.54)
+					(name "TXD0/GPIO1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 15.24 180)
+					(length 2.54)
+					(name "GPIO22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "36"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 17.78 180)
+					(length 2.54)
+					(name "GPIO23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "37"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 21.59 20.32 180)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "38"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 21.59 22.86 180)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "39"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -21.59 12.7 0)
+					(length 2.54)
+					(name "GPIO36_VP"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -21.59 10.16 0)
+					(length 2.54)
+					(name "GPIO39_VN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -21.59 7.62 0)
+					(length 2.54)
+					(name "GPIO34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -21.59 5.08 0)
+					(length 2.54)
+					(name "GPIO35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 2.54 0)
+					(length 2.54)
+					(name "GPIO32"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -21.59 0 0)
+					(length 2.54)
+					(name "GPIO33"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:IEC_power_polarity_symbols_barrel_jack_Center_positive"
+			(exclude_from_sim no)
+			(in_bom no)
+			(on_board no)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#SYM"
+				(at 0 6.985 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "IEC_power_polarity_symbols_barrel_jack_Center_positive"
+				(at -0.1524 -7.3152 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:Symbol_Barrel_Polarity_Center_Positive"
+				(at -0.4318 -5.3594 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 -2.54 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "IEC power polarity symbols barrel jack"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Sim.Enable" "0"
+				(at 0 -2.54 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "polarity"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "IEC_power_polarity_symbols_barrel_jack_Center_positive_0_1"
+				(circle
+					(center -8.89 0)
+					(radius 1.27)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 8.89 0)
+					(radius 1.27)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "IEC_power_polarity_symbols_barrel_jack_Center_positive_1_1"
+				(polyline
+					(pts
+						(xy -8.382 0) (xy -9.398 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -7.62 0) (xy -1.905 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -1.524 1.0433)
+					(mid 0 1.8469)
+					(end 1.524 1.0433)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -1.0433 -1.524)
+					(mid -1.8469 0)
+					(end -1.0433 1.524)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 0)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(arc
+					(start 1.524 -1.0433)
+					(mid 0 -1.8469)
+					(end -1.524 -1.0433)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 0) (xy 7.62 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 8.89 -0.508) (xy 8.89 0.508)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 9.398 0) (xy 8.382 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE"
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "D"
+				(at -3.81 2.54 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Value" "LED_T1.75_CLEAR_WHITE"
+				(at -1.27 -3.81 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial"
+				(at 5.08 5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+				(at 5.08 7.62 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Description" "LED WHITE CLEAR T-1 3/4 T/H"
+				(at 5.08 25.4 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Digi-Key_PN" "160-1772-ND"
+				(at 5.08 10.16 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "MPN" "LTW-2R3D7"
+				(at 5.08 12.7 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Category" "Optoelectronics"
+				(at 5.08 15.24 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Family" "LED Indication - Discrete"
+				(at 5.08 17.78 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+				(at 5.08 20.32 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTW-2R3D7/160-1772-ND/1277121"
+				(at 5.08 22.86 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Manufacturer" "Lite-On Inc."
+				(at 5.08 27.94 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Status" "Active"
+				(at 5.08 30.48 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "ki_keywords" "160-1772-ND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "LED_T1.75_CLEAR_WHITE_0_1"
+				(polyline
+					(pts
+						(xy -2.54 1.27) (xy -2.54 -1.27) (xy 0 0) (xy -2.54 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy -0.635 3.81) (xy 0 3.81) (xy 0 3.175)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 3.81) (xy -1.27 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.635 3.175) (xy 1.27 3.175) (xy 1.27 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 3.175) (xy 0 1.905)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "LED_T1.75_CLEAR_WHITE_1_1"
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 0 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:MountingHole_Pad_3.5mm"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "H103"
+				(at 2.54 1.2446 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "MountingHole_Pad_3.5mm"
+				(at 0 -1.27 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:MountingHole_3.5mm_Pad_Via"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Mounting Hole with connection"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "0"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "AssemblyType" "NA"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "NA"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "NA"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN" "NA"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer" "NA"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "mounting hole"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "MountingHole*Pad*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "MountingHole_Pad_3.5mm_0_1"
+				(circle
+					(center 0 1.27)
+					(radius 1.27)
+					(stroke
+						(width 1.27)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "MountingHole_Pad_3.5mm_1_1"
+				(pin input line
+					(at 0 -2.54 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:RotaryEncoder_Switch_MP"
+			(pin_names
+				(offset 0.254)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "SW"
+				(at 2.54 6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "RotaryEncoder_Switch"
+				(at 11.43 -6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -3.81 4.064 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 6.604 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Rotary encoder, dual channel, incremental quadrate outputs, with switch"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "rotary switch encoder switch push button"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "RotaryEncoder*Switch*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "RotaryEncoder_Switch_MP_0_1"
+				(rectangle
+					(start -5.08 5.08)
+					(end 5.08 -5.08)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(polyline
+					(pts
+						(xy -5.08 2.54) (xy -3.81 2.54) (xy -3.81 2.032)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -5.08 0) (xy -3.81 0) (xy -3.81 -1.016) (xy -3.302 -2.032)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -5.08 -2.54) (xy -3.81 -2.54) (xy -3.81 -2.032)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -4.318 0) (xy -3.81 0) (xy -3.81 1.016) (xy -3.302 2.032)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -3.81 0)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy -0.635 -1.778) (xy -0.635 1.778)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -0.381 0)
+					(radius 1.905)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -0.381 -1.778) (xy -0.381 1.778)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -0.381 -2.794)
+					(mid -3.0988 -0.0635)
+					(end -0.381 2.667)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -0.127 1.778) (xy -0.127 -1.778)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.254 2.921) (xy -0.508 2.667) (xy 0.127 2.286)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.254 -3.048) (xy -0.508 -2.794) (xy 0.127 -2.413)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.81 1.016) (xy 3.81 -1.016)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.81 0) (xy 3.429 0)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 4.318 1.016)
+					(radius 0.127)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 4.318 -1.016)
+					(radius 0.127)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 5.08 2.54) (xy 4.318 2.54) (xy 4.318 1.016)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 5.08 -2.54) (xy 4.318 -2.54) (xy 4.318 -1.016)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "RotaryEncoder_Switch_MP_1_1"
+				(pin passive line
+					(at -7.62 2.54 0)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 -2.54 0)
+					(length 2.54)
+					(name "B"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 0 0)
+					(length 2.54)
+					(name "C"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -7.62 90)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "MP1"
+						(effects
+							(font
+								(size 0.762 0.762)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 7.62 270)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "MP2"
+						(effects
+							(font
+								(size 0.762 0.762)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 2.54 180)
+					(length 2.54)
+					(name "S1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "S1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 -2.54 180)
+					(length 2.54)
+					(name "S2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "S2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:SWITCH_TACTILE_SPST-NO_0.05A_24V"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "S101"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Value" "SWITCH_TACTILE_SPST-NO_0.05A_24V"
+				(at -11.43 -4.445 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:Switch_Tactile_THT_6x6mm"
+				(at 5.08 5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "https://www.te.com/commerce/DocumentDelivery/DDEController?Action=srchrtrv&DocNm=1825910&DocType=Customer+Drawing&DocLang=English"
+				(at 5.08 7.62 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Description" "SWITCH TACTILE SPST-NO 0.05A 24V"
+				(at 5.08 25.4 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Distributor 1 PN" "C13828"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "JLCPCB"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 2" "Digikey"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 2 PN" "450-1804-ND"
+				(at 5.08 10.16 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Manufacturer" "TE Connectivity ALCOSWITCH Switches"
+				(at 5.08 27.94 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "MPN" "TE Connectivity 1825910-7,   Dongguan Guangzhu Industrial C13828"
+				(at 5.08 12.7 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Category" "Switches"
+				(at 5.08 15.24 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Family" "Tactile Switches"
+				(at 5.08 17.78 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Datasheet_Link" "https://www.te.com/commerce/DocumentDelivery/DDEController?Action=srchrtrv&DocNm=1825910&DocType=Customer+Drawing&DocLang=English"
+				(at 5.08 20.32 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Detail_Page" "/product-detail/en/te-connectivity-alcoswitch-switches/1825910-7/450-1804-ND/1731414"
+				(at 5.08 22.86 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Status" "Active"
+				(at 5.08 30.48 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Assembly Type" ""
+				(at -139.7 -68.58 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "AssemblyType" "HAND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "0.0315"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "450-1804-ND FSMJ"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "SWITCH_TACTILE_SPST-NO_0.05A_24V_0_1"
+				(polyline
+					(pts
+						(xy -2.54 2.54) (xy -2.54 -2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 1.27) (xy 1.778 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 0) (xy -2.54 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -1.524 0)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 1.524 0)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 0) (xy 1.778 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 -2.54) (xy 2.54 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "SWITCH_TACTILE_SPST-NO_0.05A_24V_1_1"
+				(polyline
+					(pts
+						(xy -1.016 2.794) (xy 0.889 2.794)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.794) (xy 0 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 2.54 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 -2.54 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:ToolingHole_Pad_1.152mm"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "T"
+				(at -1.27 3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "ToolingHole_Pad_1.152mm"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "ToolingHole_1.152mm_Pad_Via"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Tooling Hole"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "Tooling hole"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "MountingHole*Pad*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "ToolingHole_Pad_1.152mm_1_1"
+				(circle
+					(center 0 0)
+					(radius 1.27)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "MF"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "U_Box_V104_General_Alarm_Device_LED_Standoff_0_1"
+				(circle
+					(center -2.54 0)
+					(radius 1.27)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 0)
+					(radius 4.0161)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.54 0)
+					(radius 1.27)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Graphic:Logo_Open_Hardware_Small"
+			(exclude_from_sim no)
+			(in_bom no)
+			(on_board no)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#SYM"
+				(at 0 6.985 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Logo_Open_Hardware_Small"
+				(at 0 -5.715 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Open Hardware logo, small"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Sim.Enable" "0"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "Logo"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Logo_Open_Hardware_Small_0_1"
+				(polyline
+					(pts
+						(xy 3.3528 -4.3434) (xy 3.302 -4.318) (xy 3.175 -4.2418) (xy 2.9972 -4.1148) (xy 2.7686 -3.9624)
+						(xy 2.54 -3.81) (xy 2.3622 -3.7084) (xy 2.2352 -3.6068) (xy 2.1844 -3.5814) (xy 2.159 -3.6068)
+						(xy 2.0574 -3.6576) (xy 1.905 -3.7338) (xy 1.8034 -3.7846) (xy 1.6764 -3.8354) (xy 1.6002 -3.8354)
+						(xy 1.6002 -3.8354) (xy 1.5494 -3.7338) (xy 1.4732 -3.5306) (xy 1.3462 -3.302) (xy 1.2446 -3.0226)
+						(xy 1.1176 -2.7178) (xy 0.9652 -2.413) (xy 0.8636 -2.1082) (xy 0.7366 -1.8288) (xy 0.6604 -1.6256)
+						(xy 0.6096 -1.4732) (xy 0.5842 -1.397) (xy 0.5842 -1.397) (xy 0.6604 -1.3208) (xy 0.7874 -1.2446)
+						(xy 1.0414 -1.016) (xy 1.2954 -0.6858) (xy 1.4478 -0.3302) (xy 1.524 0.0762) (xy 1.4732 0.4572)
+						(xy 1.3208 0.8128) (xy 1.0668 1.143) (xy 0.762 1.3716) (xy 0.4064 1.524) (xy 0 1.5748) (xy -0.381 1.5494)
+						(xy -0.7366 1.397) (xy -1.0668 1.143) (xy -1.2192 0.9906) (xy -1.397 0.6604) (xy -1.524 0.3048)
+						(xy -1.524 0.2286) (xy -1.4986 -0.1778) (xy -1.397 -0.5334) (xy -1.1938 -0.8636) (xy -0.9144 -1.143)
+						(xy -0.8636 -1.1684) (xy -0.7366 -1.27) (xy -0.635 -1.3462) (xy -0.5842 -1.397) (xy -1.0668 -2.5908)
+						(xy -1.143 -2.794) (xy -1.2954 -3.1242) (xy -1.397 -3.4036) (xy -1.4986 -3.6322) (xy -1.5748 -3.7846)
+						(xy -1.6002 -3.8354) (xy -1.6002 -3.8354) (xy -1.651 -3.8354) (xy -1.7272 -3.81) (xy -1.905 -3.7338)
+						(xy -2.0066 -3.683) (xy -2.1336 -3.6068) (xy -2.2098 -3.5814) (xy -2.2606 -3.6068) (xy -2.3622 -3.683)
+						(xy -2.54 -3.81) (xy -2.7686 -3.9624) (xy -2.9718 -4.0894) (xy -3.1496 -4.2164) (xy -3.302 -4.318)
+						(xy -3.3528 -4.3434) (xy -3.3782 -4.3434) (xy -3.429 -4.318) (xy -3.5306 -4.2164) (xy -3.7084 -4.064)
+						(xy -3.937 -3.8354) (xy -3.9624 -3.81) (xy -4.1656 -3.6068) (xy -4.318 -3.4544) (xy -4.4196 -3.3274)
+						(xy -4.445 -3.2766) (xy -4.445 -3.2766) (xy -4.4196 -3.2258) (xy -4.318 -3.0734) (xy -4.2164 -2.8956)
+						(xy -4.064 -2.667) (xy -3.6576 -2.0828) (xy -3.8862 -1.5494) (xy -3.937 -1.3716) (xy -4.0386 -1.1684)
+						(xy -4.0894 -1.0414) (xy -4.1148 -0.9652) (xy -4.191 -0.9398) (xy -4.318 -0.9144) (xy -4.5466 -0.8636)
+						(xy -4.8006 -0.8128) (xy -5.0546 -0.7874) (xy -5.2578 -0.7366) (xy -5.4356 -0.7112) (xy -5.5118 -0.6858)
+						(xy -5.5118 -0.6858) (xy -5.5372 -0.635) (xy -5.5372 -0.5588) (xy -5.5372 -0.4318) (xy -5.5626 -0.2286)
+						(xy -5.5626 0.0762) (xy -5.5626 0.127) (xy -5.5372 0.4064) (xy -5.5372 0.635) (xy -5.5372 0.762)
+						(xy -5.5372 0.8382) (xy -5.5372 0.8382) (xy -5.461 0.8382) (xy -5.3086 0.889) (xy -5.08 0.9144)
+						(xy -4.826 0.9652) (xy -4.8006 0.9906) (xy -4.5466 1.0414) (xy -4.318 1.0668) (xy -4.1656 1.1176)
+						(xy -4.0894 1.143) (xy -4.0894 1.143) (xy -4.0386 1.2446) (xy -3.9624 1.4224) (xy -3.8608 1.6256)
+						(xy -3.7846 1.8288) (xy -3.7084 2.0066) (xy -3.6576 2.159) (xy -3.6322 2.2098) (xy -3.6322 2.2098)
+						(xy -3.683 2.286) (xy -3.7592 2.413) (xy -3.8862 2.5908) (xy -4.064 2.8194) (xy -4.064 2.8448)
+						(xy -4.2164 3.0734) (xy -4.3434 3.2512) (xy -4.4196 3.3782) (xy -4.445 3.4544) (xy -4.445 3.4544)
+						(xy -4.3942 3.5052) (xy -4.2926 3.6322) (xy -4.1148 3.81) (xy -3.937 4.0132) (xy -3.8608 4.064)
+						(xy -3.6576 4.2926) (xy -3.5052 4.4196) (xy -3.4036 4.4958) (xy -3.3528 4.5212) (xy -3.3528 4.5212)
+						(xy -3.302 4.4704) (xy -3.1496 4.3688) (xy -2.9718 4.2418) (xy -2.7432 4.0894) (xy -2.7178 4.0894)
+						(xy -2.4892 3.937) (xy -2.3114 3.81) (xy -2.1844 3.7084) (xy -2.1336 3.683) (xy -2.1082 3.683)
+						(xy -2.032 3.7084) (xy -1.8542 3.7592) (xy -1.6764 3.8354) (xy -1.4732 3.937) (xy -1.27 4.0132)
+						(xy -1.143 4.064) (xy -1.0668 4.1148) (xy -1.0668 4.1148) (xy -1.0414 4.191) (xy -1.016 4.3434)
+						(xy -0.9652 4.572) (xy -0.9144 4.8514) (xy -0.889 4.9022) (xy -0.8382 5.1562) (xy -0.8128 5.3848)
+						(xy -0.7874 5.5372) (xy -0.762 5.588) (xy -0.7112 5.6134) (xy -0.5842 5.6134) (xy -0.4064 5.6134)
+						(xy -0.1524 5.6134) (xy 0.0762 5.6134) (xy 0.3302 5.6134) (xy 0.5334 5.6134) (xy 0.6858 5.588)
+						(xy 0.7366 5.588) (xy 0.7366 5.588) (xy 0.762 5.5118) (xy 0.8128 5.334) (xy 0.8382 5.1054) (xy 0.9144 4.826)
+						(xy 0.9144 4.7752) (xy 0.9652 4.5212) (xy 1.016 4.2926) (xy 1.0414 4.1402) (xy 1.0668 4.0894)
+						(xy 1.0668 4.0894) (xy 1.1938 4.0386) (xy 1.3716 3.9624) (xy 1.5748 3.8608) (xy 2.0828 3.6576)
+						(xy 2.7178 4.0894) (xy 2.7686 4.1402) (xy 2.9972 4.2926) (xy 3.175 4.4196) (xy 3.302 4.4958) (xy 3.3782 4.5212)
+						(xy 3.3782 4.5212) (xy 3.429 4.4704) (xy 3.556 4.3434) (xy 3.7338 4.191) (xy 3.9116 3.9878) (xy 4.064 3.8354)
+						(xy 4.2418 3.6576) (xy 4.3434 3.556) (xy 4.4196 3.4798) (xy 4.4196 3.429) (xy 4.4196 3.4036) (xy 4.3942 3.3274)
+						(xy 4.2926 3.2004) (xy 4.1656 2.9972) (xy 4.0132 2.794) (xy 3.8862 2.5908) (xy 3.7592 2.3876)
+						(xy 3.6576 2.2352) (xy 3.6322 2.159) (xy 3.6322 2.1336) (xy 3.683 2.0066) (xy 3.7592 1.8288) (xy 3.8608 1.6002)
+						(xy 4.064 1.1176) (xy 4.3942 1.0414) (xy 4.5974 1.016) (xy 4.8768 0.9652) (xy 5.1308 0.9144) (xy 5.5372 0.8382)
+						(xy 5.5626 -0.6604) (xy 5.4864 -0.6858) (xy 5.4356 -0.6858) (xy 5.2832 -0.7366) (xy 5.0546 -0.762)
+						(xy 4.8006 -0.8128) (xy 4.5974 -0.8636) (xy 4.3688 -0.9144) (xy 4.2164 -0.9398) (xy 4.1402 -0.9398)
+						(xy 4.1148 -0.9652) (xy 4.064 -1.0668) (xy 3.9878 -1.2446) (xy 3.9116 -1.4478) (xy 3.81 -1.651)
+						(xy 3.7338 -1.8542) (xy 3.683 -2.0066) (xy 3.6576 -2.0828) (xy 3.683 -2.1336) (xy 3.7846 -2.2606)
+						(xy 3.8862 -2.4638) (xy 4.0386 -2.667) (xy 4.191 -2.8956) (xy 4.318 -3.0734) (xy 4.3942 -3.2004)
+						(xy 4.445 -3.2766) (xy 4.4196 -3.3274) (xy 4.3434 -3.429) (xy 4.1656 -3.5814) (xy 3.937 -3.8354)
+						(xy 3.8862 -3.8608) (xy 3.683 -4.064) (xy 3.5306 -4.2164) (xy 3.4036 -4.318) (xy 3.3528 -4.3434)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Jumper:Jumper_2_Bridged"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "JP"
+				(at 0 1.905 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Jumper_2_Bridged"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Jumper, 2-pole, closed/bridged"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "Jumper SPST"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Jumper* TestPoint*2Pads* TestPoint*Bridge*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Jumper_2_Bridged_0_0"
+				(circle
+					(center -2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "Jumper_2_Bridged_0_1"
+				(arc
+					(start -1.524 0.254)
+					(mid 0 0.762)
+					(end 1.524 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "Jumper_2_Bridged_1_1"
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "B"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Regulator_Linear:AMS1117-3.3"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "U"
+				(at -3.81 3.175 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "AMS1117-3.3"
+				(at 0 3.175 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+				(at 0 5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "http://www.advanced-monolithic.com/pdf/ds1117.pdf"
+				(at 2.54 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "1A Low Dropout regulator, positive, 3.3V fixed output, SOT-223"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "linear regulator ldo fixed positive"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "SOT?223*TabPin2*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "AMS1117-3.3_0_1"
+				(rectangle
+					(start -5.08 -5.08)
+					(end 5.08 1.905)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+			)
+			(symbol "AMS1117-3.3_1_1"
+				(pin power_in line
+					(at 0 -7.62 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_out line
+					(at 7.62 0 180)
+					(length 2.54)
+					(name "VO"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at -7.62 0 0)
+					(length 2.54)
+					(name "VI"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Regulator_Linear:LM7805_TO220"
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "U"
+				(at -3.81 3.175 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "LM7805_TO220"
+				(at 0 3.175 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "Package_TO_SOT_THT:TO-220-3_Vertical"
+				(at 0 5.715 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+				)
+			)
+			(property "Datasheet" "https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF"
+				(at 0 -1.27 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Positive 1A 35V Linear Regulator, Fixed Output 5V, TO-220"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "Voltage Regulator 1A Positive"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "TO?220*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "LM7805_TO220_0_1"
+				(rectangle
+					(start -5.08 1.905)
+					(end 5.08 -5.08)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+			)
+			(symbol "LM7805_TO220_1_1"
+				(pin power_in line
+					(at -7.62 0 0)
+					(length 2.54)
+					(name "VI"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -7.62 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_out line
+					(at 7.62 0 180)
+					(length 2.54)
+					(name "VO"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:+3.3V"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "+3.3V"
+				(at 0 3.556 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "+3.3V_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "+3.3V_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(hide yes)
+					(name "+3.3V"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:+5V"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "+5V"
+				(at 0 3.556 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"+5V\""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "+5V_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "+5V_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(hide yes)
+					(name "+5V"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:PWR_FLAG"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#FLG"
+				(at 0 1.905 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "PWR_FLAG"
+				(at 0 3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Special symbol for telling ERC where power comes from"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "flag power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_0"
+				(pin power_out line
+					(at 0 0 90)
+					(length 0)
+					(name "pwr"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(text "Power Input, Reverse protected."
+		(exclude_from_sim no)
+		(at 15.875 18.415 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "02202e00-6caa-4788-9d4c-cd31425f7f41")
+	)
+	(text "BOOT"
+		(exclude_from_sim no)
+		(at 180.34 143.51 0)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left bottom)
+		)
+		(uuid "07caad48-07e4-4a29-ab5d-6835f7344899")
+	)
+	(text "currect setting \nresistor"
+		(exclude_from_sim no)
+		(at 124.46 161.29 0)
+		(effects
+			(font
+				(size 0.762 0.762)
+			)
+			(justify left bottom)
+		)
+		(uuid "185afef7-94de-46bb-b04b-d30f6098d406")
+	)
+	(text "RTS	Request to Send	Out\nCTS	Clear to Send	In"
+		(exclude_from_sim no)
+		(at 148.59 139.7 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "26964fbf-e8bd-441a-83b8-f05dde8f2bbe")
+	)
+	(text "controls boot"
+		(exclude_from_sim no)
+		(at 168.275 123.19 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "4111fe6e-ba44-4652-a43b-9cf27698d78a")
+	)
+	(text "↑StatusLED"
+		(exclude_from_sim no)
+		(at 115.57 170.18 0)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left bottom)
+		)
+		(uuid "57b7e314-ac2c-4601-a425-4e19dd064d03")
+	)
+	(text "RESET"
+		(exclude_from_sim no)
+		(at 45.72 72.39 0)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left bottom)
+		)
+		(uuid "62d6c0a4-8d9c-47e3-bf80-d5b0553f8bb8")
+	)
+	(text "Power Indicator"
+		(exclude_from_sim no)
+		(at 157.48 54.61 0)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left bottom)
+		)
+		(uuid "778942c1-a5eb-4c37-a7e5-1bae8be6282f")
+	)
+	(text "MENU"
+		(exclude_from_sim no)
+		(at 72.39 138.43 0)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left bottom)
+		)
+		(uuid "7fae4902-1b08-4e2d-8bc2-011d0c018ec5")
+	)
+	(text "clk"
+		(exclude_from_sim no)
+		(at 53.34 133.985 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "9125816a-86bf-4092-9aa7-1132d49add69")
+	)
+	(text "ControllerVcc comes from a USB host."
+		(exclude_from_sim no)
+		(at 168.275 17.145 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a25e161b-833e-4d6b-9bf3-e0b8a8257f06")
+	)
+	(text "DT"
+		(exclude_from_sim no)
+		(at 53.34 141.605 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "b2517a33-866c-4158-af02-5b6f54153a62")
+	)
+	(text "Voltage regulator for ESP32"
+		(exclude_from_sim no)
+		(at 212.09 19.685 0)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left bottom)
+		)
+		(uuid "b43333ec-5131-4b89-9558-536c4067a26c")
+	)
+	(text "Voltage regulator for 12V in to +5V"
+		(exclude_from_sim no)
+		(at 48.26 15.24 0)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left bottom)
+		)
+		(uuid "ecbd92f8-1a18-42f7-91dc-384884c750e8")
+	)
+	(junction
+		(at 161.29 91.44)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "03468543-327b-47f3-9671-11e40e6c365d")
+	)
+	(junction
+		(at 111.76 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "03621892-b27c-4129-9d25-96e7e46fc9ca")
+	)
+	(junction
+		(at 111.76 106.68)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "039d8d9d-cee0-451e-87bf-367c7bd79d0c")
+	)
+	(junction
+		(at 210.82 134.62)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0554b82b-960b-4c3b-ac71-c4ea76a56ac7")
+	)
+	(junction
+		(at 144.78 138.43)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "055c117d-ab7d-406b-a05e-0ff8e606605b")
+	)
+	(junction
+		(at 147.32 138.43)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0d5cfec3-60b8-4ead-9751-2e942cd0a570")
+	)
+	(junction
+		(at 171.45 99.06)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "13712ae1-b4e4-4645-8f0d-37b6e1bc237d")
+	)
+	(junction
+		(at 210.82 139.7)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "14dc0ad6-2547-4241-bbb4-ab8ee0d14274")
+	)
+	(junction
+		(at 33.02 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "168541e9-4b42-499e-bc97-341acbfb186a")
+	)
+	(junction
+		(at 121.92 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "195f0b50-6417-4727-814b-cf1391e47f25")
+	)
+	(junction
+		(at 190.5 137.16)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1ff8c054-6d67-4bca-b740-900ed8ff62e3")
+	)
+	(junction
+		(at 74.93 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3027e5a5-c41a-40fb-ba4f-793c7545cdd5")
+	)
+	(junction
+		(at 111.76 96.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "33fdc9ee-bd3c-4433-b322-f3d045dc5894")
+	)
+	(junction
+		(at 147.32 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3776d9fc-34f1-47cb-828d-285a18c1c50b")
+	)
+	(junction
+		(at 190.5 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "397602ef-9661-4e78-b678-96bb0057799a")
+	)
+	(junction
+		(at 101.6 93.98)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "41bc5617-a2bf-429d-a0aa-9ec5dbf92fce")
+	)
+	(junction
+		(at 36.83 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "444154d3-c757-4e59-aaf5-de4585250cbf")
+	)
+	(junction
+		(at 35.56 33.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4aa1cccd-27e6-40d5-88ad-95cc6d778882")
+	)
+	(junction
+		(at 173.99 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4ce67390-a76a-4513-860e-9d10a5dd6936")
+	)
+	(junction
+		(at 111.76 111.76)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5237aee7-a4e0-4179-b9cb-bf9b58957aba")
+	)
+	(junction
+		(at 39.37 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "53643437-1d77-4de7-bd0b-b04e2a707771")
+	)
+	(junction
+		(at 127 138.43)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "545a140e-d467-46da-9b81-41caa80279ab")
+	)
+	(junction
+		(at 210.82 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "54abda77-8082-4431-8a05-d2b9a55743fd")
+	)
+	(junction
+		(at 161.29 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5bc1644a-04ef-4eaf-8485-f1349ce0667c")
+	)
+	(junction
+		(at 262.89 34.29)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6134dd35-a9fd-49ca-94b5-a350606fa23e")
+	)
+	(junction
+		(at 35.56 92.71)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "64afb8fe-419f-4632-9719-0b3c9c7bf92c")
+	)
+	(junction
+		(at 124.46 138.43)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "659ca905-0664-48b1-ac86-3e8199cae7fc")
+	)
+	(junction
+		(at 236.22 34.29)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "698e6353-e8f1-408f-a5b3-eaa185e606db")
+	)
+	(junction
+		(at 43.18 66.04)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6c5a1751-0efe-4b3a-bcd7-ecc33694ce29")
+	)
+	(junction
+		(at 111.76 91.44)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6cd0e424-c94a-45e4-a629-f4677de250b6")
+	)
+	(junction
+		(at 35.56 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6e642b49-a859-41f1-a5d7-a4322f76b310")
+	)
+	(junction
+		(at 111.76 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6f67c1d7-253b-4612-b0de-010ee1456657")
+	)
+	(junction
+		(at 40.64 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6fb13ebf-e482-4746-a96d-af0c2c7b7c67")
+	)
+	(junction
+		(at 36.83 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7038dc1f-9eba-43e5-a9d1-b67d2eaec00f")
+	)
+	(junction
+		(at 275.59 34.29)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7071553b-818a-4728-9ca1-80500eb457e5")
+	)
+	(junction
+		(at 210.82 152.4)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "707606ee-9971-4796-9b36-804d6c8790ed")
+	)
+	(junction
+		(at 161.29 119.38)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7526ee9c-d1d8-4ea1-8157-a823e3c523e8")
+	)
+	(junction
+		(at 111.76 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "76a80887-cb1a-42ce-afdc-6548a41cb7d6")
+	)
+	(junction
+		(at 210.82 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "76b50a90-6e4d-479c-ac0d-e8736ad2d53d")
+	)
+	(junction
+		(at 111.76 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "77e8fd82-a18f-4184-a532-3ed516f46e86")
+	)
+	(junction
+		(at 68.58 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7a842307-2b31-4a52-926c-0b714d544955")
+	)
+	(junction
+		(at 54.61 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7b02338b-8a00-4c28-8ecd-234b1aabe897")
+	)
+	(junction
+		(at 29.21 44.45)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7b5e784c-ea5b-4f61-8c1c-7b17f6c36992")
+	)
+	(junction
+		(at 101.6 74.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7d3aa73b-91fa-43f0-80bc-6f538523848d")
+	)
+	(junction
+		(at 36.83 44.45)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7d3d8af7-7b43-481a-a4ad-aca68bdf2d6f")
+	)
+	(junction
+		(at 161.29 93.98)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "81ff9a06-26ac-480d-b245-a2e158524e34")
+	)
+	(junction
+		(at 62.23 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "82790838-6fe0-45b6-bf2d-e2a9cd72193a")
+	)
+	(junction
+		(at 57.15 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "897f109d-1110-472c-96dc-b0703ced6ca9")
+	)
+	(junction
+		(at 161.29 106.68)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8ba36a18-e944-4796-9846-8f0cb45c7a09")
+	)
+	(junction
+		(at 161.29 114.3)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9042ff97-4455-413a-bf7c-7f2e1fa37256")
+	)
+	(junction
+		(at 184.15 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "95befd87-3192-4f05-933a-0f47e9d25c2d")
+	)
+	(junction
+		(at 161.29 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "961defd8-71de-48b4-a696-2f1d1d7501f7")
+	)
+	(junction
+		(at 71.12 134.62)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "99b5c5ea-9bf1-4d9f-92dd-f15ca011df61")
+	)
+	(junction
+		(at 111.76 116.84)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9afbf8ad-d9b7-4d19-982d-24158cf9f2b2")
+	)
+	(junction
+		(at 31.75 44.45)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9ed499c7-5425-4cb5-9a87-99e3edb35e15")
+	)
+	(junction
+		(at 60.96 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9f3c99a1-8a4d-4259-b670-67c4fdb1da9c")
+	)
+	(junction
+		(at 101.6 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ac791dc9-db68-4a56-87e6-0cf7bed47b98")
+	)
+	(junction
+		(at 161.29 111.76)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ad322ace-4935-4845-a88a-1a249ec5f7f9")
+	)
+	(junction
+		(at 111.76 93.98)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ae5f9aa9-de46-4c5c-9ec7-4e1137328c6e")
+	)
+	(junction
+		(at 133.35 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "afbde9e9-c37b-4718-9dfa-36259b43e1eb")
+	)
+	(junction
+		(at 67.31 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b018eb50-59d5-40f8-9e07-95fd22f3dae6")
+	)
+	(junction
+		(at 234.95 34.29)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b0a2e6f2-0dd1-4e76-8be2-a77b63d3bf3f")
+	)
+	(junction
+		(at 161.29 96.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b50a46ae-49a5-4aec-bdb6-84fc9a68491f")
+	)
+	(junction
+		(at 161.29 116.84)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bc45b9fd-e049-4a17-ba46-0d7100817fcd")
+	)
+	(junction
+		(at 101.6 71.12)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "be1bec4b-041a-4e01-af6a-b4c3661c0942")
+	)
+	(junction
+		(at 273.05 34.29)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c2fcdc36-5c0e-41f8-ac32-69992883fe87")
+	)
+	(junction
+		(at 111.76 119.38)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c38da32d-fb8c-4a8d-bf76-c5be3ac14d84")
+	)
+	(junction
+		(at 85.09 71.12)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c668d3e4-8d66-42f4-a4c3-173ddc957afc")
+	)
+	(junction
+		(at 119.38 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c6fe1b85-f97d-4bfd-9e78-056d597ff1b6")
+	)
+	(junction
+		(at 137.16 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ca7094ce-fe61-40eb-a6a8-198d0445006d")
+	)
+	(junction
+		(at 161.29 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cb989bcc-5d7c-4831-a361-daa2f30130ff")
+	)
+	(junction
+		(at 179.07 134.62)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cdbdc718-033b-4a38-920a-b047d114e262")
+	)
+	(junction
+		(at 111.76 104.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d4ec2be4-cc0d-44b6-bf66-3c68f9cd5569")
+	)
+	(junction
+		(at 242.57 34.29)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d53cfcfe-6178-478a-b832-10a5e0f566ac")
+	)
+	(junction
+		(at 49.53 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dbacfa0d-d96a-4421-9366-dcde6c6cc1ed")
+	)
+	(junction
+		(at 210.82 127)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e4b7e3cc-3e58-45c9-82a4-25b7beb49ead")
+	)
+	(junction
+		(at 163.83 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e582e3cf-90ba-4170-bcc1-bd27db3de3ac")
+	)
+	(junction
+		(at 238.76 34.29)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "eafa446a-b330-49a1-ab14-b8f3828f0a1c")
+	)
+	(junction
+		(at 64.77 24.13)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "eb4babce-b649-4484-825b-70f6a873515a")
+	)
+	(junction
+		(at 72.39 104.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "eecccfab-7303-475b-ae08-a9ebf9e67dbc")
+	)
+	(junction
+		(at 161.29 99.06)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f3015d71-82be-4be9-9545-d6ed2af4bcd1")
+	)
+	(junction
+		(at 111.76 99.06)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f3bb3367-adfa-40ab-8c86-02713bfe9d9d")
+	)
+	(junction
+		(at 171.45 87.63)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f4c9f50d-dbbe-4768-9efb-9e33f56f53d7")
+	)
+	(junction
+		(at 69.85 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f55e9c3b-b023-41a5-9056-e959734a22f8")
+	)
+	(junction
+		(at 64.77 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f5c78b36-4ad8-4138-851d-1ca90e8ef509")
+	)
+	(junction
+		(at 111.76 114.3)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f664cf0b-28a9-4324-b0b5-4b47b2940695")
+	)
+	(junction
+		(at 151.13 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f83ead1a-75d9-4d68-988b-2502bc6bf206")
+	)
+	(junction
+		(at 161.29 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fdbe3e86-8364-4e79-baa3-6d7040901b14")
+	)
+	(no_connect
+		(at 215.9 68.58)
+		(uuid "741b5bd2-deff-4b6c-bd0a-654dfa6768e5")
+	)
+	(no_connect
+		(at 205.74 68.58)
+		(uuid "9154aaac-b1e2-4313-bc00-87e2c0478c10")
+	)
+	(wire
+		(pts
+			(xy 236.22 29.21) (xy 236.22 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "007990a9-c320-4aa2-a0ce-ff13e677b0e9")
+	)
+	(wire
+		(pts
+			(xy 101.6 179.07) (xy 100.33 179.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "009365d1-aabd-44d4-a2c6-0f3e14bb1fd3")
+	)
+	(wire
+		(pts
+			(xy 97.79 104.14) (xy 111.76 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "014d4585-54c9-4d9d-926d-c9b3276287b3")
+	)
+	(wire
+		(pts
+			(xy 137.16 27.94) (xy 137.16 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "02453566-9de5-4eee-956f-e83ce9df1c0c")
+	)
+	(wire
+		(pts
+			(xy 92.71 111.76) (xy 111.76 111.76)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "042f2a42-66fb-42f8-88f2-ef5f489830ae")
+	)
+	(wire
+		(pts
+			(xy 171.45 97.79) (xy 171.45 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0466292d-ad7f-4bb9-8e28-f0d4310b85f2")
+	)
+	(wire
+		(pts
+			(xy 67.31 19.05) (xy 175.26 19.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "04a3c572-8732-49af-a6fa-a0dc1695593b")
+	)
+	(wire
+		(pts
+			(xy 180.34 46.99) (xy 173.99 46.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0518cace-86b1-4ba2-b373-5a1d2a3ad0e0")
+	)
+	(wire
+		(pts
+			(xy 124.46 138.43) (xy 124.46 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0625045d-05ca-4a01-8954-420dde7b2fa6")
+	)
+	(wire
+		(pts
+			(xy 53.34 134.62) (xy 55.88 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "067522d9-7bb0-41bc-97b3-ae66446320e7")
+	)
+	(wire
+		(pts
+			(xy 179.07 134.62) (xy 179.07 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "078a5778-a240-4b14-ba4a-61d79b595764")
+	)
+	(wire
+		(pts
+			(xy 210.82 149.86) (xy 210.82 152.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "07d23bba-8c23-4bac-a63b-cd3825880c01")
+	)
+	(wire
+		(pts
+			(xy 137.16 135.89) (xy 137.16 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0821ff62-2b84-4df1-8eff-877922d134ae")
+	)
+	(wire
+		(pts
+			(xy 40.64 92.71) (xy 40.64 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "088d5e51-d335-4ec3-b973-84929e7e5d79")
+	)
+	(wire
+		(pts
+			(xy 262.89 43.18) (xy 262.89 45.72)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "09741eab-1e1d-478c-a889-f3c4d6f865e1")
+	)
+	(wire
+		(pts
+			(xy 147.32 46.99) (xy 147.32 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "09eff4f5-a0fa-472b-a332-19f443fdaacb")
+	)
+	(wire
+		(pts
+			(xy 97.79 93.98) (xy 101.6 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0a6dbdb3-91a3-4710-95c2-e4cb0fec3ba9")
+	)
+	(wire
+		(pts
+			(xy 161.29 116.84) (xy 173.99 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0a75b557-a09a-4fb1-91be-3ddce06c3e13")
+	)
+	(wire
+		(pts
+			(xy 50.8 139.7) (xy 55.88 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0bbcfb05-08cb-410b-8803-56056cbf829f")
+	)
+	(wire
+		(pts
+			(xy 133.35 27.94) (xy 137.16 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0c297fdb-786d-44c4-a442-1ed275998790")
+	)
+	(wire
+		(pts
+			(xy 33.02 25.4) (xy 35.56 25.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0c4a6881-e316-4506-b478-be45d2374882")
+	)
+	(wire
+		(pts
+			(xy 133.35 29.21) (xy 133.35 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0cb3a2f9-fd32-4dc0-ad92-fe8e648f8f5e")
+	)
+	(wire
+		(pts
+			(xy 54.61 88.9) (xy 54.61 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0d933a3f-3440-4e0d-861e-292ffd45e9ca")
+	)
+	(wire
+		(pts
+			(xy 273.05 35.56) (xy 273.05 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0dff39f0-d730-4050-a315-9a0d91e91577")
+	)
+	(wire
+		(pts
+			(xy 33.02 30.48) (xy 35.56 30.48)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0f577625-8d53-4c2e-b392-87074b798556")
+	)
+	(wire
+		(pts
+			(xy 190.5 27.94) (xy 190.5 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "10e74ae7-e34f-4ca4-8b78-e0a740259c92")
+	)
+	(wire
+		(pts
+			(xy 214.63 34.29) (xy 217.17 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12fda8d1-f574-4a7a-aa21-e7e2262625f5")
+	)
+	(wire
+		(pts
+			(xy 111.76 88.9) (xy 114.3 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "13358993-267e-4de7-86c6-a78b0914ae61")
+	)
+	(wire
+		(pts
+			(xy 242.57 43.18) (xy 242.57 45.72)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "146f00b5-69b2-4772-9450-043ed39adc6b")
+	)
+	(wire
+		(pts
+			(xy 157.48 91.44) (xy 161.29 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "14e05fc7-47e7-46ed-9391-124c096321fd")
+	)
+	(wire
+		(pts
+			(xy 127 158.75) (xy 119.38 158.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "150012b8-86c0-432d-badf-122f0d7f7141")
+	)
+	(wire
+		(pts
+			(xy 251.46 45.72) (xy 251.46 41.91)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "166b432e-dd26-43b0-b5aa-c53564487569")
+	)
+	(wire
+		(pts
+			(xy 173.99 121.92) (xy 181.61 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "172670cd-d136-45d6-9376-cc007d2b0725")
+	)
+	(wire
+		(pts
+			(xy 29.21 44.45) (xy 31.75 44.45)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "17295aac-6f5e-4629-a691-0986aa311896")
+	)
+	(wire
+		(pts
+			(xy 238.76 27.94) (xy 238.76 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "17cf0df8-96d4-47fc-874c-6767973f280e")
+	)
+	(wire
+		(pts
+			(xy 153.67 35.56) (xy 151.13 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1a8b417f-53c1-4c04-99ad-648f94c546f6")
+	)
+	(wire
+		(pts
+			(xy 242.57 35.56) (xy 242.57 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1adf7c80-3f7f-4ef4-9149-c1e4d2f7d491")
+	)
+	(wire
+		(pts
+			(xy 67.31 19.05) (xy 67.31 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1ba606f6-f9aa-4e71-a1a0-e1d721ef59d9")
+	)
+	(wire
+		(pts
+			(xy 49.53 80.01) (xy 49.53 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1cfe3f49-7172-43b7-97d6-ee2e83b77201")
+	)
+	(wire
+		(pts
+			(xy 157.48 119.38) (xy 161.29 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1e12c4fa-95d4-4da0-a05c-feff406c9d2f")
+	)
+	(wire
+		(pts
+			(xy 271.78 80.01) (xy 265.43 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1ec7070f-5644-48b7-b11e-28b14dd09ccd")
+	)
+	(wire
+		(pts
+			(xy 121.92 27.94) (xy 133.35 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1ef1760a-38d6-4ffa-962d-f7de7d8501d0")
+	)
+	(wire
+		(pts
+			(xy 274.32 152.4) (xy 266.7 152.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "20857af3-e57f-4c07-b06a-07d30ab730ea")
+	)
+	(wire
+		(pts
+			(xy 69.85 34.29) (xy 69.85 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2116ffcb-f0eb-4e93-b329-3a6beb901b04")
+	)
+	(wire
+		(pts
+			(xy 179.07 139.7) (xy 180.34 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "214afdce-2ddf-422a-a1fe-b0f333dcdb48")
+	)
+	(wire
+		(pts
+			(xy 57.15 66.04) (xy 57.15 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "22476318-d783-4fc2-ba4a-5b67b6c4c49a")
+	)
+	(wire
+		(pts
+			(xy 269.24 114.3) (xy 266.7 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "226b0b38-0ccb-4dd1-8705-7d12bb46df96")
+	)
+	(wire
+		(pts
+			(xy 105.41 121.92) (xy 111.76 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "22d4a748-a6ee-4b94-ad4b-89b5d995e1c8")
+	)
+	(wire
+		(pts
+			(xy 187.96 26.67) (xy 187.96 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "231bfd33-e9a7-4dd1-a7fc-14b6f918eab1")
+	)
+	(wire
+		(pts
+			(xy 26.67 49.53) (xy 31.75 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2345aabc-f329-4fce-a1f5-45293716b794")
+	)
+	(wire
+		(pts
+			(xy 97.79 71.12) (xy 101.6 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2348d889-f5b9-492e-8dfb-862d94168a8a")
+	)
+	(wire
+		(pts
+			(xy 234.95 34.29) (xy 234.95 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23e72f93-c944-47ca-9311-73de4b6e3496")
+	)
+	(wire
+		(pts
+			(xy 54.61 123.19) (xy 77.47 123.19)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "243c0e23-4725-4e8b-9266-fd201ca8ba88")
+	)
+	(wire
+		(pts
+			(xy 111.76 119.38) (xy 114.3 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "24459baf-4ab4-4210-bac0-0f0bdb004c07")
+	)
+	(wire
+		(pts
+			(xy 161.29 111.76) (xy 170.18 111.76)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "25f1741f-35d7-4857-91fe-1ab72080a414")
+	)
+	(wire
+		(pts
+			(xy 176.53 31.75) (xy 175.26 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "27b1da6c-48fa-4322-b32c-4045e9fc6c2e")
+	)
+	(wire
+		(pts
+			(xy 217.17 142.24) (xy 210.82 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "294eb528-140f-4c57-b0c7-64efcf956c4d")
+	)
+	(wire
+		(pts
+			(xy 140.97 182.88) (xy 143.51 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "299e608b-a216-4b2e-a6b7-5d0a275049b9")
+	)
+	(wire
+		(pts
+			(xy 39.37 27.94) (xy 36.83 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2c6198d8-fefd-4aaf-bd8d-ffbd97bb0a34")
+	)
+	(wire
+		(pts
+			(xy 158.75 27.94) (xy 158.75 26.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2cfa9481-c72f-4293-9eb5-4d8aff27c0a0")
+	)
+	(wire
+		(pts
+			(xy 95.25 109.22) (xy 111.76 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d1a0fda-d10d-403b-a75f-cbc2effe7a3c")
+	)
+	(wire
+		(pts
+			(xy 111.76 96.52) (xy 114.3 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d33768e-15a2-47d1-b227-5c95c7d1ff39")
+	)
+	(wire
+		(pts
+			(xy 262.89 35.56) (xy 262.89 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d8ad920-4cfd-4ffd-8dac-acaa70eb348d")
+	)
+	(wire
+		(pts
+			(xy 45.72 60.96) (xy 43.18 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2e7d5a12-37e6-4f18-8220-bab1a98e48a7")
+	)
+	(wire
+		(pts
+			(xy 72.39 104.14) (xy 72.39 125.73)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2ece91bd-5817-4200-ac7f-11792a244d66")
+	)
+	(wire
+		(pts
+			(xy 36.83 87.63) (xy 36.83 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2f65cdd9-21c5-43b6-ad78-6c22576e919f")
+	)
+	(wire
+		(pts
+			(xy 140.97 191.77) (xy 143.51 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2f8694fb-d7e1-4ff7-b233-2b1e0e89a2a0")
+	)
+	(wire
+		(pts
+			(xy 31.75 44.45) (xy 36.83 44.45)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2fe61f34-bcf8-49a9-8b23-187e87c6349c")
+	)
+	(wire
+		(pts
+			(xy 105.41 60.96) (xy 105.41 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3161c57f-2a27-409f-aeae-9f1e360aa44a")
+	)
+	(wire
+		(pts
+			(xy 54.61 88.9) (xy 60.96 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "331fd281-6aa8-455b-a792-8e60d1225ac3")
+	)
+	(wire
+		(pts
+			(xy 190.5 31.75) (xy 194.31 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "33880395-3412-4935-ae55-4d1a02ea11b3")
+	)
+	(wire
+		(pts
+			(xy 161.29 101.6) (xy 177.8 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "341910b7-d87d-4dd8-9cc5-13f7845cb899")
+	)
+	(wire
+		(pts
+			(xy 64.77 27.94) (xy 67.31 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "35712cc5-6346-42d6-97ca-b9af4ddff0de")
+	)
+	(wire
+		(pts
+			(xy 33.02 88.9) (xy 36.83 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3862b270-9043-4a9f-a16e-5f9883d727d6")
+	)
+	(wire
+		(pts
+			(xy 111.76 93.98) (xy 114.3 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a2b9db1-17d2-47e7-a685-7ea1b98a646f")
+	)
+	(wire
+		(pts
+			(xy 161.29 119.38) (xy 170.18 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a998f4e-54cc-4dc6-bafc-19afbfeab24a")
+	)
+	(wire
+		(pts
+			(xy 171.45 86.36) (xy 157.48 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3aa56749-41b4-4733-9bf4-a608d8b83b5d")
+	)
+	(wire
+		(pts
+			(xy 190.5 137.16) (xy 194.31 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b649d82-18f2-41d0-a97b-bded544abc4b")
+	)
+	(wire
+		(pts
+			(xy 234.95 43.18) (xy 234.95 45.72)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3bb89fab-c3e4-483e-87f3-44b4d36d1a1e")
+	)
+	(wire
+		(pts
+			(xy 67.31 27.94) (xy 69.85 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3c9283ea-8f18-484c-8395-d112caac26ef")
+	)
+	(wire
+		(pts
+			(xy 77.47 133.35) (xy 71.12 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e43cbc7-4b42-482f-a461-55767f062736")
+	)
+	(wire
+		(pts
+			(xy 46.99 180.34) (xy 52.07 180.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f05da57-fe55-4b78-81d0-76128bda1d66")
+	)
+	(wire
+		(pts
+			(xy 68.58 88.9) (xy 76.2 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f31c2ab-fda5-440d-bfd3-219288ac16b9")
+	)
+	(wire
+		(pts
+			(xy 119.38 27.94) (xy 121.92 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "44c5e640-2fb1-4da6-986d-27657827e9d0")
+	)
+	(wire
+		(pts
+			(xy 238.76 34.29) (xy 242.57 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "44e319f7-abd2-40a3-82c2-f182da6c25c1")
+	)
+	(wire
+		(pts
+			(xy 157.48 114.3) (xy 161.29 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "45b1f27a-f375-4495-bd91-59a8b7e0787a")
+	)
+	(wire
+		(pts
+			(xy 177.8 111.76) (xy 189.23 111.76)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "45ff6760-ea15-44d5-83ac-1b23340dd048")
+	)
+	(wire
+		(pts
+			(xy 161.29 109.22) (xy 179.07 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4608d120-6807-4a2a-b6f8-98ff93393f12")
+	)
+	(wire
+		(pts
+			(xy 209.55 96.52) (xy 209.55 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "461f8a18-5435-4c4e-95c7-474118b60c98")
+	)
+	(wire
+		(pts
+			(xy 101.6 93.98) (xy 111.76 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "46a7e2b7-8b76-43bc-8e98-40b7e78a16f6")
+	)
+	(wire
+		(pts
+			(xy 157.48 109.22) (xy 161.29 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "46ae839f-75d1-4afc-b1a8-8336c500df49")
+	)
+	(wire
+		(pts
+			(xy 161.29 35.56) (xy 163.83 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4730c87d-5dbf-4ca9-9051-7058d9c02690")
+	)
+	(wire
+		(pts
+			(xy 77.47 123.19) (xy 77.47 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "48a5c05b-06df-4104-9e9c-40b3dea96a23")
+	)
+	(wire
+		(pts
+			(xy 68.58 99.06) (xy 68.58 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "48b7e579-7a4c-4cd1-b9be-f12f7a0aa2d1")
+	)
+	(wire
+		(pts
+			(xy 267.97 85.09) (xy 265.43 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4906e5ab-8ac8-4adc-954d-0e4ffb80c78b")
+	)
+	(wire
+		(pts
+			(xy 205.74 152.4) (xy 210.82 152.4)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4a14aee1-92c4-4c19-aa15-cbad854852ca")
+	)
+	(wire
+		(pts
+			(xy 40.64 27.94) (xy 39.37 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4fbf9bdd-a3ae-489f-ae61-27169fcb68d6")
+	)
+	(wire
+		(pts
+			(xy 81.28 101.6) (xy 111.76 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "517b5782-8d90-48aa-b722-8a2859c7b139")
+	)
+	(wire
+		(pts
+			(xy 157.48 96.52) (xy 161.29 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5216187d-69ee-4a73-ac6d-561e8ff373fd")
+	)
+	(wire
+		(pts
+			(xy 157.48 99.06) (xy 161.29 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "522b2f25-c8c9-4797-b5e2-2413c5a9483c")
+	)
+	(wire
+		(pts
+			(xy 144.78 135.89) (xy 144.78 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "52d26c6a-9efc-461a-97e4-5a3a6381b196")
+	)
+	(wire
+		(pts
+			(xy 71.12 71.12) (xy 71.12 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "531640c5-3b42-4419-834e-ac2a9c56bff9")
+	)
+	(wire
+		(pts
+			(xy 236.22 34.29) (xy 238.76 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "534fbc92-4739-441d-98bb-9d97a511ff68")
+	)
+	(wire
+		(pts
+			(xy 157.48 111.76) (xy 161.29 111.76)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "541393f3-2a8c-47ea-9069-9b938d32fb81")
+	)
+	(wire
+		(pts
+			(xy 74.93 105.41) (xy 74.93 128.27)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5495b4ec-f230-430d-9e88-9cc9f8414cf7")
+	)
+	(wire
+		(pts
+			(xy 36.83 35.56) (xy 36.83 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "555a3626-fb24-4c4a-a6c2-82ef3480af5c")
+	)
+	(wire
+		(pts
+			(xy 46.99 129.54) (xy 46.99 132.08)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5676c50e-73d7-48d9-aca9-9488c668018e")
+	)
+	(wire
+		(pts
+			(xy 111.76 121.92) (xy 114.3 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "578eabd7-081b-4f8b-8fe6-f7e11a83ce34")
+	)
+	(wire
+		(pts
+			(xy 62.23 27.94) (xy 64.77 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "58082787-784d-45c5-9574-ce82374d0643")
+	)
+	(wire
+		(pts
+			(xy 72.39 96.52) (xy 72.39 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5899bd74-597f-4bb3-a0ad-cdf4267f5297")
+	)
+	(wire
+		(pts
+			(xy 266.7 148.59) (xy 274.32 148.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "58b6dc11-58e4-4e0a-9b0e-3020e5cdcafb")
+	)
+	(wire
+		(pts
+			(xy 175.26 31.75) (xy 175.26 19.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "59042357-1906-4cc3-8728-aac7327f825e")
+	)
+	(wire
+		(pts
+			(xy 50.8 139.7) (xy 50.8 125.73)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "59789abf-2b3b-4570-aca7-686343642e49")
+	)
+	(wire
+		(pts
+			(xy 55.88 33.02) (xy 62.23 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5a37c812-2d01-4842-a654-68f469573638")
+	)
+	(wire
+		(pts
+			(xy 60.96 88.9) (xy 60.96 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b28062c-03c8-4f62-89d6-a412e40bee1f")
+	)
+	(wire
+		(pts
+			(xy 46.99 185.42) (xy 48.26 185.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5c201be8-28a4-4de5-b9ec-6e2bdb173590")
+	)
+	(wire
+		(pts
+			(xy 78.74 99.06) (xy 111.76 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f343bf7-3585-409f-933e-ce876c69aaf9")
+	)
+	(wire
+		(pts
+			(xy 101.6 63.5) (xy 101.6 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60a933e2-aa33-40c6-80d2-133e9d882435")
+	)
+	(wire
+		(pts
+			(xy 194.31 31.75) (xy 194.31 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6178ebd8-b2f9-4ffe-9f35-5c459968cd00")
+	)
+	(wire
+		(pts
+			(xy 99.06 116.84) (xy 111.76 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "61a1ae6a-ee06-4a5d-b30c-db02755c70ee")
+	)
+	(wire
+		(pts
+			(xy 101.6 182.88) (xy 100.33 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "623f9f16-c117-4c45-8b1d-ca84801100cf")
+	)
+	(wire
+		(pts
+			(xy 60.96 99.06) (xy 60.96 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62441b8e-bff5-49b1-a485-4272e3dfdfdd")
+	)
+	(wire
+		(pts
+			(xy 100.33 185.42) (xy 101.6 185.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "624c4d6f-3e9e-4785-83b1-f81f96168a9d")
+	)
+	(wire
+		(pts
+			(xy 149.86 46.99) (xy 147.32 46.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "625a7cfc-5eb2-4026-9c29-b2abfc485af5")
+	)
+	(wire
+		(pts
+			(xy 64.77 24.13) (xy 64.77 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62ec098b-1fce-414d-b5ab-faaa33f2b273")
+	)
+	(wire
+		(pts
+			(xy 124.46 135.89) (xy 124.46 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6804cb72-ea5e-4f82-8dd9-be415086da09")
+	)
+	(wire
+		(pts
+			(xy 86.36 27.94) (xy 119.38 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "691c947a-c326-4585-86df-5f2b82ecd531")
+	)
+	(wire
+		(pts
+			(xy 161.29 106.68) (xy 171.45 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "694cc900-10e7-4769-812b-0a9a46c6ea4a")
+	)
+	(wire
+		(pts
+			(xy 140.97 189.23) (xy 143.51 189.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "695d0127-ac63-4825-8ae2-e06395533d4b")
+	)
+	(wire
+		(pts
+			(xy 17.78 88.9) (xy 25.4 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "697fd977-9eaa-4dd2-8642-26fb12dc66e4")
+	)
+	(wire
+		(pts
+			(xy 156.21 27.94) (xy 156.21 26.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "69861798-e967-44ca-a012-573f6c16bb26")
+	)
+	(wire
+		(pts
+			(xy 64.77 60.96) (xy 57.15 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6a44e070-8bd0-4048-97b7-e4b94fe9a0ad")
+	)
+	(wire
+		(pts
+			(xy 45.72 27.94) (xy 49.53 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6af8e452-28b4-4e97-9ec5-d0550a3fd366")
+	)
+	(wire
+		(pts
+			(xy 121.92 146.05) (xy 124.46 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6b2dfce6-bfda-4035-ac32-c246a06648d5")
+	)
+	(wire
+		(pts
+			(xy 101.6 119.38) (xy 111.76 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6b59a1c2-62df-4fec-be2a-d842d77efa80")
+	)
+	(wire
+		(pts
+			(xy 66.04 181.61) (xy 69.85 181.61)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6be81913-a9c9-4a7c-bf3a-56db5f50ce5d")
+	)
+	(wire
+		(pts
+			(xy 105.41 140.97) (xy 105.41 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6c7bbb88-517f-4bee-b9cf-cdef44a0d7ea")
+	)
+	(wire
+		(pts
+			(xy 57.15 27.94) (xy 62.23 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6ca2b0df-d934-40c7-af5e-aebad87786c0")
+	)
+	(wire
+		(pts
+			(xy 48.26 189.23) (xy 46.99 189.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6d978f74-8ea9-4ff6-b8e5-8673b23c63d6")
+	)
+	(wire
+		(pts
+			(xy 96.52 63.5) (xy 101.6 63.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6e87f750-b4b1-4063-94b8-f53b8d289f05")
+	)
+	(wire
+		(pts
+			(xy 194.31 38.1) (xy 193.04 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f6bc88b-0171-4d91-a248-c603415eaeff")
+	)
+	(wire
+		(pts
+			(xy 111.76 91.44) (xy 114.3 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6ff1ff0e-4dca-4600-9b26-8b625ebcd038")
+	)
+	(wire
+		(pts
+			(xy 163.83 27.94) (xy 167.64 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "71cfaf8b-2e6e-4844-bcc1-42e0f236d310")
+	)
+	(wire
+		(pts
+			(xy 171.45 87.63) (xy 173.99 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "731ed305-46de-41e1-bff1-52902ae0b1c4")
+	)
+	(wire
+		(pts
+			(xy 35.56 93.98) (xy 35.56 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "74261126-978c-4708-9d14-9158d606d1af")
+	)
+	(wire
+		(pts
+			(xy 129.54 135.89) (xy 129.54 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "75c1ebe6-53b3-4917-afb1-09bb98e450bb")
+	)
+	(wire
+		(pts
+			(xy 190.5 137.16) (xy 190.5 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "76d1aef2-fb53-4d4f-9616-20e485006328")
+	)
+	(wire
+		(pts
+			(xy 71.12 80.01) (xy 49.53 80.01)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "76f6150c-1a8d-457f-b5da-7b41007c7db5")
+	)
+	(wire
+		(pts
+			(xy 101.6 140.97) (xy 101.6 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "774a662d-4138-4617-bc63-eea1b3e25dca")
+	)
+	(wire
+		(pts
+			(xy 119.38 36.83) (xy 119.38 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "77648e31-bba4-48bd-afa4-a2a28192e442")
+	)
+	(wire
+		(pts
+			(xy 26.67 44.45) (xy 29.21 44.45)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "78d98b38-a8c6-4b76-87b4-989f4c06eb27")
+	)
+	(wire
+		(pts
+			(xy 273.05 43.18) (xy 273.05 45.72)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a87bbf2-0a7f-4c21-a15d-659ec40e0d18")
+	)
+	(wire
+		(pts
+			(xy 269.24 111.76) (xy 266.7 111.76)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7aba6ff9-f6e8-4dec-8e17-5c7f3afb55b1")
+	)
+	(wire
+		(pts
+			(xy 53.34 128.27) (xy 74.93 128.27)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7b4ec8a9-6ee8-4ea2-a978-9223cce3549f")
+	)
+	(wire
+		(pts
+			(xy 101.6 71.12) (xy 101.6 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7d0413b3-7afa-4ccb-b9a6-16e191a7fa34")
+	)
+	(wire
+		(pts
+			(xy 100.33 191.77) (xy 101.6 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7d2becc5-53f7-4376-8dc4-32d2a3543fd1")
+	)
+	(wire
+		(pts
+			(xy 274.32 137.16) (xy 266.7 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7d571609-6a69-41ff-a28d-2224c15c2cbc")
+	)
+	(wire
+		(pts
+			(xy 76.2 88.9) (xy 76.2 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7d642da2-ba9a-44bd-8f1d-58f793497ec9")
+	)
+	(wire
+		(pts
+			(xy 157.48 104.14) (xy 161.29 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7e1c7490-0636-44f0-add4-c3505e733d7e")
+	)
+	(wire
+		(pts
+			(xy 273.05 34.29) (xy 275.59 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7e39ca3c-b0d2-4805-9e0c-bb19e9fba8d0")
+	)
+	(wire
+		(pts
+			(xy 57.15 66.04) (xy 55.88 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7f8a5044-d337-47ff-8e27-132ba923f90d")
+	)
+	(wire
+		(pts
+			(xy 157.48 88.9) (xy 161.29 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "81363b2d-0a37-4e94-b942-de620bf8dd10")
+	)
+	(wire
+		(pts
+			(xy 81.28 101.6) (xy 81.28 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8156a450-2657-41a8-9899-ad0a6118022a")
+	)
+	(wire
+		(pts
+			(xy 43.18 66.04) (xy 45.72 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "817f8498-e6b0-4924-95a0-2b9dfe56ae88")
+	)
+	(wire
+		(pts
+			(xy 85.09 63.5) (xy 85.09 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "81b77e27-07b2-4383-b655-e605a64714a4")
+	)
+	(wire
+		(pts
+			(xy 52.07 137.16) (xy 55.88 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "828bd17d-c5e8-416a-b5e9-57737db12a97")
+	)
+	(wire
+		(pts
+			(xy 142.24 135.89) (xy 142.24 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "82b215f1-1dd7-4ecd-bcb6-375f3405bd31")
+	)
+	(wire
+		(pts
+			(xy 36.83 27.94) (xy 35.56 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "82b6f929-9ce7-48fa-b6df-8d394b178747")
+	)
+	(wire
+		(pts
+			(xy 48.26 191.77) (xy 46.99 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8598184d-b7ab-4b13-a1e9-766fd487e24d")
+	)
+	(wire
+		(pts
+			(xy 93.98 88.9) (xy 111.76 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "86135405-fa22-4447-ae20-e586f7e44ce2")
+	)
+	(wire
+		(pts
+			(xy 49.53 88.9) (xy 54.61 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "871d9c71-c258-41e6-98e4-70483c3d6775")
+	)
+	(wire
+		(pts
+			(xy 179.07 134.62) (xy 173.99 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "879a58ff-f4c7-4faf-8d52-002e7460e21e")
+	)
+	(wire
+		(pts
+			(xy 35.56 33.02) (xy 35.56 36.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "88485288-4500-47f3-a57c-7d2569fb56ed")
+	)
+	(wire
+		(pts
+			(xy 71.12 71.12) (xy 85.09 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "885defbb-9402-454e-9c19-2a3a9b6d317c")
+	)
+	(wire
+		(pts
+			(xy 161.29 93.98) (xy 176.53 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "890f181a-cfcd-49ec-926f-b55166d1b6f7")
+	)
+	(wire
+		(pts
+			(xy 161.29 88.9) (xy 171.45 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "89c3f855-845a-4471-8c79-0ee0530b50c4")
+	)
+	(wire
+		(pts
+			(xy 21.59 93.98) (xy 21.59 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "89ef6afe-0ce0-4eae-81a5-152f8b07d258")
+	)
+	(wire
+		(pts
+			(xy 71.12 133.35) (xy 71.12 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8a55ce41-13af-4d76-ab78-b2d1fa9bd055")
+	)
+	(wire
+		(pts
+			(xy 64.77 22.86) (xy 64.77 24.13)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8b78a3fc-4347-44dc-a512-456515762b9c")
+	)
+	(wire
+		(pts
+			(xy 71.12 134.62) (xy 81.28 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8cca549c-fd14-4368-8b72-e508e0d79ef0")
+	)
+	(wire
+		(pts
+			(xy 224.79 34.29) (xy 234.95 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d23800f-9449-43bd-8122-fa504f4747c0")
+	)
+	(wire
+		(pts
+			(xy 262.89 34.29) (xy 273.05 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8df9065a-bfee-4b53-a3ac-14801da8192f")
+	)
+	(wire
+		(pts
+			(xy 36.83 44.45) (xy 36.83 45.72)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "906fa46a-7dd7-4a69-8896-82d82a5f98ce")
+	)
+	(wire
+		(pts
+			(xy 38.1 66.04) (xy 43.18 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "90949bf3-bde3-47ee-9e98-ba88cb95d6eb")
+	)
+	(wire
+		(pts
+			(xy 60.96 105.41) (xy 74.93 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9215bbeb-105f-4d14-b378-6481bab00b8f")
+	)
+	(wire
+		(pts
+			(xy 111.76 106.68) (xy 114.3 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "923dc0be-c4e1-4f46-b01c-3e9fdaea3f65")
+	)
+	(wire
+		(pts
+			(xy 190.5 134.62) (xy 190.5 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "92538116-995e-4d74-b1ee-6eefe22e73c7")
+	)
+	(wire
+		(pts
+			(xy 73.66 142.24) (xy 73.66 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "92d8800c-4713-4ffd-a35c-cbb2e7166078")
+	)
+	(wire
+		(pts
+			(xy 166.37 46.99) (xy 157.48 46.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "946176c8-8081-4101-a7f8-94c2216345cc")
+	)
+	(wire
+		(pts
+			(xy 31.75 49.53) (xy 31.75 44.45)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94ac6993-3218-41cc-8aac-ba6e504e0868")
+	)
+	(wire
+		(pts
+			(xy 119.38 29.21) (xy 119.38 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "95414291-1ffd-445c-a597-b58b34bef509")
+	)
+	(wire
+		(pts
+			(xy 35.56 36.83) (xy 29.21 36.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "95efc0c1-80d7-48c3-b5f8-3e7f38fb46d6")
+	)
+	(wire
+		(pts
+			(xy 161.29 99.06) (xy 171.45 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "95fb9b57-3c5c-4512-9dfc-f77658a5a945")
+	)
+	(wire
+		(pts
+			(xy 157.48 93.98) (xy 161.29 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9633cc63-4921-47e2-824e-417d3454ef3e")
+	)
+	(wire
+		(pts
+			(xy 210.82 139.7) (xy 210.82 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "96dfed56-73be-4d8a-95fc-f078974b8349")
+	)
+	(wire
+		(pts
+			(xy 140.97 185.42) (xy 144.78 185.42)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "97f18940-42e0-4e0b-b2b0-1d7dfd1d616e")
+	)
+	(wire
+		(pts
+			(xy 161.29 114.3) (xy 179.07 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9862760b-77f5-41e5-a0da-be1445a40e6d")
+	)
+	(wire
+		(pts
+			(xy 280.67 34.29) (xy 280.67 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9ab4a278-05cc-4ca8-9949-eb0c29727754")
+	)
+	(wire
+		(pts
+			(xy 214.63 29.21) (xy 214.63 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9aea3c55-b2f2-4299-b0ee-529165c76e07")
+	)
+	(wire
+		(pts
+			(xy 210.82 127) (xy 210.82 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9bd11fcd-4da2-4d2a-8f82-e7a6d0028191")
+	)
+	(wire
+		(pts
+			(xy 72.39 96.52) (xy 111.76 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c46fae2-b8e2-44c7-8c42-79ef78582e3c")
+	)
+	(wire
+		(pts
+			(xy 134.62 135.89) (xy 134.62 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a0091a17-892f-4799-86ed-50c9454a0477")
+	)
+	(wire
+		(pts
+			(xy 163.83 35.56) (xy 163.83 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a07a2b73-2a24-484f-89df-c2ee38f6aa4b")
+	)
+	(wire
+		(pts
+			(xy 127 135.89) (xy 127 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a11397fa-8c25-41b3-b548-810999fe71ac")
+	)
+	(wire
+		(pts
+			(xy 71.12 189.23) (xy 77.47 189.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a27b8122-7c38-468f-8e80-7984351b810f")
+	)
+	(wire
+		(pts
+			(xy 29.21 36.83) (xy 29.21 44.45)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a3c1a6ff-8a21-4fea-87ec-c5cf6716c332")
+	)
+	(wire
+		(pts
+			(xy 36.83 43.18) (xy 36.83 44.45)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a476ec8c-a62f-4c77-a591-48b3bef849eb")
+	)
+	(wire
+		(pts
+			(xy 95.25 106.68) (xy 111.76 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a51201ce-1353-47ff-affc-a923b3ba2066")
+	)
+	(wire
+		(pts
+			(xy 210.82 142.24) (xy 210.82 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a5450344-b5d1-4997-b7ca-fce6b1525402")
+	)
+	(wire
+		(pts
+			(xy 139.7 166.37) (xy 119.38 166.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a5f23641-5a26-4fba-ab74-a7d2446074ba")
+	)
+	(wire
+		(pts
+			(xy 95.25 114.3) (xy 111.76 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a60b7e43-cfb2-4f6b-a164-d2899332fdc9")
+	)
+	(wire
+		(pts
+			(xy 189.23 91.44) (xy 190.5 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a804039b-8dac-4be9-8d1c-f53ef1c68693")
+	)
+	(wire
+		(pts
+			(xy 147.32 138.43) (xy 147.32 153.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a8ced33a-fed0-4d4d-b300-e4fff4ab72e9")
+	)
+	(wire
+		(pts
+			(xy 111.76 101.6) (xy 114.3 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aa3571e0-51c2-4c46-b768-306543f56461")
+	)
+	(wire
+		(pts
+			(xy 217.17 149.86) (xy 210.82 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "abaa63e1-24ad-411f-b914-2666c1827d4b")
+	)
+	(wire
+		(pts
+			(xy 151.13 35.56) (xy 151.13 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "abeb9fe9-dc98-44ab-ab3b-742c8d493c6b")
+	)
+	(wire
+		(pts
+			(xy 69.85 41.91) (xy 69.85 43.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ac226511-41fc-4e4b-9810-f755e03f681e")
+	)
+	(wire
+		(pts
+			(xy 21.59 176.53) (xy 24.13 176.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ac41630d-ce9e-412f-bbde-7e4f7cc0dab5")
+	)
+	(wire
+		(pts
+			(xy 78.74 99.06) (xy 78.74 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad38da87-0b42-4c3e-a776-63a5194b84f1")
+	)
+	(wire
+		(pts
+			(xy 210.82 125.73) (xy 210.82 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ae70448e-542d-431e-8f38-62a2358dade0")
+	)
+	(wire
+		(pts
+			(xy 111.76 109.22) (xy 114.3 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aef5f99d-7693-4429-80b7-bd3798a67045")
+	)
+	(wire
+		(pts
+			(xy 35.56 30.48) (xy 35.56 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "afdf75e6-8996-4246-a688-6d377984791d")
+	)
+	(wire
+		(pts
+			(xy 78.74 40.64) (xy 78.74 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aff5ea89-86a6-4e3e-a187-dc2b99f64ddf")
+	)
+	(wire
+		(pts
+			(xy 99.06 140.97) (xy 99.06 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b016e04d-c0bf-4a86-9b6c-bcf76ace7247")
+	)
+	(wire
+		(pts
+			(xy 161.29 121.92) (xy 173.99 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b111959d-5779-4cc6-b5da-993d38612d12")
+	)
+	(wire
+		(pts
+			(xy 132.08 135.89) (xy 132.08 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b2d28381-1776-43f5-8102-e6638e6e772e")
+	)
+	(wire
+		(pts
+			(xy 53.34 128.27) (xy 53.34 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3c41e09-515f-490e-8188-e2dd71cba849")
+	)
+	(wire
+		(pts
+			(xy 69.85 27.94) (xy 71.12 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b41eec96-de99-4cca-a174-16528685c0a2")
+	)
+	(wire
+		(pts
+			(xy 275.59 30.48) (xy 275.59 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b6a9be71-0b37-4365-aaef-2b3a701edc88")
+	)
+	(wire
+		(pts
+			(xy 144.78 138.43) (xy 144.78 153.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b79f7f0c-b1e5-449e-ad50-c2d15a8e8871")
+	)
+	(wire
+		(pts
+			(xy 35.56 25.4) (xy 35.56 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7a9536a-7f29-4bd7-8049-6368db1d7124")
+	)
+	(wire
+		(pts
+			(xy 157.48 121.92) (xy 161.29 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7c05c66-57ba-4502-a290-19af8c44cb47")
+	)
+	(wire
+		(pts
+			(xy 21.59 104.14) (xy 21.59 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7c5e5bf-4f0d-4eaa-89fa-e2ffac52b38d")
+	)
+	(wire
+		(pts
+			(xy 217.17 134.62) (xy 210.82 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7d07269-7836-4faa-b058-a3eb1186395f")
+	)
+	(wire
+		(pts
+			(xy 111.76 114.3) (xy 114.3 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b8130a4c-8d3a-4161-aa72-9f22cac050f8")
+	)
+	(wire
+		(pts
+			(xy 60.96 24.13) (xy 64.77 24.13)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b86e5e46-e623-470f-aab4-0a654715c7c1")
+	)
+	(wire
+		(pts
+			(xy 161.29 91.44) (xy 181.61 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b9a2b5de-0a55-46d7-8ed8-9d130d3feea3")
+	)
+	(wire
+		(pts
+			(xy 210.82 134.62) (xy 210.82 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b9de82ac-e92f-4c86-95ef-5d2acd3ee878")
+	)
+	(wire
+		(pts
+			(xy 157.48 101.6) (xy 161.29 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb296156-184f-474b-8d0b-88ca4c72a2d7")
+	)
+	(wire
+		(pts
+			(xy 127 138.43) (xy 127 151.13)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bbfbfc68-0cb4-4bfa-832c-87aa503264be")
+	)
+	(wire
+		(pts
+			(xy 158.75 27.94) (xy 163.83 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bcb27b86-fc52-4c42-ad8a-2c4a60749310")
+	)
+	(wire
+		(pts
+			(xy 186.69 114.3) (xy 189.23 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bcb6d768-6a47-46c7-ad29-cf6300ebc86f")
+	)
+	(wire
+		(pts
+			(xy 73.66 139.7) (xy 71.12 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bd6bcb21-0982-470d-837e-d2fba9d96e68")
+	)
+	(wire
+		(pts
+			(xy 147.32 135.89) (xy 147.32 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bda5acc5-34c2-4142-8def-aa7a9c193d5e")
+	)
+	(wire
+		(pts
+			(xy 269.24 121.92) (xy 266.7 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bdae4942-d901-4085-99f3-d1b5a1aa6f74")
+	)
+	(wire
+		(pts
+			(xy 133.35 36.83) (xy 133.35 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "be215129-36e4-4e28-bcda-921e58bb5581")
+	)
+	(wire
+		(pts
+			(xy 243.84 123.19) (xy 246.38 123.19)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "be64f0af-d65c-4ef1-8ab0-ff1186c81f83")
+	)
+	(wire
+		(pts
+			(xy 36.83 88.9) (xy 40.64 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c119fda0-285c-432e-8fce-a04f70bdca4c")
+	)
+	(wire
+		(pts
+			(xy 74.93 105.41) (xy 78.74 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3f0fee0-b339-4d2f-b88d-939e34e025e2")
+	)
+	(wire
+		(pts
+			(xy 234.95 34.29) (xy 236.22 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c50847a2-09a5-4f67-885e-41433f06da2b")
+	)
+	(wire
+		(pts
+			(xy 147.32 27.94) (xy 151.13 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c55c82e9-00b6-457c-8ead-5b9658f6d6e1")
+	)
+	(wire
+		(pts
+			(xy 209.55 97.79) (xy 171.45 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c6330d00-8001-4b9a-aa07-6099bb7fe3f4")
+	)
+	(wire
+		(pts
+			(xy 105.41 72.39) (xy 101.6 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c92c5c65-793c-4074-9a61-6ec4ebe90f90")
+	)
+	(wire
+		(pts
+			(xy 52.07 144.78) (xy 52.07 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca9797da-1d82-4438-b60f-a8825b6bf7bd")
+	)
+	(wire
+		(pts
+			(xy 179.07 134.62) (xy 180.34 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cab728af-011a-4c57-98be-d036c4c60962")
+	)
+	(wire
+		(pts
+			(xy 33.02 80.01) (xy 33.02 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb7adfc4-ae2e-4bcc-a684-93ad2c4e0163")
+	)
+	(wire
+		(pts
+			(xy 62.23 27.94) (xy 62.23 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cee93102-27c6-47f9-8fbd-8dea24274cf5")
+	)
+	(wire
+		(pts
+			(xy 171.45 99.06) (xy 175.26 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cf9d2d25-48ff-4409-9cee-563c72613003")
+	)
+	(wire
+		(pts
+			(xy 111.76 111.76) (xy 114.3 111.76)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d0eb0eea-7067-4655-93c1-b055dca1317a")
+	)
+	(wire
+		(pts
+			(xy 190.5 27.94) (xy 190.5 26.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d186982d-7de4-4661-af4e-3b388f86da9b")
+	)
+	(wire
+		(pts
+			(xy 63.5 129.54) (xy 46.99 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d20d10fb-98c0-489d-8596-6637a9f2bfd4")
+	)
+	(wire
+		(pts
+			(xy 171.45 87.63) (xy 171.45 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d22f21b6-d0da-4a23-8747-42409ef226c2")
+	)
+	(wire
+		(pts
+			(xy 173.99 134.62) (xy 173.99 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2bdf1ec-ef61-4ec8-9a64-eb6b363f4b22")
+	)
+	(wire
+		(pts
+			(xy 184.15 38.1) (xy 184.15 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2e0f101-8308-480f-b3c1-4da5e551a04e")
+	)
+	(wire
+		(pts
+			(xy 137.16 27.94) (xy 147.32 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d3d8b3a4-da4a-406f-b5e4-71ec7321f954")
+	)
+	(wire
+		(pts
+			(xy 266.7 140.97) (xy 274.32 140.97)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d4aa9520-c696-40ed-b309-e5c63619d093")
+	)
+	(wire
+		(pts
+			(xy 90.17 71.12) (xy 85.09 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d6c59023-2144-4a29-b58b-21a755f77350")
+	)
+	(wire
+		(pts
+			(xy 95.25 140.97) (xy 95.25 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d83a0525-0045-43d6-b38e-e90d4af6e38b")
+	)
+	(wire
+		(pts
+			(xy 217.17 127) (xy 210.82 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d8705b57-0942-45fa-9a23-d5d53a1e0112")
+	)
+	(wire
+		(pts
+			(xy 274.32 144.78) (xy 266.7 144.78)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "da113ef5-6fe8-414b-b168-3be7d62ff95d")
+	)
+	(wire
+		(pts
+			(xy 269.24 109.22) (xy 266.7 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "da941a4d-535c-46dd-9506-9a1f105eb07a")
+	)
+	(wire
+		(pts
+			(xy 259.08 34.29) (xy 262.89 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ddc90e1e-01b1-495e-b136-102a14921c41")
+	)
+	(wire
+		(pts
+			(xy 60.96 88.9) (xy 68.58 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df0b8206-8ee3-455c-ae85-a636c2af18bc")
+	)
+	(wire
+		(pts
+			(xy 76.2 91.44) (xy 111.76 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df92658c-758b-47c3-9f1a-302b0da1b36b")
+	)
+	(wire
+		(pts
+			(xy 111.76 99.06) (xy 114.3 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e009fedf-a80f-4d86-bc36-1149b5a9713a")
+	)
+	(wire
+		(pts
+			(xy 242.57 34.29) (xy 243.84 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e0d9468d-ca69-4fb5-b09b-bae5e03c47b3")
+	)
+	(wire
+		(pts
+			(xy 186.69 109.22) (xy 187.96 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e1bbbcec-f562-49e7-8ace-ad521d186d52")
+	)
+	(wire
+		(pts
+			(xy 210.82 152.4) (xy 210.82 153.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e1cf445d-6652-44ae-a67e-987ca5db2ca7")
+	)
+	(wire
+		(pts
+			(xy 68.58 104.14) (xy 72.39 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e2975829-0eb7-467b-9ce9-526de8d8bca5")
+	)
+	(wire
+		(pts
+			(xy 193.04 27.94) (xy 190.5 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e2c56d74-fa93-4234-8f2d-b6cd9bc778fc")
+	)
+	(wire
+		(pts
+			(xy 267.97 92.71) (xy 265.43 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e437264a-2893-4983-9d20-90f356e33265")
+	)
+	(wire
+		(pts
+			(xy 139.7 135.89) (xy 139.7 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e4b0b187-969f-48cb-bb04-1d8228ef0d51")
+	)
+	(wire
+		(pts
+			(xy 101.6 189.23) (xy 100.33 189.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e66d62e6-b777-4f62-bb49-c471581fe623")
+	)
+	(wire
+		(pts
+			(xy 185.42 38.1) (xy 184.15 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6902e20-f118-4811-a431-decb652c2bd9")
+	)
+	(wire
+		(pts
+			(xy 21.59 92.71) (xy 35.56 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e7cb38a7-1a88-4af1-a135-94afb4068d9b")
+	)
+	(wire
+		(pts
+			(xy 157.48 106.68) (xy 161.29 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e89349a1-0955-4ab6-9212-43fb7a67da06")
+	)
+	(wire
+		(pts
+			(xy 111.76 104.14) (xy 114.3 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e9750486-8899-4994-a5c9-dbfd83dde26a")
+	)
+	(wire
+		(pts
+			(xy 111.76 116.84) (xy 114.3 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ec47447d-773a-4bcd-84f4-7f081a3e0902")
+	)
+	(wire
+		(pts
+			(xy 157.48 116.84) (xy 161.29 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef1ff236-1b61-4d16-9cae-0683020d3aab")
+	)
+	(wire
+		(pts
+			(xy 35.56 33.02) (xy 33.02 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef6b7de1-d99d-4417-a150-1b09ec049a3b")
+	)
+	(wire
+		(pts
+			(xy 187.96 31.75) (xy 184.15 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef866b12-abaf-4f18-b848-9168c4af126c")
+	)
+	(wire
+		(pts
+			(xy 88.9 63.5) (xy 85.09 63.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f070043f-4f08-4434-ad66-8c419f58c0e4")
+	)
+	(wire
+		(pts
+			(xy 171.45 86.36) (xy 171.45 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f0c1f3e1-0b68-4b77-9e60-4b6b3245f5ac")
+	)
+	(wire
+		(pts
+			(xy 57.15 60.96) (xy 55.88 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f1764a93-95af-4bea-aede-f0673319fc8e")
+	)
+	(wire
+		(pts
+			(xy 92.71 140.97) (xy 92.71 111.76)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f18992fb-6484-4baf-add4-7036a5d39376")
+	)
+	(wire
+		(pts
+			(xy 54.61 99.06) (xy 54.61 123.19)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f264ac9a-c4b7-4471-af16-acda245fcb9d")
+	)
+	(wire
+		(pts
+			(xy 68.58 88.9) (xy 68.58 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f346cfd6-96ee-45f9-9eab-78241f4ab3a8")
+	)
+	(wire
+		(pts
+			(xy 194.31 137.16) (xy 194.31 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4ac11f2-e892-41cd-892f-55245b99640d")
+	)
+	(wire
+		(pts
+			(xy 72.39 60.96) (xy 105.41 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4edecc3-61b7-4001-b758-e1a741cb679c")
+	)
+	(wire
+		(pts
+			(xy 35.56 92.71) (xy 40.64 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f577c61e-a3da-4892-aeba-895c8ef0c49e")
+	)
+	(wire
+		(pts
+			(xy 21.59 182.88) (xy 24.13 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f57dbda5-ccc6-439f-a053-aeb32530f8f4")
+	)
+	(wire
+		(pts
+			(xy 101.6 72.39) (xy 101.6 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f5b16b93-17a2-4176-8caa-e3b67c87eb3c")
+	)
+	(wire
+		(pts
+			(xy 43.18 66.04) (xy 43.18 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f5d35921-24f0-493d-a36d-b4153be1a2f2")
+	)
+	(wire
+		(pts
+			(xy 101.6 74.93) (xy 101.6 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f6100c17-3c50-4045-addd-f0629a8cce53")
+	)
+	(wire
+		(pts
+			(xy 40.64 88.9) (xy 49.53 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f642fcbd-2380-45c6-afff-38ac267774f1")
+	)
+	(wire
+		(pts
+			(xy 55.88 40.64) (xy 55.88 43.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f6e816b1-a4e5-4421-a6e5-1d4f494c3f69")
+	)
+	(wire
+		(pts
+			(xy 35.56 102.87) (xy 35.56 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f8237b43-684f-4512-bf1d-7181f894ea44")
+	)
+	(wire
+		(pts
+			(xy 275.59 34.29) (xy 280.67 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f8d0c5c6-271f-49b8-84b8-cce77cd340e4")
+	)
+	(wire
+		(pts
+			(xy 35.56 27.94) (xy 33.02 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f902e4e8-9ee1-4a25-9265-d1dd56c6a813")
+	)
+	(wire
+		(pts
+			(xy 77.47 74.93) (xy 101.6 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f9ae06e3-5a83-4d3b-848c-71ca2b09c7d2")
+	)
+	(wire
+		(pts
+			(xy 207.01 139.7) (xy 210.82 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fbc9d5b4-5c39-445f-9c51-50a40df05e14")
+	)
+	(wire
+		(pts
+			(xy 151.13 27.94) (xy 156.21 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fd517522-94a0-4241-a9f7-b66adeff577e")
+	)
+	(wire
+		(pts
+			(xy 161.29 96.52) (xy 191.77 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fdfca061-a266-45db-91b4-1e37f59e7c1b")
+	)
+	(wire
+		(pts
+			(xy 50.8 125.73) (xy 72.39 125.73)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fe3c454f-e1ab-46a1-8bdf-347583c6c0f8")
+	)
+	(wire
+		(pts
+			(xy 77.47 82.55) (xy 69.85 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fe721fc3-087c-4082-aa8a-a262784e7618")
+	)
+	(image
+		(at 244.475 174.625)
+		(scale 0.2225)
+		(uuid "a2f33916-4f74-46ac-8520-7c0afb889453")
+		(data "iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz"
+			"AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h"
+			"aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73"
+			"+/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA"
+			"xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y"
+			"Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h"
+			"xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO"
+			"GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful"
+			"fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv"
+			"4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ"
+			"EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R"
+			"Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM"
+			"vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H"
+			"cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0"
+			"6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT"
+			"O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA"
+			"4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86"
+			"sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+"
+			"oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/"
+			"55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0"
+			"qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+"
+			"KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn"
+			"Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4"
+			"mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii"
+			"P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr"
+			"voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6"
+			"bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO"
+			"h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da"
+			"4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y"
+			"YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC"
+			"0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP"
+			"SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb"
+			"WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw"
+			"v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay"
+			"PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX"
+			"Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh"
+			"oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD"
+			"7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da"
+			"43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l"
+			"zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl"
+			"pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS"
+			"H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV"
+			"ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY"
+			"MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2"
+			"NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx"
+			"fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl"
+			"tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew"
+			"iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj"
+			"jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI"
+			"cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo"
+			"XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R"
+			"9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv"
+			"8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV"
+			"RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY"
+			"l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf"
+			"YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN"
+			"EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU"
+			"sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z"
+			"7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs"
+			"OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs"
+			"qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7"
+			"G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6"
+			"wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7"
+			"zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln"
+			"Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX"
+			"apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk"
+			"lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw"
+			"TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb"
+			"54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID"
+			"qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd"
+			"P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l"
+			"UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD"
+			"zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH"
+			"Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1"
+			"QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/"
+			"ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX"
+			"08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC"
+			"KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ"
+			"SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu"
+			"h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp"
+			"VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf"
+			"G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK"
+			"dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO"
+			"uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2"
+			"DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn"
+			"byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc"
+			"dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N"
+			"iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP"
+			"NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4"
+			"wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8"
+			"K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s"
+			"xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS"
+			"Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC"
+			"Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5"
+			"m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm"
+			"aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj"
+			"gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn"
+			"p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL"
+			"ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx"
+			"u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+"
+			"FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa"
+			"ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h"
+			"1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj"
+			"DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy"
+			"+Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj"
+			"wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj"
+			"7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ"
+			"lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN"
+			"2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY"
+			"CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi"
+			"mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E"
+			"uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x"
+			"j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD"
+			"45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO"
+			"4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni"
+			"buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY"
+			"HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH"
+			"NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ"
+			"azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N"
+			"SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP"
+			"hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe"
+			"nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4"
+			"b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN"
+			"xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S"
+			"pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq"
+			"3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB"
+			"Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL"
+			"4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw"
+			"qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX"
+			"9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n"
+			"frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/"
+			"eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK"
+			"TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u"
+			"RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9"
+			"DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j"
+			"2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx"
+			"BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy"
+			"91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7"
+			"jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw"
+			"pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ"
+			"cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M"
+			"xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23"
+			"7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8"
+			"D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw"
+			"YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu"
+			"QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs"
+			"uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA"
+			"PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6"
+			"yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN"
+			"xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq"
+			"JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT"
+			"+HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg"
+			"hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K"
+			"hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt"
+			"g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z"
+			"5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf"
+			"u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO"
+			"Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG"
+			"gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK"
+			"hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x"
+			"moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56"
+			"KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp"
+			"ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz"
+			"eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO"
+			"0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA"
+			"BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ"
+			"2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB"
+			"4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF"
+			"6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI"
+			"gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv"
+			"OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt"
+			"8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI"
+			"bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM"
+			"500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4"
+			"CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V"
+			"aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5"
+			"yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF"
+			"zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss"
+			"tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q"
+			"r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj"
+			"xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h"
+			"6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y"
+			"9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE"
+			"XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh"
+			"oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk"
+			"Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4"
+			"ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW"
+			"zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr"
+			"wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV"
+			"BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7"
+			"LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr"
+			"owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX"
+			"hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j"
+			"1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF"
+			"5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw"
+			"a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6"
+			"Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN"
+			"+SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds"
+			"lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ"
+			"i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu"
+			"fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy"
+			"r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28"
+			"dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az"
+			"70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk"
+			"EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL"
+			"p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf"
+			"nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA"
+			"ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c"
+			"q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu"
+			"Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR"
+			"TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53"
+			"en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA"
+			"x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ"
+			"t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+"
+			"R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf"
+			"5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH"
+			"e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG"
+			"po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh"
+			"6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln"
+			"9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU"
+			"xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ"
+			"rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W"
+			"lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb"
+			"afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs"
+			"FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR"
+			"OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC"
+			"P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp"
+			"EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh"
+			"6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK"
+			"GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ"
+			"hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s"
+			"amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+"
+			"fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij"
+			"TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv"
+			"I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf"
+			"kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ"
+			"BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD"
+			"9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn"
+			"jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8"
+			"I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI"
+			"8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs"
+			"Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN"
+			"MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5"
+			"2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU"
+			"2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss"
+			"ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m"
+			"sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq"
+			"LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT"
+			"tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9"
+			"oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p"
+			"zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu"
+			"WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy"
+			"diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX"
+			"ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY"
+			"5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau"
+			"Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7"
+			"oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG"
+			"xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q"
+			"zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik"
+			"sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN"
+			"ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc"
+			"MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E"
+			"YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3"
+			"bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz"
+			"DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC"
+			"TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES"
+			"3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K"
+			"Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd"
+			"b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5"
+			"99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys"
+			"7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa"
+			"Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e"
+			"8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1"
+			"vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK"
+			"VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4"
+			"ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD"
+			"CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4"
+			"qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr"
+			"1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe"
+			"GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK"
+			"yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj"
+			"po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO"
+			"Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF"
+			"tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D"
+			"mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM"
+			"eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN"
+			"veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu"
+			"5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL"
+			"Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t"
+			"rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl"
+			"sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx"
+			"mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG"
+			"PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk"
+			"Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk"
+			"caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO"
+			"jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS"
+			"gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E"
+			"OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+"
+			"p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO"
+			"cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM"
+			"S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc"
+			"vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3"
+			"boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn"
+			"DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD"
+			"90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw"
+			"0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT"
+			"5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI"
+			"7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP"
+			"QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw"
+			"oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E"
+			"mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/"
+			"N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm"
+			"vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC"
+			"+OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp"
+			"gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz"
+			"gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni"
+			"R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3"
+			"j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo"
+			"BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl"
+			"IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4"
+			"jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA"
+			"Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS"
+			"AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz"
+			"6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H"
+			"qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp"
+			"cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa"
+			"M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv"
+			"4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M"
+			"IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD"
+			"Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r"
+			"un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr"
+			"2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/"
+			"kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF"
+			"7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8"
+			"YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk"
+			"zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp"
+			"8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF"
+			"o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt"
+			"Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA"
+			"hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx"
+			"LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk"
+			"iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2"
+			"HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5"
+			"K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo"
+			"XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/"
+			"D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j"
+			"MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c"
+			"O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB"
+			"fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X"
+			"/V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI"
+			"a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe"
+			"L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37"
+			"zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY"
+			"BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg=="
+		)
+	)
+	(label "nS1"
+		(at 85.09 101.6 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "34dc82e3-41bd-4476-ad40-c9ffcc99baec")
+	)
+	(label "+5V"
+		(at 125.73 27.94 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "3e3b7a61-4807-4ab1-a86d-d12a1b1a0297")
+	)
+	(label "Vin"
+		(at 92.71 19.05 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "425ff377-0c0f-4717-923a-01041fcd1017")
+	)
+	(label "RT_ENC_B"
+		(at 77.47 96.52 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "633c4e55-d099-4ace-8dd8-78adc5a4cb09")
+	)
+	(label "RT_ENC_A"
+		(at 81.28 99.06 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "729e3b4a-3082-42fa-89cd-5f51ec4abc1c")
+	)
+	(label "TX1"
+		(at 147.32 153.67 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "894b3ee2-d114-4e4d-8ce4-66b5bc73957b")
+	)
+	(label "CTS1"
+		(at 97.79 109.22 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "946aab90-1e48-4ad1-96c7-299c7036e924")
+	)
+	(label "RTS1"
+		(at 97.79 106.68 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "95125360-b52f-4454-837f-9dbf562b1747")
+	)
+	(label "3v3Controller"
+		(at 40.64 88.9 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a22bfc63-302b-4464-9e79-393a07307b02")
+	)
+	(label "+5esp32"
+		(at 226.06 34.29 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a3086c6d-009c-42df-a8ef-067a2ac724b5")
+	)
+	(label "LED_BUILTIN"
+		(at 127 151.13 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "e1345516-6ea7-4984-a9df-aa13bf5393d1")
+	)
+	(label "RX1"
+		(at 144.78 153.67 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "fe750e9b-b513-4e34-a6aa-527d4771cba0")
+	)
+	(global_label "CIPO"
+		(shape input)
+		(at 101.6 182.88 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "01d71b3b-e67d-44ca-b9f8-67e652edc26d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 108.3269 182.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Busy"
+		(shape output)
+		(at 269.24 114.3 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "03ecf8ca-0455-458c-b4bf-c68ef57e38fd")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 275.9063 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "ControllerRX"
+		(shape input)
+		(at 175.26 99.06 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0900fd0d-cb3c-471a-9fc5-030aa0af1c48")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 189.4252 99.06 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Switch_Mute"
+		(shape input)
+		(at 97.79 104.14 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "139755cb-929b-4ef1-99fb-ac67acf6f2ec")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 84.048 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+	)
+	(global_label "nRESET"
+		(shape input)
+		(at 21.59 182.88 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1471edf9-a0d4-4076-94ec-06239f331664")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 12.4443 182.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+	)
+	(global_label "Light3"
+		(shape output)
+		(at 274.32 148.59 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1528a544-7ce4-4a3b-944f-a90f34ba46b1")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 282.4377 148.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "ControllerTX"
+		(shape output)
+		(at 191.77 96.52 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "17502264-35f9-4154-b229-534320edfde2")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 205.6328 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "ControllerRX"
+		(shape input)
+		(at 48.26 191.77 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1ba30855-952a-4bae-9df2-293bd81f7ecc")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 62.4252 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "RTS1"
+		(shape input)
+		(at 95.25 106.68 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "1eb1a2ee-83ac-4fc5-af03-67558264c09c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 88.3418 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+	)
+	(global_label "CTS1"
+		(shape input)
+		(at 95.25 109.22 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "38ec81e3-5066-4e3a-be7b-0af8a3780fde")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 88.3418 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+	)
+	(global_label "VBus"
+		(shape input)
+		(at 48.26 185.42 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3a6eea99-2b5e-42b8-911f-99623e80bc0e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 55.0473 185.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "ControllerRX2"
+		(shape input)
+		(at 173.99 116.84 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "3d6e3c31-73a2-4607-a4da-eb757c34fd42")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 189.3647 116.84 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "RTS1"
+		(shape input)
+		(at 143.51 189.23 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "43b3408b-e98a-4f9a-af3e-a590062b0118")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 150.4182 189.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "SPI_SCK"
+		(shape input)
+		(at 187.96 109.22 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "46f29c9a-14e4-4b51-b682-d09049eece73")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 198.013 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "ControllerTX"
+		(shape input)
+		(at 48.26 189.23 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "47c8e0c8-c399-4625-a766-4b51e8cffcdd")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 62.1228 189.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "TX1"
+		(shape input)
+		(at 147.32 153.67 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4ac5b67e-f700-493c-a8c6-dd256c55c3d1")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 147.32 159.3082 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+	)
+	(global_label "Light1"
+		(shape output)
+		(at 101.6 140.97 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "4b30932e-9781-4ca2-8d1f-9ea1b6b35c6c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 101.6 149.0877 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+	)
+	(global_label "SCL"
+		(shape input)
+		(at 267.97 85.09 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5692b59d-c87b-4356-a7ef-279ecf176fb7")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 273.7292 85.09 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "CTS1"
+		(shape input)
+		(at 143.51 191.77 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "57c8cb56-2920-46a0-8e2a-7f3c307bf6af")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 150.4182 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "SPI_SCK"
+		(shape output)
+		(at 101.6 185.42 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5a9e49d8-c470-4aa5-8355-36b40ba88219")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 111.653 185.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "GPIO0"
+		(shape input)
+		(at 181.61 121.92 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5e7d9260-eace-4b0c-8f0e-6e27f5fc9b14")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 189.5464 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "ControllerVcc"
+		(shape passive)
+		(at 101.6 191.77 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "62108188-1674-4d13-99dc-30ed50f65936")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 115.599 191.77 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "ControllerTX2"
+		(shape output)
+		(at 189.23 114.3 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "662b295d-9529-45cd-87da-c18ac5a0db71")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 204.3023 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Light4"
+		(shape output)
+		(at 92.71 140.97 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "72b005c0-5d36-49a8-b14e-90c2bff500c4")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 92.71 149.0877 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "ControllerTX2"
+		(shape input)
+		(at 269.24 109.22 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7d094b12-99be-41d6-a285-d1eca7495a9c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 284.3123 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Light2"
+		(shape output)
+		(at 274.32 144.78 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8310eea7-e658-478c-859e-95e612f4f72d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 282.4377 144.78 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Light4"
+		(shape output)
+		(at 274.32 152.4 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8475ed2e-788b-438b-922e-5e8808f55adc")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 282.4377 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "GPIO0"
+		(shape input)
+		(at 21.59 176.53 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "879019ac-5e66-4ceb-b214-9d342e107693")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 13.6536 176.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+	)
+	(global_label "RX1"
+		(shape input)
+		(at 143.51 182.88 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9854e2dd-2038-48ac-ac5b-81e7809eae04")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 149.4506 182.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "nCS"
+		(shape input)
+		(at 189.23 111.76 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9970be4a-a160-4c73-a2d1-f7d2aa23e0ac")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 195.1101 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "SCL"
+		(shape output)
+		(at 176.53 93.98 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a05f3b7c-c340-4571-afd7-f9d90c04cee5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 182.2892 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "ControllerRX2"
+		(shape output)
+		(at 269.24 111.76 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a3b335af-5e7e-46e3-8ed8-219007c8b44a")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 284.6147 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Busy"
+		(shape input)
+		(at 170.18 119.38 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "a508e5cc-449f-4a3c-a211-b1e42b44ce24")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 176.8463 119.38 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Light1"
+		(shape output)
+		(at 274.32 140.97 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "aad9bf2e-cb74-4f20-9fa6-e2ded9361869")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 282.4377 140.97 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "VBus"
+		(shape passive)
+		(at 167.64 27.94 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b4eef599-b4f0-4483-9fa2-45ebf8db51c3")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 26.67 3.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+	)
+	(global_label "nCS"
+		(shape output)
+		(at 101.6 189.23 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b7f72da4-5e03-4274-b475-07ef149de1ad")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 107.4801 189.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "ControllerVcc"
+		(shape passive)
+		(at 193.04 27.94 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b98c0f7d-8ba0-40fe-b1c5-b36399dbadf2")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 21.59 3.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+	)
+	(global_label "SDA"
+		(shape bidirectional)
+		(at 267.97 92.71 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b9bd1edd-6d20-45c0-8c3c-917a0c01857b")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 274.7422 92.71 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Light3"
+		(shape output)
+		(at 95.25 140.97 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "bdb25a70-739b-4893-ad8d-751f68b15dea")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 95.25 149.0877 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "COPI"
+		(shape output)
+		(at 101.6 179.07 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "c85915ff-9a08-41ad-a8fc-5f0a0dcf2eb0")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 108.3269 179.07 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "RX1"
+		(shape input)
+		(at 144.78 153.67 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "cd959308-4b6e-4e3d-a438-746bbeabe5fc")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 144.78 159.6106 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+	)
+	(global_label "nRESET"
+		(shape input)
+		(at 97.79 93.98 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "d3acf90a-9e92-419f-9e48-887571e3170e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 88.6443 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+	)
+	(global_label "CIPO"
+		(shape output)
+		(at 171.45 106.68 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d5c76730-3eae-49e4-8b84-b3fcd022bb83")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 178.1769 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Vin"
+		(shape passive)
+		(at 175.26 19.05 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d80da892-aaa1-44e2-a3e1-2cdc73b19558")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 26.67 3.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+	)
+	(global_label "Light2"
+		(shape output)
+		(at 99.06 140.97 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "da73302c-0766-4c38-a423-b40ee10ca9c3")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 99.06 149.0877 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "TX1"
+		(shape input)
+		(at 144.78 185.42 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "db7f2634-f079-43b3-9e9a-c844afd6daf2")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 150.4182 185.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Light0"
+		(shape output)
+		(at 274.32 137.16 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "df1c8572-f48c-4cbc-9947-6c34ee68e9d4")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 282.4377 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "COPI"
+		(shape input)
+		(at 190.5 91.44 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e77a5962-251a-459a-91c1-bd23d55f8fd9")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 197.2269 91.44 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Switch_Mute"
+		(shape bidirectional)
+		(at 269.24 121.92 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ea505d25-6ffd-4549-b3ad-fa99a75d2d97")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 283.9345 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "SDA"
+		(shape bidirectional)
+		(at 177.8 101.6 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f1e0b9a0-1477-44af-a5e4-5d3afa1503ee")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 184.5722 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+	)
+	(global_label "Light0"
+		(shape output)
+		(at 105.41 140.97 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "f8adaa0c-20e7-4763-acc5-27dfade791df")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 105.41 149.0877 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D_Schottky")
+		(at 53.34 27.94 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b4a83f")
+		(property "Reference" "D101"
+			(at 53.34 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Schottky 2A"
+			(at 55.88 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:D_SMB_POLARITY"
+			(at 53.34 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 53.34 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "100V 850mV@2A 2A SMA(DO-214AC) Schottky Diodes ROHS"
+			(at 53.34 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 53.34 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14996"
+			(at 53.34 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "SS210"
+			(at 53.34 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "MDD（Microdiode Electronics）"
+			(at 53.34 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 53.34 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0343"
+			(at 53.34 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 53.34 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 53.34 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "0f0e9217-f9db-40ba-8ef4-3f2faf8ba31e")
+		)
+		(pin "2"
+			(uuid "33e7f40a-6bd6-4659-8f7c-1c0edb709159")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "D101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 36.83 39.37 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b4bd4b")
+		(property "Reference" "C101"
+			(at 39.751 38.2016 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "39pF"
+			(at 39.751 40.513 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 37.7952 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 36.83 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 39pF NP0 ±5% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 36.83 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 36.83 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 36.83 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C107049"
+			(at 36.83 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603JRNPO9BN390"
+			(at 36.83 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 36.83 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.003"
+			(at 36.83 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 36.83 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 36.83 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d2fc921f-d8a1-4b9a-9be2-414911d5a1f2")
+		)
+		(pin "2"
+			(uuid "cb43aa9c-e1e2-428b-af4c-b56480f88e05")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Polarized")
+		(at 55.88 36.83 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5acad")
+		(property "Reference" "C102"
+			(at 58.8772 35.6616 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "47uF 16V"
+			(at 58.8772 37.973 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4"
+			(at 56.8452 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 55.88 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS"
+			(at 55.88 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 55.88 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2895272"
+			(at 55.88 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "KNSCHA"
+			(at 55.88 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RVT47UF16V67RV0019"
+			(at 55.88 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 55.88 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.038"
+			(at 55.88 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 55.88 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 55.88 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "96e4920f-156e-4bf4-bd18-e1990a9a192a")
+		)
+		(pin "2"
+			(uuid "c3d8167c-d495-4cc3-862a-4c65ceaca228")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Polarized")
+		(at 133.35 33.02 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5b741")
+		(property "Reference" "C109"
+			(at 136.3472 31.8516 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "47uF 16V"
+			(at 136.3472 34.163 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4"
+			(at 134.3152 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 133.35 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS"
+			(at 133.35 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 133.35 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2895272"
+			(at 133.35 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "KNSCHA"
+			(at 133.35 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RVT47UF16V67RV0019"
+			(at 133.35 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 133.35 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.038"
+			(at 133.35 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 133.35 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 133.35 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d23587eb-aed9-459b-a896-65e08a48a21c")
+		)
+		(pin "2"
+			(uuid "dcaa2c85-5054-4ab1-b9f8-6c10ef332b8b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C109")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 119.38 33.02 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b5d253")
+		(property "Reference" "C108"
+			(at 122.301 31.8516 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 122.301 34.163 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 120.3452 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 119.38 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 119.38 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 119.38 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 119.38 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 119.38 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 119.38 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 119.38 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 119.38 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 119.38 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 119.38 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "5b594103-960c-48b0-8512-a72269c0ed79")
+		)
+		(pin "2"
+			(uuid "1bcfee51-8e7d-47c4-94ea-680539d4ce8b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C108")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 137.16 25.4 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b6f384")
+		(property "Reference" "#PWR0113"
+			(at 137.16 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+5V"
+			(at 137.541 21.0058 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 137.16 25.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 137.16 25.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 137.16 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "b09cb8bb-37d2-42d3-bbca-5fa3891f8fb2")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0113")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:Barrel_Jack_Switch_SMT")
+		(at 25.4 30.48 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062bbf172")
+		(property "Reference" "J101"
+			(at 17.78 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Barrel_Jack_Switch_SMT"
+			(at 27.94 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:BarrelJack_CLIFF_FC681465S_SMT_Horizontal"
+			(at 26.67 31.496 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.lcsc.com/datasheet/C319134.pdf   , https://tensility.s3.amazonaws.com/uploads/pdffiles/54-00164.pdf"
+			(at 26.67 31.496 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Power Barrel Connector Jack 2.10mm ID (0.083\"), 5.50mm OD (0.217\") Surface Mount, Right Angle"
+			(at 25.4 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 25.4 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C319134"
+			(at 25.4 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "XKB Connectivity "
+			(at 25.4 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "DC-005-5A-2.0-SMT"
+			(at 25.4 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2" "Digikey"
+			(at 25.4 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2 PN" "839-54-00164CT-ND"
+			(at 25.4 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.205"
+			(at 25.4 30.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 25.4 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" "54-00164"
+			(at 25.4 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" "Tensility International Corp"
+			(at 25.4 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "229c2268-f7aa-4043-8f2b-e7565dcd0df5")
+		)
+		(pin "2"
+			(uuid "82a590bd-071e-47b8-9cfa-65b3e782f1e1")
+		)
+		(pin "3"
+			(uuid "a2998a06-c7b5-4ea7-8855-e6e2c2b16112")
+		)
+		(pin "4"
+			(uuid "a0bf60d1-28fb-4db3-bd63-1cacb020bea6")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "J101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 69.85 38.1 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062bd2de4")
+		(property "Reference" "C105"
+			(at 72.771 36.9316 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 72.771 39.243 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 70.8152 41.91 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 69.85 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 69.85 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 69.85 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 69.85 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 69.85 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 69.85 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 69.85 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 69.85 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 69.85 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 69.85 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "71befeab-219c-4b33-9202-ae3da6a4f459")
+		)
+		(pin "2"
+			(uuid "ffb17192-2476-4f56-9c03-0d5fd8f8911e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C105")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MountingHole_Pad_3.5mm")
+		(at 217.17 147.32 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062ce9822")
+		(property "Reference" "H104"
+			(at 219.71 146.0754 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MountingHole_Pad_3.5mm"
+			(at 217.17 148.59 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:MountingHole_3.5mm_Pad_Via"
+			(at 217.17 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 217.17 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "MountingHole_Pad_3.5mm"
+			(at 217.17 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "NA"
+			(at 217.17 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0"
+			(at 217.17 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 217.17 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 217.17 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 217.17 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 217.17 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 217.17 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 217.17 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "0bb4a166-6c5e-4e20-a9bb-d297e640e277")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "H104")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MountingHole_Pad_3.5mm")
+		(at 217.17 139.7 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062cea64d")
+		(property "Reference" "H103"
+			(at 219.71 138.4554 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MountingHole_Pad_3.5mm"
+			(at 217.17 140.97 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:MountingHole_3.5mm_Pad_Via"
+			(at 217.17 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 217.17 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "MountingHole_Pad_3.5mm"
+			(at 217.17 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "NA"
+			(at 217.17 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0"
+			(at 217.17 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 217.17 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 217.17 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 217.17 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 217.17 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 217.17 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 217.17 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6c32e8f5-06f6-423c-9fac-ceecafde8819")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "H103")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MountingHole_Pad_3.5mm")
+		(at 217.17 132.08 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062ceaa1a")
+		(property "Reference" "H102"
+			(at 219.71 130.8354 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MountingHole_Pad_3.5mm"
+			(at 217.17 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:MountingHole_3.5mm_Pad_Via"
+			(at 217.17 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 217.17 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "MountingHole_Pad_3.5mm"
+			(at 217.17 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "NA"
+			(at 217.17 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0"
+			(at 217.17 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 217.17 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 217.17 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 217.17 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 217.17 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 217.17 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 217.17 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "adf671c6-4639-4878-af83-28a5550faebe")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "H102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MountingHole_Pad_3.5mm")
+		(at 217.17 124.46 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062ceadbe")
+		(property "Reference" "H101"
+			(at 219.71 123.2154 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MountingHole_Pad_3.5mm"
+			(at 217.17 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:MountingHole_3.5mm_Pad_Via"
+			(at 217.17 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 217.17 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "MountingHole_Pad_3.5mm"
+			(at 217.17 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "NA"
+			(at 217.17 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0"
+			(at 217.17 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 217.17 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 217.17 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 217.17 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 217.17 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 217.17 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 217.17 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7c2287a9-de27-4535-a4ed-d5a151b07cc6")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "H101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:22-23-2021")
+		(at 156.21 24.13 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062d30624")
+		(property "Reference" "J102"
+			(at 154.0002 23.1648 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "0.100_2Pin"
+			(at 154.0002 25.4762 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+			(at 161.29 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811011511_Amphenol-ICC-68000-102HLF_C168673.pdf"
+			(at 161.29 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "HEADER VERT 2POS 2.54MM"
+			(at 161.29 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" ""
+			(at 161.29 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "68000-102HLF"
+			(at 161.29 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Connectors, Interconnects"
+			(at 161.29 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Rectangular Connectors - Headers, Male Pins"
+			(at 161.29 41.91 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" ""
+			(at 161.29 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" ""
+			(at 161.29 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Amphenol ICC"
+			(at 161.29 52.07 0)
+			(hide yes)
+			(effects
+				(font
+					(size 0.001 0.001)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 161.29 54.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Assembly Type" ""
+			(at 26.67 3.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 156.21 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C168673"
+			(at 156.21 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.1458"
+			(at 156.21 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 156.21 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 156.21 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 156.21 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "1f6b0142-c2aa-44dd-b04e-11765d41538c")
+		)
+		(pin "2"
+			(uuid "bc069602-24df-4cc8-88d7-c1c1309a94b5")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "J102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 153.67 46.99 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062d74668")
+		(property "Reference" "R110"
+			(at 152.4 41.91 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 153.67 44.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 153.67 45.212 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 153.67 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 153.67 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 153.67 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 153.67 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 153.67 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 153.67 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 153.67 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 153.67 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 153.67 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 153.67 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "998e46a6-8682-43ec-977c-7f4db27a6e1e")
+		)
+		(pin "2"
+			(uuid "cc0f4b34-edd9-4f5e-a8a6-4ea33b52af8d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R110")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:Polyfuse_Small")
+		(at 43.18 27.94 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062d8df8e")
+		(property "Reference" "F101"
+			(at 44.45 25.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Polyfuse_Small_1A"
+			(at 44.45 30.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Fuse:Fuse_0603_1608Metric"
+			(at 38.1 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" ""
+			(at 43.18 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "6V 1A 50A -40℃~+85℃ 1.8A 40mΩ 300ms 120mΩ 0603 Resettable Fuses ROHS"
+			(at 43.18 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Littelfuse"
+			(at 43.18 27.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "0603L100SLYR"
+			(at 43.18 27.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 43.18 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.2448"
+			(at 43.18 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 43.18 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C207017"
+			(at 43.18 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 43.18 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 43.18 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "8b2a4ac2-074b-4ce2-8a78-7ffdb383facf")
+		)
+		(pin "2"
+			(uuid "bda1ac1e-7e71-4814-b281-3ecae41b905d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "F101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D_Schottky")
+		(at 180.34 31.75 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062e0564a")
+		(property "Reference" "D104"
+			(at 176.53 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Schottky 2A"
+			(at 175.26 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:D_SMB_POLARITY"
+			(at 180.34 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 180.34 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "100V 850mV@2A 2A SMA(DO-214AC) Schottky Diodes ROHS"
+			(at 180.34 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 180.34 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14996"
+			(at 180.34 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "SS210"
+			(at 180.34 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "MDD（Microdiode Electronics）"
+			(at 180.34 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 180.34 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0343"
+			(at 180.34 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 180.34 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 180.34 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d91d7632-b389-4bd6-a516-48722e24246d")
+		)
+		(pin "2"
+			(uuid "412fde02-f505-4c27-ae66-dac15a30d6d6")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "D104")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 39.37 27.94 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062e136ff")
+		(property "Reference" "#FLG0101"
+			(at 39.37 26.035 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 36.83 22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 39.37 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 39.37 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 39.37 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f8ef2910-6c99-499f-ae5f-25daa228d114")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#FLG0101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 64.77 22.86 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062e14b5b")
+		(property "Reference" "#FLG0102"
+			(at 64.77 20.955 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 68.58 17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 64.77 22.86 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 64.77 22.86 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 64.77 22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "befcd0a4-7037-400e-902a-2ef7425c4d24")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#FLG0102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 157.48 35.56 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062e2029a")
+		(property "Reference" "R106"
+			(at 156.21 30.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 157.48 33.02 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 157.48 33.782 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 157.48 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "DNI"
+			(at 157.48 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DNI"
+			(at 157.48 35.56 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "DNI"
+			(at 157.48 35.56 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 157.48 35.56 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "DNI"
+			(at 157.48 35.56 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 157.48 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 157.48 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 157.48 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 157.48 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d8c82e7e-5ccc-4f05-88e7-5942e665ae20")
+		)
+		(pin "2"
+			(uuid "65348679-815e-4d03-a9b9-7da3cc7474c4")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R106")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 189.23 38.1 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062e47436")
+		(property "Reference" "R107"
+			(at 187.96 33.02 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 189.23 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 189.23 36.322 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 189.23 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "DNI"
+			(at 189.23 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DNI"
+			(at 189.23 38.1 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "DNI"
+			(at 189.23 38.1 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 189.23 38.1 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "DNI"
+			(at 189.23 38.1 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 189.23 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 189.23 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 189.23 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 189.23 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "746d59c9-9501-4157-abc1-12fa622f639b")
+		)
+		(pin "2"
+			(uuid "c66839fe-8684-4e0e-820a-bf7750aafc5c")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R107")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 262.89 45.72 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "02d99bf8-b6c4-4b56-af91-0f62d8b856dc")
+		(property "Reference" "#PWR0116"
+			(at 262.89 52.07 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 262.89 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 262.89 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 262.89 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f27b3489-9063-4cba-b376-eb551d0fbe6c")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0116")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 60.96 24.13 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "03b31824-c9ec-4eb2-b379-23f077cd8439")
+		(property "Reference" "TP102"
+			(at 53.34 17.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Vin"
+			(at 53.34 20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 66.04 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 66.04 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Red"
+			(at 60.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 60.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 60.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 60.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 60.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 60.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 60.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 60.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 60.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c23b162a-fb9b-4474-8051-9ffe99fe9cd5")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "TP102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 63.5 144.78 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "05933f9e-78ff-4c3e-83b5-04566a333f0c")
+		(property "Reference" "#PWR0104"
+			(at 63.5 151.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 63.5 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 63.5 144.78 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 63.5 144.78 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 63.5 144.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "edf6daf8-818b-4bd3-b964-c0a324e8f214")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0104")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 209.55 96.52 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "05b874ab-3615-4699-a39f-952859f8a8e5")
+		(property "Reference" "TP108"
+			(at 209.55 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "U0_RX"
+			(at 210.82 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 214.63 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 214.63 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 209.55 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 209.55 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 209.55 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 209.55 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 209.55 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 209.55 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 209.55 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 209.55 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 209.55 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7645220d-4394-4b67-93b5-7fa3109751ef")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "TP108")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Regulator_Linear:AMS1117-3.3")
+		(at 251.46 34.29 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0668f098-e577-4234-8711-82af43e1b67a")
+		(property "Reference" "U103"
+			(at 251.46 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "AMS1117-3.3"
+			(at 251.46 30.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+			(at 251.46 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "http://www.advanced-monolithic.com/pdf/ds1117.pdf"
+			(at 254 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "72dB@(120Hz) 1A Fixed 3.3V Positive electrode SOT-223 Voltage Regulators - Linear, Low Drop Out (LDO) Regulators ROHS"
+			(at 251.46 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 251.46 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C6186"
+			(at 251.46 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "AMS1117-3.3"
+			(at 251.46 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Advanced Monolithic Systems"
+			(at 251.46 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.15"
+			(at 251.46 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 251.46 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 251.46 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 251.46 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "371a81b3-dee8-4fea-9d5d-b6c6c46a3ffc")
+		)
+		(pin "2"
+			(uuid "13ca2af2-93f6-4f3a-8a91-68ebb11e07e1")
+		)
+		(pin "3"
+			(uuid "93b041b5-4c59-4dc0-b2f3-b792fec1424e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "U103")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 127 154.94 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0e172c51-95e4-4b73-b008-527e1140a069")
+		(property "Reference" "R112"
+			(at 124.46 155.575 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 129.54 155.575 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 125.222 154.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 127 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 127 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 127 154.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 127 154.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 127 154.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 127 154.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 127 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 127 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 127 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 127 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ab733aa0-c897-4c3a-ab8f-105bdd2a9379")
+		)
+		(pin "2"
+			(uuid "a129ac10-b47e-4e91-b580-cfe72fb6fa53")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R112")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 251.46 45.72 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0f14fc8e-2c36-4840-b6d9-d3664319c54d")
+		(property "Reference" "#PWR0115"
+			(at 251.46 52.07 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 251.46 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 251.46 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 251.46 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 251.46 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "87e844ce-68a4-4fb5-8956-dd08b92ff65a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0115")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 182.88 114.3 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0f8fe905-c6c5-4324-a449-9adb06b5a34f")
+		(property "Reference" "R116"
+			(at 181.61 112.395 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "39R"
+			(at 187.325 113.03 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 182.88 112.522 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 182.88 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "100mW ±1% 39Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 182.88 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 182.88 114.3 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C325713"
+			(at 182.88 114.3 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 182.88 114.3 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC0603391%N"
+			(at 182.88 114.3 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 182.88 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0027"
+			(at 182.88 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 182.88 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 182.88 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c6ac4148-1aee-4e15-a0ce-1f35bce7b13a")
+		)
+		(pin "2"
+			(uuid "0defed48-ba4c-4613-9f6e-8c36f22bae49")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R116")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3.3V")
+		(at 17.78 88.9 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "125bb5c2-64b0-4bec-8c00-3ee46b8587ed")
+		(property "Reference" "#PWR09"
+			(at 17.78 92.71 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 17.78 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 17.78 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 17.78 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 17.78 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "cf08f323-bd44-415f-8d20-567630d8c6c6")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR09")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 73.66 181.61 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "12a06a26-cc67-4997-b99c-46146aca26c8")
+		(property "Reference" "R1009"
+			(at 72.39 176.53 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1R0"
+			(at 73.66 179.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 73.66 179.832 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 73.66 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 73.66 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 73.66 181.61 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 73.66 181.61 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 73.66 181.61 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 73.66 181.61 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 73.66 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 73.66 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 73.66 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 73.66 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "57bd9ec0-2090-4b66-97d0-e890e280c9cd")
+		)
+		(pin "2"
+			(uuid "bd84431a-4e4c-46ff-bb08-b5a910b8c247")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R1009")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:ESP32-WROOM-32D-PINORDER")
+		(at 135.89 109.22 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "137f564a-c1ab-4aaf-b07c-443dc9d45715")
+		(property "Reference" "U102"
+			(at 114.3 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "ESP32-WROOM-32E-N4"
+			(at 114.3 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:ESP32-WROOM-32D"
+			(at 152.4 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32d_esp32-wroom-32u_datasheet_en.pdf"
+			(at 128.27 107.95 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "SMD,18x25.5mm WiFi Modules ROHS"
+			(at 135.89 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "3.42"
+			(at 135.89 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 135.89 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C701341"
+			(at 135.89 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "ESP32-WROOM-32E-N4"
+			(at 135.89 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Espressif Systems"
+			(at 135.89 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 135.89 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 135.89 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 135.89 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "1039851d-ece4-4841-9798-a1bbb926fa80")
+		)
+		(pin "10"
+			(uuid "3c21ada1-88fe-4641-9f06-5daff57353b9")
+		)
+		(pin "11"
+			(uuid "8e3b56eb-f9fa-40c2-bc2f-04c34955e4c2")
+		)
+		(pin "12"
+			(uuid "b5e6624d-68dc-479b-b6a8-167ad75a612a")
+		)
+		(pin "13"
+			(uuid "161d5961-dfaf-4fe3-871f-34fa27e9f4de")
+		)
+		(pin "14"
+			(uuid "befef87e-fb9d-4462-8157-b0e1823ae264")
+		)
+		(pin "15"
+			(uuid "8d94697a-7d41-485e-a6f1-079a1ee37e41")
+		)
+		(pin "16"
+			(uuid "edc07a6b-6c70-44bf-b30f-89cfc0180f30")
+		)
+		(pin "17"
+			(uuid "b3b968d1-d5e2-44b9-a3ee-ec67f13b23b3")
+		)
+		(pin "18"
+			(uuid "22d83693-db63-49cb-937f-afda87ccd8da")
+		)
+		(pin "19"
+			(uuid "951ff812-3dc5-42be-9253-99e4c4366937")
+		)
+		(pin "2"
+			(uuid "9c9372a6-4977-4022-979e-4360a0cf7490")
+		)
+		(pin "20"
+			(uuid "5866623c-245b-4fcd-8861-50fef0747777")
+		)
+		(pin "21"
+			(uuid "a64cd5c7-4b16-4ee4-962c-c16f9101e8c1")
+		)
+		(pin "22"
+			(uuid "416e6d3f-95a9-44e6-8372-c9dbffde81c1")
+		)
+		(pin "23"
+			(uuid "d2dc7485-1b1d-4550-9b53-9fc24728e1a8")
+		)
+		(pin "24"
+			(uuid "14a60c64-2ac1-4040-a6e2-20c6205d8bd7")
+		)
+		(pin "25"
+			(uuid "4270eb97-1629-44a7-88e5-d5058c3746cc")
+		)
+		(pin "26"
+			(uuid "e68d19b3-e921-4114-823c-637b9278e8c1")
+		)
+		(pin "27"
+			(uuid "c8da9217-381b-40b2-bc52-2293d9212ca7")
+		)
+		(pin "28"
+			(uuid "4af5e87b-4861-4b50-933d-b61b223d0938")
+		)
+		(pin "29"
+			(uuid "a531d93d-36b1-4ecc-a1a4-fbe5d6f0849b")
+		)
+		(pin "3"
+			(uuid "6a0544ea-01f1-4ef6-85f5-51450c6a54a5")
+		)
+		(pin "30"
+			(uuid "07d27aa8-c9b5-4dd4-a4ff-0e5be3081c03")
+		)
+		(pin "31"
+			(uuid "06bc3cd9-5124-4271-9247-4ff7c63e62de")
+		)
+		(pin "32"
+			(uuid "00d4181f-3739-4e2f-b315-0e1fb5c2b4ca")
+		)
+		(pin "33"
+			(uuid "8e02ef48-4c00-414b-8cae-f1a9b4d80919")
+		)
+		(pin "34"
+			(uuid "d87df385-3c52-4942-a125-2cc2d9483179")
+		)
+		(pin "35"
+			(uuid "5dbb7c21-fe34-4569-ba55-1e9cfa49c3c0")
+		)
+		(pin "36"
+			(uuid "c76f72f4-0cef-4c1d-9a3e-b45d1b896c19")
+		)
+		(pin "37"
+			(uuid "4a124e09-5bc2-49f8-a8c2-107e35b2fbc3")
+		)
+		(pin "38"
+			(uuid "e92ed94c-7fb2-4f55-a694-a0fb3bee022a")
+		)
+		(pin "39"
+			(uuid "ef7216d3-4fd6-4fb4-8ac7-c20301b37fa5")
+		)
+		(pin "4"
+			(uuid "832542a5-4677-416a-a612-955de33b6709")
+		)
+		(pin "5"
+			(uuid "52057ec7-b3b2-4fa9-9f52-4f4920b6cdeb")
+		)
+		(pin "6"
+			(uuid "0ae7a78d-1275-43c9-a58b-50f622040e43")
+		)
+		(pin "7"
+			(uuid "3c041688-92a0-49c6-80a9-05fe69b210f8")
+		)
+		(pin "8"
+			(uuid "471e87c7-23e6-4283-8ad0-7ac3b4efeecb")
+		)
+		(pin "9"
+			(uuid "7f92bc99-6599-4b4e-9081-3a8d97772ba2")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "U102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 185.42 91.44 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1572af9d-ac0f-4e2c-b81d-da9ba8e38938")
+		(property "Reference" "R113"
+			(at 183.515 89.535 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "39R"
+			(at 189.865 90.17 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 185.42 89.662 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 185.42 91.44 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "100mW ±1% 39Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 185.42 91.44 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 185.42 91.44 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C325713"
+			(at 185.42 91.44 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 185.42 91.44 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC0603391%N"
+			(at 185.42 91.44 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 185.42 91.44 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0027"
+			(at 185.42 91.44 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 185.42 91.44 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 185.42 91.44 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "94e37146-b9f1-4203-9ef4-e4f0c7015c1d")
+		)
+		(pin "2"
+			(uuid "c63ff8eb-18a8-486d-84e6-571290035277")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R113")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 38.1 66.04 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "15a449fb-5566-4fb3-b957-f28bd7459cdc")
+		(property "Reference" "#PWR0129"
+			(at 38.1 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 38.1 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 66.04 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 38.1 66.04 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 66.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "53a97304-f46a-4c08-993f-18700c0ecb2d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0129")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D_Schottky")
+		(at 92.71 63.5 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "168ceaa1-180b-4b94-b2b0-2b2776f0d037")
+		(property "Reference" "D103"
+			(at 92.71 57.9882 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Schottky 2A"
+			(at 92.71 60.2996 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:D_SMB_POLARITY"
+			(at 92.71 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 92.71 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "100V 850mV@2A 2A SMA(DO-214AC) Schottky Diodes ROHS"
+			(at 92.71 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 92.71 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14996"
+			(at 92.71 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "SS210"
+			(at 92.71 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "MDD（Microdiode Electronics）"
+			(at 92.71 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 92.71 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0343"
+			(at 92.71 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 92.71 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 92.71 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "fe2a2e0e-39de-47d1-b6f3-ffb758f42bf0")
+		)
+		(pin "2"
+			(uuid "20fb4fa8-d664-4249-8479-4d4c1f35f23c")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "D103")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 234.95 45.72 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "16e9960e-753d-48be-9df4-256b47766d81")
+		(property "Reference" "#PWR0112"
+			(at 234.95 52.07 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 234.95 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 234.95 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 234.95 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 234.95 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "20b163c0-a727-4257-b600-8977445bc206")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0112")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 238.76 27.94 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "183463d1-c33a-4a24-bbaf-f9d956990224")
+		(property "Reference" "#FLG0104"
+			(at 238.76 26.035 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 241.935 24.765 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 238.76 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 238.76 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 238.76 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "28700eea-a725-49e8-9531-2ee7065b9ae2")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#FLG0104")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x14")
+		(at 106.68 104.14 0)
+		(mirror y)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "19998d8d-ff7e-4974-8b3e-35aeab9399ae")
+		(property "Reference" "J104"
+			(at 109.855 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x14 1mm"
+			(at 112.395 85.725 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Connector_PinSocket_1.00mm:PinSocket_1x14_P1.00mm_Vertical"
+			(at 106.68 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 106.68 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Gold 250V 1A Policy 1mm 14P 260℃ -40℃~+105℃ 1.27mm Single Row Black Brass 1x14P 1.27mm Plugin,P=1.27mm Pin Headers ROHS"
+			(at 106.68 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 106.68 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2881659"
+			(at 106.68 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "X1311WV-10J-C18D27"
+			(at 106.68 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "XKB Connection"
+			(at 106.68 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 106.68 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.25"
+			(at 106.68 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 106.68 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 106.68 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "2cdc7925-6fc3-4466-932a-c3ca0b8b3f4a")
+		)
+		(pin "10"
+			(uuid "d0b93e49-6580-4a14-9cf7-9fa0e6b5387c")
+		)
+		(pin "11"
+			(uuid "62dd146f-7c2e-4902-a145-d4b48cf59ba6")
+		)
+		(pin "12"
+			(uuid "e29955ca-6275-45d3-9fb5-3d69953ea2eb")
+		)
+		(pin "13"
+			(uuid "46d295a1-18b0-4d6c-8f9d-5c951e7dea50")
+		)
+		(pin "14"
+			(uuid "45223f3a-ebce-4341-bad5-59f2aabc94c5")
+		)
+		(pin "2"
+			(uuid "f9c6eb7a-d131-4ec2-838f-295e05fe2d62")
+		)
+		(pin "3"
+			(uuid "94c65481-d676-437f-9db5-6ebb6cbd8f07")
+		)
+		(pin "4"
+			(uuid "943c4c10-03ac-486f-b576-86fe8998a1d9")
+		)
+		(pin "5"
+			(uuid "16b84e3a-adcc-4da6-bcd2-4cceb42bf890")
+		)
+		(pin "6"
+			(uuid "e46e0355-6d6f-417c-8d47-c00502ed25fa")
+		)
+		(pin "7"
+			(uuid "82ec21bf-74bd-4cb8-b375-23bacbd0b2c3")
+		)
+		(pin "8"
+			(uuid "f134d536-e7d0-4d04-b44c-2236b254295e")
+		)
+		(pin "9"
+			(uuid "733e788d-9493-4ac1-a017-5b9d3c661674")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "J104")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 46.99 132.08 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1b39393c-8bbd-4590-ab4f-0be891153637")
+		(property "Reference" "#PWR0105"
+			(at 46.99 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 46.99 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 46.99 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 46.99 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 46.99 132.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6850522c-3cbb-4bed-b33f-f57810e0371c")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0105")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 205.74 152.4 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "24843ded-cb99-4ffd-aa9a-ade99421a212")
+		(property "Reference" "TP106"
+			(at 196.85 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "TP_GND"
+			(at 198.12 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 210.82 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://lcsc.com/datasheet/lcsc_datasheet_2504101957_ronghe-RH-5116_C5199806.pdf"
+			(at 210.82 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Green"
+			(at 205.74 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 205.74 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 205.74 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199806"
+			(at 205.74 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5116"
+			(at 205.74 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 205.74 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.4"
+			(at 205.74 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 205.74 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 205.74 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "73de3f8d-5385-4d12-a6a5-b9721b0a9a00")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "TP106")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:SWITCH_TACTILE_SPST-NO_0.05A_24V")
+		(at 50.8 63.5 0)
+		(mirror y)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "266d135f-2a5e-48fa-8409-76ce7a9511a7")
+		(property "Reference" "S101"
+			(at 50.8 58.42 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Value" "SWITCH_TACTILE_SPST-NO_0.05A_24V"
+			(at 62.23 67.945 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:Switch_Tactile_THT_6x6mm"
+			(at 45.72 58.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.te.com/commerce/DocumentDelivery/DDEController?Action=srchrtrv&DocNm=1825910&DocType=Customer+Drawing&DocLang=English"
+			(at 45.72 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "Red Round Button SPST Through Hole Without Bracket Plugin-4P,6x6mm Tactile Switches ROHS"
+			(at 45.72 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 50.8 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C592731"
+			(at 50.8 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2" "Digikey"
+			(at 50.8 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2 PN" "450-1804-ND"
+			(at 45.72 53.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "TE Connectivity ALCOSWITCH Switches"
+			(at 45.72 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "TE Connectivity 1825910-7"
+			(at 45.72 50.8 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Switches"
+			(at 45.72 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Tactile Switches"
+			(at 45.72 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "https://www.te.com/commerce/DocumentDelivery/DDEController?Action=srchrtrv&DocNm=1825910&DocType=Customer+Drawing&DocLang=English"
+			(at 45.72 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/te-connectivity-alcoswitch-switches/1825910-7/450-1804-ND/1731414"
+			(at 45.72 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 45.72 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Assembly Type" ""
+			(at 190.5 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 50.8 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0315"
+			(at 50.8 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 50.8 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" "YE"
+			(at 50.8 63.5 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e05ad340-ea4c-4c78-a585-89858fb11aba")
+		)
+		(pin "2"
+			(uuid "05130eb2-5047-4560-964c-1cb844f79165")
+		)
+		(pin "3"
+			(uuid "c23e6353-c9f2-4a2b-b17b-43651c7e5f76")
+		)
+		(pin "4"
+			(uuid "8a48fd55-89e8-40f6-a8c2-fe94ce0d201f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "S101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 66.04 181.61 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2cb0c264-c7da-4408-beeb-80c784af4a4e")
+		(property "Reference" "#PWR029"
+			(at 66.04 185.42 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+5V"
+			(at 66.421 177.2158 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 66.04 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 66.04 181.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 66.04 181.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "cff28e41-befe-4d51-9f2d-9088816c050e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR029")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:RotaryEncoder_Switch_MP")
+		(at 63.5 137.16 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2d22c134-87c7-42ed-88e6-9d6c1476c55d")
+		(property "Reference" "SW101"
+			(at 63.5 127 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "RotaryEncoder_Switch"
+			(at 63.5 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:RotaryEncoder_Alps_EC12E-Switch_Vertical_H20mm_MP1_MP2"
+			(at 59.69 133.096 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 63.5 130.556 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Plugin Rotary Encoders ROHS"
+			(at 63.5 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 63.5 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C202365"
+			(at 63.5 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "EC11E18244AU"
+			(at 63.5 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ALPSALPINE"
+			(at 63.5 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 63.5 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "1.9830"
+			(at 63.5 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 63.5 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 63.5 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "A"
+			(uuid "0a0f863f-6598-4e05-9a1e-64899af37642")
+		)
+		(pin "B"
+			(uuid "8de56ed2-23a6-4b75-94c0-10f0d6b88127")
+		)
+		(pin "C"
+			(uuid "d7b8e011-aac4-46e4-b6a8-884fa4076909")
+		)
+		(pin "MP1"
+			(uuid "362f55b0-e508-426d-bfff-79d350dea30c")
+		)
+		(pin "MP2"
+			(uuid "4b993437-c2b8-4b49-b861-2493f7a423e1")
+		)
+		(pin "S1"
+			(uuid "5f3de26f-0f6f-46e3-b0d8-90c2a8d16b9b")
+		)
+		(pin "S2"
+			(uuid "247ffd4a-874b-44d6-852c-5483b8d6835c")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "SW101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 133.35 38.1 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "37122510-85b3-46ae-bb5e-3623ec743e3e")
+		(property "Reference" "#PWR0110"
+			(at 133.35 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 133.35 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 133.35 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 133.35 38.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 133.35 38.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e5da7dd2-1038-4a20-b25d-796721f3de4f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0110")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:LED_T1.75_CLEAR_WHITE")
+		(at 171.45 46.99 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "3e876305-79cd-463a-96b4-0d620e9c8923")
+		(property "Reference" "D105"
+			(at 168.91 40.64 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "LED_T1.75_CLEAR_RED"
+			(at 161.29 44.45 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:LED_5mm_Radial"
+			(at 176.53 41.91 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 176.53 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "LED RED CLEAR T-1 3/4 T/H"
+			(at 176.53 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "160-1682-ND"
+			(at 176.53 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "LTL2R3KEK"
+			(at 176.53 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Optoelectronics"
+			(at 176.53 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "LED Indication - Discrete"
+			(at 176.53 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "http://optoelectronics.liteon.com/upload/download/DS20-2005-253/LTW-2R3D7.pdf"
+			(at 176.53 26.67 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/lite-on-inc/LTL2R3KEK/160-1682-ND/573572"
+			(at 176.53 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Lite-On Inc."
+			(at 176.53 19.05 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 176.53 16.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 171.45 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.36000"
+			(at 171.45 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "DigiKey"
+			(at 171.45 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "160-1682-ND"
+			(at 171.45 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 171.45 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 171.45 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "1f7d33e9-005f-45d9-8f7e-335d19791632")
+		)
+		(pin "2"
+			(uuid "bb070393-7525-4d50-a357-df94bc162c48")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "D105")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 36.83 45.72 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "42ecfc98-9883-445f-bd27-ef691ebff291")
+		(property "Reference" "#PWR0101"
+			(at 36.83 52.07 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 36.83 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 36.83 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 36.83 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 36.83 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "4885c7b1-abc2-4646-b0f3-b31f3adaa271")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 275.59 30.48 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5044db84-34b3-4eab-b77f-3f308b8ca5b4")
+		(property "Reference" "TP100"
+			(at 266.7 29.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "TP+3.3V"
+			(at 266.065 27.305 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 280.67 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 280.67 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings ROHS red"
+			(at 275.59 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 275.59 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 275.59 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 275.59 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 275.59 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 275.59 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 275.59 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 275.59 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 275.59 30.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "318e08ae-0d48-4c75-8aa1-7357c5dba08d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "TP100")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 69.85 82.55 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "59298252-48dd-4932-bc6c-780d9663f9aa")
+		(property "Reference" "#PWR0128"
+			(at 69.85 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 69.85 86.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 69.85 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 69.85 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 69.85 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ca300708-3732-48d9-8901-4eacbeda780a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0128")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 220.98 34.29 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "65c82507-c4d0-41f1-9f43-d596c106d24e")
+		(property "Reference" "R1002"
+			(at 219.71 29.21 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1R0"
+			(at 220.98 31.75 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 220.98 32.512 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 220.98 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 220.98 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 220.98 34.29 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 220.98 34.29 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 220.98 34.29 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 220.98 34.29 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 220.98 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 220.98 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 220.98 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 220.98 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6cb98129-7350-4b7d-9442-da21737d5e4a")
+		)
+		(pin "2"
+			(uuid "91e6f038-bd4e-44dd-af26-10f31e66d828")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R1002")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Polarized")
+		(at 273.05 39.37 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "67c6cbdd-425c-46ac-80be-6f2fcedfd1b9")
+		(property "Reference" "C118"
+			(at 273.05 37.465 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "47uF 16V"
+			(at 269.875 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4"
+			(at 274.0152 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 273.05 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS"
+			(at 273.05 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 273.05 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2895272"
+			(at 273.05 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "KNSCHA"
+			(at 273.05 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RVT47UF16V67RV0019"
+			(at 273.05 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 273.05 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.038"
+			(at 273.05 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 273.05 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 273.05 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "83699e6d-b9f2-4c10-8f58-9040a8cf056f")
+		)
+		(pin "2"
+			(uuid "e2e32b4e-2db7-4ead-8191-254d7f18c63e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C118")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 210.82 125.73 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6b215cc4-eab0-4d50-89f8-6b9eedf3d0f6")
+		(property "Reference" "TP104"
+			(at 201.93 123.19 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "TP_GND"
+			(at 203.2 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 215.9 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://lcsc.com/datasheet/lcsc_datasheet_2504101957_ronghe-RH-5116_C5199806.pdf"
+			(at 215.9 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Green"
+			(at 210.82 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 210.82 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 210.82 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199806"
+			(at 210.82 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5116"
+			(at 210.82 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 210.82 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.4"
+			(at 210.82 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 210.82 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 210.82 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d06d5bed-92be-4a0e-b34c-c056ee0f38e8")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "TP104")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 26.67 44.45 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6cc8777f-5263-40b5-b3ae-869d93312c98")
+		(property "Reference" "TP101"
+			(at 17.78 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "TP_GND"
+			(at 19.05 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 31.75 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://lcsc.com/datasheet/lcsc_datasheet_2504101957_ronghe-RH-5116_C5199806.pdf"
+			(at 31.75 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Green"
+			(at 26.67 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 26.67 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 26.67 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199806"
+			(at 26.67 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5116"
+			(at 26.67 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 26.67 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.4"
+			(at 26.67 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 26.67 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 26.67 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c3416f5e-b747-417c-aab6-4bf396138338")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "TP101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 33.02 80.01 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6d3fefdf-595c-41a4-8deb-dbdb5acf7deb")
+		(property "Reference" "TP109"
+			(at 22.86 72.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "3v3Controller"
+			(at 22.86 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 38.1 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 38.1 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings ROHS red"
+			(at 33.02 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 33.02 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 33.02 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 33.02 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 33.02 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 33.02 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 33.02 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 33.02 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 33.02 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "8e2cb42a-ee25-4380-894a-3c0bdffc149d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "TP109")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 194.31 139.7 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6ea77d10-53f4-4f4f-a3a3-61785fb66c22")
+		(property "Reference" "#PWR0121"
+			(at 194.31 146.05 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 194.31 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 194.31 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 194.31 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 194.31 139.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "abb3624d-b48c-4fc5-9fad-d3fde2824cb8")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0121")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 121.92 27.94 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6fcee3b3-4e61-4f69-8b79-bd71e045ce39")
+		(property "Reference" "TP103"
+			(at 114.3 21.59 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "+5V"
+			(at 114.3 24.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 127 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 127 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Red"
+			(at 121.92 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 121.92 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 121.92 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 121.92 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 121.92 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 121.92 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 121.92 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 121.92 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 121.92 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "988bf460-6c8a-4069-86ec-87b3793250b0")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "TP103")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+5V")
+		(at 214.63 29.21 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "721ad4bd-c8e1-4e96-ac7a-3aa5a78f8c72")
+		(property "Reference" "#PWR010"
+			(at 214.63 33.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+5V"
+			(at 215.011 24.8158 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 214.63 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 214.63 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 214.63 29.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "5c278aba-f8cc-491a-bcb0-a25aaa1f9276")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR010")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 207.01 139.7 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "794165ea-19a1-448d-bfeb-ad99d7e04cf7")
+		(property "Reference" "TP105"
+			(at 198.12 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "TP_GND"
+			(at 199.39 139.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 212.09 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://lcsc.com/datasheet/lcsc_datasheet_2504101957_ronghe-RH-5116_C5199806.pdf"
+			(at 212.09 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Green"
+			(at 207.01 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 207.01 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 207.01 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199806"
+			(at 207.01 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5116"
+			(at 207.01 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 207.01 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.4"
+			(at 207.01 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 207.01 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 207.01 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f27ee2fa-d333-4b92-958d-b40d15c83c00")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "TP105")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 68.58 60.96 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "798ccfae-855f-4652-a3d9-503dded1a8cf")
+		(property "Reference" "R1008"
+			(at 69.85 63.5 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 69.215 59.055 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 68.58 59.182 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 68.58 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 68.58 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 68.58 60.96 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 68.58 60.96 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 68.58 60.96 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 68.58 60.96 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 68.58 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 68.58 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 68.58 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 68.58 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "45d072c3-e244-459d-8905-2baf63553821")
+		)
+		(pin "2"
+			(uuid "9b98c379-7822-48bf-8a9a-52da72e4ad12")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R1008")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:22-23-2021")
+		(at 187.96 24.13 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "79fdcc27-ab28-484e-9b1b-7dd46c19f085")
+		(property "Reference" "J103"
+			(at 185.7502 23.1648 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "0.100_2Pin"
+			(at 185.7502 25.4762 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+			(at 193.04 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811011511_Amphenol-ICC-68000-102HLF_C168673.pdf"
+			(at 193.04 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "HEADER VERT 2POS 2.54MM"
+			(at 193.04 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" ""
+			(at 193.04 34.29 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "68000-102HLF"
+			(at 193.04 36.83 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Connectors, Interconnects"
+			(at 193.04 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Rectangular Connectors - Headers, Male Pins"
+			(at 193.04 41.91 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" ""
+			(at 193.04 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" ""
+			(at 193.04 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Amphenol ICC"
+			(at 193.04 52.07 0)
+			(hide yes)
+			(effects
+				(font
+					(size 0.001 0.001)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 193.04 54.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Assembly Type" ""
+			(at 58.42 3.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 187.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C168673"
+			(at 187.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.1458"
+			(at 187.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 187.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 187.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 187.96 24.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "93e5881a-b7c6-4f08-855a-4d2bd03c6111")
+		)
+		(pin "2"
+			(uuid "24a182ed-8c4a-4080-8903-f5e84803d23b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "J103")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 69.85 43.18 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7fd18220-c259-4dc7-931e-dd237c1f3be2")
+		(property "Reference" "#PWR0106"
+			(at 69.85 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 69.85 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 69.85 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 69.85 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 69.85 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "0d66e0ea-964e-4958-bc00-29967ad4fdbb")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0106")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:SWITCH_TACTILE_SPST-NO_0.05A_24V")
+		(at 185.42 137.16 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "7febda9f-67e6-4743-8068-bbe7a5d7f813")
+		(property "Reference" "S102"
+			(at 185.42 131.445 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Value" "SWITCH_TACTILE_SPST-NO_0.05A_24V"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:Switch_Tactile_THT_6x6mm"
+			(at 190.5 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://jlcpcb.com/api/file/downloadByFileSystemAccessId/8588949677001068544"
+			(at 190.5 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "Red Round Button SPST Through Hole Without Bracket Plugin-4P,6x6mm Tactile Switches ROHS"
+			(at 190.5 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 185.42 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C592731"
+			(at 185.42 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2" "Digikey"
+			(at 185.42 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2 PN" ""
+			(at 190.5 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "TE Connectivity ALCOSWITCH Switches"
+			(at 190.5 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "TE Connectivity 1825910-7"
+			(at 190.5 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Switches"
+			(at 190.5 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Tactile Switches"
+			(at 190.5 119.38 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" ""
+			(at 190.5 116.84 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" ""
+			(at 190.5 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 190.5 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Assembly Type" ""
+			(at 45.72 205.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 185.42 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0315"
+			(at 185.42 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 185.42 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 185.42 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "0242e060-10ab-4f20-a0d2-56a4c07056a6")
+		)
+		(pin "2"
+			(uuid "64c8221a-1c97-4fc7-860e-68fc8972a8d0")
+		)
+		(pin "3"
+			(uuid "3fe0f8e5-0b32-483e-ae84-c365724a6ef3")
+		)
+		(pin "4"
+			(uuid "7e2b2d8c-4c8f-4dd2-b4a4-1624e69cb37f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "S102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Polarized")
+		(at 234.95 39.37 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "84f3bc42-79cd-4400-a072-998a54c42d2f")
+		(property "Reference" "C115"
+			(at 229.87 37.465 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "47uF 16V"
+			(at 229.87 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4"
+			(at 235.9152 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 234.95 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS"
+			(at 234.95 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 234.95 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2895272"
+			(at 234.95 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "KNSCHA"
+			(at 234.95 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RVT47UF16V67RV0019"
+			(at 234.95 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 234.95 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.038"
+			(at 234.95 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 234.95 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 234.95 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "16ba6190-b069-40db-8fad-e35c3b2c2ef8")
+		)
+		(pin "2"
+			(uuid "97cc104b-4603-4eac-99b7-ad536fd5d0cb")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C115")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 93.98 71.12 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8637aaad-045f-4106-9915-db2015f5b18a")
+		(property "Reference" "R102"
+			(at 92.71 66.04 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10K"
+			(at 93.98 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 93.98 69.342 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 93.98 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS"
+			(at 93.98 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 93.98 71.12 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269701"
+			(at 93.98 71.12 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 93.98 71.12 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 10K F N"
+			(at 93.98 71.12 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 93.98 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 93.98 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 93.98 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 93.98 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7f41fe8b-cc3d-4609-8b97-185e1ce644d1")
+		)
+		(pin "2"
+			(uuid "ef72773c-dbf0-4e1c-a6f9-7b5d28c65f2a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 182.88 109.22 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "87bdaf45-4073-43ee-9cac-5f75127f0fe0")
+		(property "Reference" "R114"
+			(at 180.975 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "39R"
+			(at 187.325 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 182.88 107.442 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 182.88 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "100mW ±1% 39Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 182.88 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 182.88 109.22 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C325713"
+			(at 182.88 109.22 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 182.88 109.22 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC0603391%N"
+			(at 182.88 109.22 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 182.88 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0027"
+			(at 182.88 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 182.88 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 182.88 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e7ddc178-7028-45e1-95b3-dff138da1ecc")
+		)
+		(pin "2"
+			(uuid "dfd14756-5cf5-4dfb-9e49-f906a9e31fd1")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R114")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3.3V")
+		(at 280.67 31.75 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "881339e1-741b-4511-a4fe-6adc8adbccf5")
+		(property "Reference" "#PWR06"
+			(at 280.67 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 280.67 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 280.67 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 280.67 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 280.67 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "54dd7169-10e5-42c6-b354-1f0bc0de8303")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR06")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 55.88 43.18 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8b8727a9-48f3-49b9-bd0e-69c4c49ff2cb")
+		(property "Reference" "#PWR0102"
+			(at 55.88 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 55.88 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 55.88 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 55.88 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 55.88 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "71a24f56-ce8c-4af2-be1a-331a3ea4824b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 121.92 146.05 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8ba5cfbb-08fa-4867-82a4-9a54ce27c25c")
+		(property "Reference" "#PWR0123"
+			(at 121.92 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 121.92 151.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 121.92 146.05 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 121.92 146.05 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 121.92 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "3af0574c-957c-4012-b560-8e74b3abc355")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0123")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 68.58 95.25 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8f12a267-68e5-4722-bab1-19d5ad973cfe")
+		(property "Reference" "R1005"
+			(at 71.755 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10K"
+			(at 71.12 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 70.358 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 68.58 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS"
+			(at 68.58 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 68.58 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269701"
+			(at 68.58 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 68.58 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 10K F N"
+			(at 68.58 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 68.58 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 68.58 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 68.58 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 68.58 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "903f504c-d4ed-443a-8680-0b51f6db1b05")
+		)
+		(pin "2"
+			(uuid "2097108e-65c1-4773-b69c-dd269a4e8022")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R1005")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 26.67 49.53 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "90cd1e96-678c-4489-98a1-275de43edbac")
+		(property "Reference" "#FLG0103"
+			(at 26.67 47.625 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 21.59 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 26.67 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 26.67 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 26.67 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "9e3ad0fe-1da0-4046-b39f-bd60505283ca")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#FLG0103")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 273.05 45.72 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "90fca9c5-6a96-4dc1-b8f3-eac4656434f8")
+		(property "Reference" "#PWR0117"
+			(at 273.05 52.07 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 273.05 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 273.05 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 273.05 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 273.05 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "3be56ae8-44b5-427f-a2e7-fa1b5416d040")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0117")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:ToolingHole_Pad_1.152mm")
+		(at 212.09 109.22 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "916b5fe5-ce69-4f85-a56e-fce0e7ca1b42")
+		(property "Reference" "T102"
+			(at 214.63 107.95 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "ToolingHole_Pad_1.152mm"
+			(at 214.63 110.49 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:JLC_ToolingHole_0576mm"
+			(at 212.09 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 212.09 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "ToolingHole_Pad_1.152mm"
+			(at 212.09 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 212.09 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "NA"
+			(at 212.09 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0"
+			(at 212.09 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 212.09 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 212.09 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 212.09 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 212.09 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 212.09 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "T102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:U_Box_V104_General_Alarm_Device_LED_Standoff")
+		(at 165.1 62.23 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9df02aba-ac24-40d4-aded-7ee5c2a5a8e2")
+		(property "Reference" "MF103"
+			(at 162.56 66.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 148.59 66.675 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:U_Box_V104_General_Alarm_Device_LED_Standoff"
+			(at 165.1 62.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 165.1 62.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "NA"
+			(at 165.1 62.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 165.1 62.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 165.1 62.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 165.1 62.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 165.1 62.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 165.1 62.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 165.1 62.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 165.1 62.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "MF103")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3.3V")
+		(at 271.78 80.01 0)
+		(mirror y)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a1fb9b24-7df1-484c-8e2c-64a6c4a210bb")
+		(property "Reference" "#PWR017"
+			(at 271.78 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 271.78 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 271.78 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 271.78 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 271.78 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "49b3ab0e-5f1f-486b-8066-e5c0186e3a44")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR017")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 236.22 29.21 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a5aa7d82-6141-43c3-9469-ed3067c0414a")
+		(property "Reference" "+5esp32"
+			(at 227.33 27.94 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "+5esp32"
+			(at 226.695 26.035 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 241.3 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 241.3 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings ROHS red"
+			(at 236.22 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 236.22 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 236.22 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 236.22 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 236.22 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 236.22 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 236.22 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 236.22 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 236.22 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7c8f11ee-2f40-4bae-8960-59024009b31e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "+5esp32")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Polarized")
+		(at 35.56 97.79 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a9fba72b-f340-4379-9620-616229b6e10d")
+		(property "Reference" "C106"
+			(at 38.5572 96.6216 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "47uF 16V"
+			(at 38.5572 98.933 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4"
+			(at 36.5252 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 35.56 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS"
+			(at 35.56 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 35.56 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2895272"
+			(at 35.56 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "KNSCHA"
+			(at 35.56 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RVT47UF16V67RV0019"
+			(at 35.56 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 35.56 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.038"
+			(at 35.56 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 35.56 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 35.56 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "43ee1e55-2afd-4659-8478-10481b5147d2")
+		)
+		(pin "2"
+			(uuid "84eddc2b-3bc3-4534-aab9-aa8516e0bae8")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C106")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 210.82 153.67 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ab5792bd-6812-40c8-ba40-69beaa4aa88f")
+		(property "Reference" "#PWR0119"
+			(at 210.82 160.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 210.82 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 210.82 153.67 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 210.82 153.67 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 210.82 153.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ca9c30fe-8525-4d6b-b90d-218f4ac22e62")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0119")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:ToolingHole_Pad_1.152mm")
+		(at 212.09 114.3 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ad481afe-48ab-4371-bd6e-3b67d2bf0a7e")
+		(property "Reference" "T103"
+			(at 214.63 113.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "ToolingHole_Pad_1.152mm"
+			(at 214.63 115.57 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:JLC_ToolingHole_0576mm"
+			(at 212.09 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 212.09 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "ToolingHole_Pad_1.152mm"
+			(at 212.09 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 212.09 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "NA"
+			(at 212.09 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0"
+			(at 212.09 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 212.09 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 212.09 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 212.09 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 212.09 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 212.09 114.3 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "T103")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:IEC_power_polarity_symbols_barrel_jack_Center_positive")
+		(at 26.67 20.32 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim yes)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "af02160a-1dc0-422b-9983-7515b0051d56")
+		(property "Reference" "SYM102"
+			(at 19.05 22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "IEC_power_polarity_symbols_barrel_jack_Center_positive"
+			(at 26.5176 27.6352 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:Symbol_Barrel_Polarity_Center_Positive"
+			(at 26.2382 25.6794 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 26.67 22.86 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 26.67 20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "NA"
+			(at 26.67 20.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "SYM102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 54.61 95.25 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b226c008-308e-4e0f-adf3-ed92220a4232")
+		(property "Reference" "R1003"
+			(at 57.15 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10K"
+			(at 56.515 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 56.388 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 54.61 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS"
+			(at 54.61 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 54.61 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269701"
+			(at 54.61 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 54.61 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 10K F N"
+			(at 54.61 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 54.61 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 54.61 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 54.61 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 54.61 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e2122e37-ab96-43c7-b9cb-d816b9f7d2b5")
+		)
+		(pin "2"
+			(uuid "428a1554-ab24-400d-b3e9-964c5507ca3d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R1003")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Jumper:Jumper_2_Bridged")
+		(at 210.82 68.58 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board no)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b502bc54-a312-4080-b765-deeb96291fa6")
+		(property "Reference" "JP1"
+			(at 210.82 63.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Jumper_2_Bridged"
+			(at 210.82 66.04 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "2P 2-Pin 2.54mm Pitch Jumper for straight header for J102"
+			(at 210.82 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.amazon.com/2-Pin-2-54mm-Jumper-straight-header/dp/B015IPLY9C"
+			(at 210.82 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Jumper, 2-pole, closed/bridged"
+			(at 210.82 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f1e06125-d225-4dce-a76d-f27a713fdfe4")
+		)
+		(pin "2"
+			(uuid "e1190620-eeea-4464-8790-4d7d0c55d33b")
+		)
+		(instances
+			(project ""
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "JP1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 21.59 97.79 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b6564852-fea1-427d-ad1e-f734f17f42f1")
+		(property "Reference" "C103"
+			(at 24.511 96.6216 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 24.511 98.933 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 22.5552 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 21.59 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 21.59 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 21.59 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 21.59 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 21.59 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 21.59 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 21.59 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 21.59 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 21.59 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 21.59 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f308ff70-34f2-416a-8a92-f8d682669e23")
+		)
+		(pin "2"
+			(uuid "14d47031-7e05-4c86-8382-1775cd7f51f5")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C103")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 173.99 111.76 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b838f180-0fde-4563-8eeb-8c4d68e0df09")
+		(property "Reference" "R115"
+			(at 172.085 109.855 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "39R"
+			(at 178.435 111.125 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 173.99 109.982 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 173.99 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "100mW ±1% 39Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 173.99 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 173.99 111.76 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C325713"
+			(at 173.99 111.76 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 173.99 111.76 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC0603391%N"
+			(at 173.99 111.76 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 173.99 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0027"
+			(at 173.99 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 173.99 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 173.99 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "86e1a56a-df97-47b0-8471-a5c35747626a")
+		)
+		(pin "2"
+			(uuid "ec73be01-c7a7-42ac-93ce-2b3d88353e15")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R115")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 77.47 78.74 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "b8bbdaed-02a0-4430-b962-e7f00239ddab")
+		(property "Reference" "C1100"
+			(at 80.391 77.5716 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 80.391 79.883 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 78.4352 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 77.47 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 77.47 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 77.47 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 77.47 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 77.47 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 77.47 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 77.47 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 77.47 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 77.47 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 77.47 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d712931f-8b1b-48d1-8f96-2e06b15672df")
+		)
+		(pin "2"
+			(uuid "0889e78c-0874-4e17-9a0e-aba1160b8718")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C1100")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 60.96 95.25 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b96c4198-a7e7-4e44-b939-3719ceb9f4a2")
+		(property "Reference" "R1004"
+			(at 63.5 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10K"
+			(at 62.865 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 62.738 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 60.96 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS"
+			(at 60.96 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 60.96 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269701"
+			(at 60.96 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 60.96 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 10K F N"
+			(at 60.96 95.25 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 60.96 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 60.96 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 60.96 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 60.96 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "fcd2dcc5-5dd0-454d-b0cf-b7838a5558d5")
+		)
+		(pin "2"
+			(uuid "34daedc0-1a27-4c9a-8133-45fba1d0efa6")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R1004")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 21.59 104.14 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bd84f948-5f60-4956-8f01-e84c2b79c164")
+		(property "Reference" "#PWR0127"
+			(at 21.59 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 21.59 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 21.59 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 21.59 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 21.59 104.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "585d2ee0-1543-48cf-a486-ca998d47642d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0127")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:ToolingHole_Pad_1.152mm")
+		(at 212.09 104.14 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bead3382-a521-450d-879d-3affa501f4fd")
+		(property "Reference" "T101"
+			(at 214.63 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "ToolingHole_Pad_1.152mm"
+			(at 214.63 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:JLC_ToolingHole_0576mm"
+			(at 212.09 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 212.09 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "ToolingHole_Pad_1.152mm"
+			(at 212.09 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "NA"
+			(at 212.09 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "NA"
+			(at 212.09 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0"
+			(at 212.09 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 212.09 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 212.09 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "NA"
+			(at 212.09 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "NA"
+			(at 212.09 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "NA"
+			(at 212.09 104.14 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "T101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 173.99 87.63 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c033703d-d785-43dd-aa45-0442680789d6")
+		(property "Reference" "#PWR0120"
+			(at 173.99 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 173.99 86.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 173.99 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 173.99 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 173.99 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c6b58b49-c34e-4012-984d-d72f2fd09370")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0120")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Regulator_Linear:LM7805_TO220")
+		(at 78.74 27.94 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c7a20d25-3819-4e4f-aecf-c5b601fc3576")
+		(property "Reference" "U101"
+			(at 78.74 20.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "LM7805_TO220"
+			(at 78.74 22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_THT:TO-220-3_Horizontal_TabDown"
+			(at 78.74 22.225 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.onsemi.cn/PowerSolutions/document/MC7800-D.PDF"
+			(at 78.74 29.21 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "LM7805 TO220"
+			(at 78.74 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Assembly Type" ""
+			(at 78.74 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.1164"
+			(at 78.74 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 78.74 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2977083"
+			(at 78.74 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "HANSCHIP semiconductor"
+			(at 78.74 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "LM7805CTG"
+			(at 78.74 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 78.74 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 78.74 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 78.74 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "bfeccbd2-9c90-4f86-b1e9-82552dc56bd3")
+		)
+		(pin "2"
+			(uuid "eeecfda6-2658-4a64-8909-133952a74778")
+		)
+		(pin "3"
+			(uuid "51051325-ef38-4c06-8825-ecee5582bd84")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "U101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 180.34 46.99 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ca204aee-451a-4a77-88f7-42413d68c35a")
+		(property "Reference" "#PWR0111"
+			(at 180.34 53.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 180.34 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 180.34 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "aabe9b39-1a2d-4f4c-bbba-e87ae123cdd1")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0111")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3.3V")
+		(at 71.12 189.23 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "cc264b60-a673-44ec-aad1-2559d7122d98")
+		(property "Reference" "#PWR033"
+			(at 71.12 193.04 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 71.12 184.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 71.12 189.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 71.12 189.23 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 71.12 189.23 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "897f175e-4de2-449d-804e-58d7fe103cbe")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR033")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x14")
+		(at 166.37 106.68 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "ccc5c21d-bbdb-4218-9911-1637c2405155")
+		(property "Reference" "J106"
+			(at 162.56 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x14 1mm"
+			(at 158.75 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Connector_PinSocket_1.00mm:PinSocket_1x14_P1.00mm_Vertical"
+			(at 166.37 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 166.37 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Gold 250V 1A Policy 1mm 14P 260℃ -40℃~+105℃ 1.27mm Single Row Black Brass 1x14P 1.27mm Plugin,P=1.27mm Pin Headers ROHS"
+			(at 166.37 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 166.37 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2881659"
+			(at 166.37 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "X1311WV-14J-C18D27"
+			(at 166.37 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "XKB Connection"
+			(at 166.37 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 166.37 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.25"
+			(at 166.37 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 166.37 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 166.37 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "8af64f5f-3e86-492a-91a0-6dc5a0c75a52")
+		)
+		(pin "10"
+			(uuid "fc9b606d-0d2d-4f8e-841b-3b9a996023e4")
+		)
+		(pin "11"
+			(uuid "ce23c009-6bbf-4dd9-bc9e-64824fb82f9e")
+		)
+		(pin "12"
+			(uuid "811e8506-8cfc-4842-994c-1d5adaeec7cd")
+		)
+		(pin "13"
+			(uuid "549dd483-eaa5-45ad-8b65-509db6c301e3")
+		)
+		(pin "14"
+			(uuid "0b319388-48de-42e3-b0a4-1b6d31d2dba8")
+		)
+		(pin "2"
+			(uuid "afa0ee6d-d7c5-4458-afe1-f1fc3d974ffb")
+		)
+		(pin "3"
+			(uuid "64f898c7-e393-4ec2-99ce-a0bdd2df01f7")
+		)
+		(pin "4"
+			(uuid "71fdabfa-a4b1-4816-83bf-0446276c28da")
+		)
+		(pin "5"
+			(uuid "69873f2d-6061-4740-bbf6-bab10410adc7")
+		)
+		(pin "6"
+			(uuid "9acde1de-c9c3-416d-ad98-9aaaefa4a26b")
+		)
+		(pin "7"
+			(uuid "c6cf6f58-3791-4394-9631-d48bd8e46312")
+		)
+		(pin "8"
+			(uuid "59460493-f40d-4150-81a8-76f370f25c13")
+		)
+		(pin "9"
+			(uuid "64e9670c-38ad-454c-9283-fbeafb41d8a4")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "J106")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 262.89 39.37 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d42e8152-7a45-41ea-8903-ae569f4506e9")
+		(property "Reference" "C117"
+			(at 263.525 37.465 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 262.89 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 263.8552 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 262.89 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 262.89 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 262.89 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 262.89 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 262.89 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 262.89 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 262.89 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 262.89 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 262.89 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 262.89 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ff4aa2e0-bcf4-417b-9a2f-093ade36954c")
+		)
+		(pin "2"
+			(uuid "c7548490-9f21-4b66-9055-25a2a710411c")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C117")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 119.38 39.37 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d43620d5-e7be-4acf-a7a5-13079883af4f")
+		(property "Reference" "#PWR0109"
+			(at 119.38 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 119.38 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 119.38 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 39.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c2e22335-53b1-4b82-b65f-beb7c19577b5")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0109")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 73.66 142.24 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d9522071-9319-4f52-94dc-cca5183c1348")
+		(property "Reference" "#PWR0124"
+			(at 73.66 148.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 73.66 147.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 73.66 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 73.66 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "4c1f235a-096e-4bf2-b3c3-734e13d78e97")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0124")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 242.57 45.72 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "da1cc4f2-6e38-4a10-aaa9-6ef271f808a9")
+		(property "Reference" "#PWR0114"
+			(at 242.57 52.07 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 242.57 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 242.57 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 242.57 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 242.57 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "0574681c-bc62-4c8a-a7e6-2c82b4099b13")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0114")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 119.38 162.56 270)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "da9cd113-25ad-4795-8944-9694c65af45b")
+		(property "Reference" "D106"
+			(at 114.3 162.56 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Value" "RED 0603"
+			(at 110.49 165.1 90)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
+			(at 119.38 162.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://jlcpcb.com/api/file/downloadByFileSystemAccessId/8550723991833485312"
+			(at 119.38 162.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "LED RED CLEAR SMD"
+			(at 144.78 157.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 119.38 162.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2286"
+			(at 129.54 157.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "KT-0603R"
+			(at 132.08 157.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Optoelectronics"
+			(at 134.62 157.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "LED Indication - Discrete"
+			(at 137.16 157.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Hubei KENTO Elec"
+			(at 147.32 157.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 149.86 157.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" ""
+			(at 3.81 297.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "DK_Detail_Page" ""
+			(at 3.81 297.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Digi-Key_PN" ""
+			(at 3.81 297.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 119.38 162.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0054"
+			(at 119.38 162.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 119.38 162.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 119.38 162.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "baac8584-f085-4add-8a97-70caeea4d917")
+		)
+		(pin "2"
+			(uuid "0a1c02fc-5b29-4f5a-83ca-6c9d9d856055")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "D106")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 139.7 166.37 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "dbedd4ab-021a-4bf2-911b-113b12696aeb")
+		(property "Reference" "#PWR0122"
+			(at 139.7 172.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 139.7 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 166.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 139.7 166.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a7a5fe0b-9b5d-42d4-96b8-ac040a9d9de1")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0122")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 36.83 87.63 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "dd0f2474-74e7-42d0-9048-8f277070039f")
+		(property "Reference" "#FLG01"
+			(at 36.83 85.725 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 39.37 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 36.83 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 36.83 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 36.83 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "23d19e7e-1ada-4433-9737-6629603b92c9")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#FLG01")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 78.74 40.64 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "dd53f014-c116-430a-ba29-b9e594d30d52")
+		(property "Reference" "#PWR0107"
+			(at 78.74 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 78.74 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 78.74 40.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e82e1450-1873-4341-8da7-cb844319dcd1")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0107")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 93.98 88.9 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "dfc5c5f9-8104-4bdf-b9ea-bc0de02c7466")
+		(property "Reference" "#PWR0118"
+			(at 87.63 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 90.17 88.9 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" ""
+			(at 93.98 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 93.98 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "773373fe-ea03-412a-a746-8c2a232cbd6b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0118")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Graphic:Logo_Open_Hardware_Small")
+		(at 266.7 173.99 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e3c9b7d8-fadd-427c-88e4-717973e7bc41")
+		(property "Reference" "SYM101"
+			(at 266.7 167.005 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Logo_Open_Hardware_Small"
+			(at 266.7 179.705 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Symbol:OSHW-Logo2_7.3x6mm_SilkScreen"
+			(at 266.7 173.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 266.7 173.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 266.7 173.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "NA"
+			(at 266.7 173.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "SYM101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3.3V")
+		(at 243.84 123.19 0)
+		(mirror y)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e4549564-5f3e-4be1-a322-c2a5a8e1cc6a")
+		(property "Reference" "#PWR0103"
+			(at 243.84 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 243.84 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 243.84 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 243.84 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 243.84 123.19 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "1453901b-452e-4cec-8545-173b022e8d95")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0103")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3.3V")
+		(at 52.07 180.34 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e65cc6c9-6b99-44bd-a037-206336e75b4e")
+		(property "Reference" "#PWR025"
+			(at 52.07 184.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 52.07 175.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 52.07 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 52.07 180.34 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 52.07 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6137dbb5-e484-4cb4-8ee3-fe46bd52b4fb")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR025")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 242.57 39.37 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e7f390f1-4d6d-44f9-84de-4b6e89995fa9")
+		(property "Reference" "C116"
+			(at 238.76 37.465 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 238.125 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 243.5352 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 242.57 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 242.57 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 242.57 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 242.57 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 242.57 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 242.57 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 242.57 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 242.57 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 242.57 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 242.57 39.37 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "4805a021-81e2-4005-973f-3e80e3166329")
+		)
+		(pin "2"
+			(uuid "ab7ebe8a-9d3e-454b-8ef7-a169e298b83a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "C116")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 35.56 102.87 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f24af445-7dd2-4117-a01a-88edb3e2d25c")
+		(property "Reference" "#PWR0126"
+			(at 35.56 109.22 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 35.56 107.95 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 35.56 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 35.56 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 35.56 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c18098ca-a1e3-4e59-9a63-7033c46c9f8c")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0126")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 29.21 88.9 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f34148cc-2b6e-4056-bea3-b7baeb7c0cd2")
+		(property "Reference" "R101"
+			(at 27.94 83.82 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1R0"
+			(at 29.21 86.36 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 29.21 87.122 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 29.21 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 29.21 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 29.21 88.9 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 29.21 88.9 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 29.21 88.9 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 29.21 88.9 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 29.21 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 29.21 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 29.21 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 29.21 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "8c7ad06e-33a0-4187-917f-f9d41d9f9dac")
+		)
+		(pin "2"
+			(uuid "6a61dc60-afba-4a98-8262-46b7773eb64d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "R101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x10")
+		(at 134.62 143.51 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "f4976296-dca4-4db7-9215-2f391dd01491")
+		(property "Reference" "J107"
+			(at 121.285 136.525 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Conn_01x10 1mm"
+			(at 117.475 138.43 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Connector_PinSocket_1.00mm:PinSocket_1x10_P1.00mm_Vertical"
+			(at 134.62 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 134.62 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Gold 250V 1A Policy 1mm 10P 260℃ -40℃~+105℃ 1.27mm Single Row Black Brass 1.27mm 1x10P Plugin,P=1.27mm Pin Headers ROHS"
+			(at 134.62 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 134.62 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2881655"
+			(at 134.62 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "X1311WV-10J-C18D27"
+			(at 134.62 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "XKB Connection"
+			(at 134.62 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 134.62 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.19"
+			(at 134.62 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 134.62 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 134.62 143.51 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "37f7fb90-ad0b-4e3c-9fe4-a8006992498f")
+		)
+		(pin "10"
+			(uuid "2f3f7a7e-f558-4bfc-b14d-aa1342d86807")
+		)
+		(pin "2"
+			(uuid "35219702-ab48-4a80-8f39-f853fe322565")
+		)
+		(pin "3"
+			(uuid "5aa312cc-a622-4027-8b91-f16ca6ab1784")
+		)
+		(pin "4"
+			(uuid "beb565c6-4b24-46b3-8a6f-008553bb07c1")
+		)
+		(pin "5"
+			(uuid "c5b97d97-15f6-4af1-9267-39ce17b124e6")
+		)
+		(pin "6"
+			(uuid "6084c551-2162-408d-9f26-3a595603bffe")
+		)
+		(pin "7"
+			(uuid "65b3bfb8-8d5f-45d5-a83c-c56728f446c2")
+		)
+		(pin "8"
+			(uuid "fefaa4d4-e08e-45f2-87e2-af596c97d5ec")
+		)
+		(pin "9"
+			(uuid "0800b58a-7431-47ec-920f-816b89e599f2")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "J107")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 52.07 144.78 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f8a3f7a7-0d17-4f1e-8fea-40598cf13a18")
+		(property "Reference" "#PWR0125"
+			(at 52.07 151.13 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 52.07 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 52.07 144.78 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 52.07 144.78 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 52.07 144.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "b2dd32f4-a0fb-4490-a3fa-ad82e2655f93")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(reference "#PWR0125")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet
+		(at 247.65 134.62)
+		(size 19.05 22.86)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(stroke
+			(width 0)
+			(type solid)
+		)
+		(fill
+			(color 0 0 0 0)
+		)
+		(uuid "00000000-0000-0000-0000-000062b3ac2f")
+		(property "Sheetname" "AlarmLights5"
+			(at 247.65 133.9084 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "AlarmLights5.kicad_sch"
+			(at 247.65 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "Light0" input
+			(at 266.7 137.16 0)
+			(uuid "b7f9f08e-a453-417d-85cd-91825edfc9b0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "Light1" input
+			(at 266.7 140.97 0)
+			(uuid "ba1bbb93-b94f-41b4-861f-8fb7e09eba15")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "Light2" input
+			(at 266.7 144.78 0)
+			(uuid "10fb35f8-7b5d-4518-9439-2cab6d8c7b39")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "Light3" input
+			(at 266.7 148.59 0)
+			(uuid "a91aa7ce-44b2-4424-a92e-87642fc220ca")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "Light4" input
+			(at 266.7 152.4 0)
+			(uuid "06e674d6-f1d0-4124-a9e9-d2e78a8f61c6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(page "6")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 246.38 74.93)
+		(size 19.05 21.59)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(stroke
+			(width 0)
+			(type solid)
+		)
+		(fill
+			(color 0 0 0 0)
+		)
+		(uuid "00000000-0000-0000-0000-000062b871ee")
+		(property "Sheetname" "LCD And I2C Interface"
+			(at 246.38 74.2184 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "LCD And I2C Interface.kicad_sch"
+			(at 246.38 97.155 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "SCL" input
+			(at 265.43 85.09 0)
+			(uuid "45416589-0bcb-4ff0-8a40-2cb2b33993c3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "SDA" bidirectional
+			(at 265.43 92.71 0)
+			(uuid "c0e7b28b-397d-45dc-ae6b-c8e17de3b2cc")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "3V3Raw" input
+			(at 265.43 80.01 0)
+			(uuid "6fbd0c59-d8ec-40ee-b82c-28ffa5eb7aa8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(page "4")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 77.47 173.99)
+		(size 22.86 20.32)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0)
+			(type solid)
+		)
+		(fill
+			(color 0 0 0 0)
+		)
+		(uuid "00000000-0000-0000-0000-000062b93801")
+		(property "Sheetname" "SPI Peripherial"
+			(at 77.47 173.2784 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "SPI Peripherial.kicad_sch"
+			(at 77.47 194.2596 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "COPI" input
+			(at 100.33 179.07 0)
+			(uuid "efcf6732-1888-4421-b3b1-afa02fcf7d95")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "CIPO" output
+			(at 100.33 182.88 0)
+			(uuid "81f4bf45-023f-49fc-a768-13d5b638dd56")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "SCK" input
+			(at 100.33 185.42 0)
+			(uuid "6606d53d-3aa5-48e9-9029-b5037d3c81b6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "nCS" input
+			(at 100.33 189.23 0)
+			(uuid "7cceff3a-0829-4914-8e97-a01cddbdca44")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "ControllerVcc" passive
+			(at 100.33 191.77 0)
+			(uuid "bf550a5e-b09a-4f7a-8b1b-ea2cfb853db2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "5VRaw" input
+			(at 77.47 181.61 180)
+			(uuid "2d45e052-ba37-45ea-a766-63aae880be5b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "3V3Raw" input
+			(at 77.47 189.23 180)
+			(uuid "ba2cb794-4092-4a30-8846-4fd19b7377a4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(page "3")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 24.13 173.99)
+		(size 22.86 20.32)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0)
+			(type solid)
+		)
+		(fill
+			(color 0 0 0 0)
+		)
+		(uuid "00000000-0000-0000-0000-000062bc4e7e")
+		(property "Sheetname" "USB_UART"
+			(at 24.13 173.2784 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "USB_UART.kicad_sch"
+			(at 24.13 194.2596 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "ControllerRX" output
+			(at 46.99 191.77 0)
+			(uuid "d1acbca9-d31c-4537-adb6-02d51a612713")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "ControllerTX" input
+			(at 46.99 189.23 0)
+			(uuid "113d56c0-8c37-4dea-8f83-e264538b6b37")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "VBus" passive
+			(at 46.99 185.42 0)
+			(uuid "e04aad36-a95b-4223-b7d2-1a32234dbf22")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "GPIO0" passive
+			(at 24.13 176.53 180)
+			(uuid "f42818b5-6af6-41f6-baec-5029550abe99")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "nRESET" passive
+			(at 24.13 182.88 180)
+			(uuid "87df5e5f-e804-4eb3-8075-68b2bc64aa9b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "3v3" input
+			(at 46.99 180.34 0)
+			(uuid "146aa4ba-4b23-457e-957b-64722b102d46")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(page "2")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 246.38 106.68)
+		(size 20.32 19.05)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(stroke
+			(width 0)
+			(type solid)
+		)
+		(fill
+			(color 0 0 0 0)
+		)
+		(uuid "00000000-0000-0000-0000-000062dd8e5f")
+		(property "Sheetname" "AlarmAudio"
+			(at 246.38 105.9684 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "AlarmAudio.kicad_sch"
+			(at 246.38 126.365 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "Switch_Mute" input
+			(at 266.7 121.92 0)
+			(uuid "d81bef48-b4c9-47c6-9081-8dc659c51945")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "ControllerTX" input
+			(at 266.7 109.22 0)
+			(uuid "d6cd7013-25a0-4e3e-b10a-8678ce882e59")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "ControllerRX" output
+			(at 266.7 111.76 0)
+			(uuid "fb122c6f-2188-492f-9ac3-4c66786af0db")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "Busy" output
+			(at 266.7 114.3 0)
+			(uuid "6b08f541-ae59-45a0-bf6b-674bbb8e1f1f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "3v3" input
+			(at 246.38 123.19 180)
+			(uuid "d260c05c-8029-4ec2-8369-5e5c0185992f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(page "5")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 118.11 173.99)
+		(size 22.86 20.32)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+		)
+		(fill
+			(color 0 0 0 0)
+		)
+		(uuid "b048976a-3284-45ec-9285-06d31a0a2b0c")
+		(property "Sheetname" "RS232"
+			(at 118.11 173.2784 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "RS232.kicad_sch"
+			(at 118.11 194.2596 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "RTS1" input
+			(at 140.97 189.23 0)
+			(uuid "3bfbd16f-1241-406d-854b-93609e8b0b4f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "CTS1" input
+			(at 140.97 191.77 0)
+			(uuid "d67828c3-0660-4e06-aeca-8579151bcc00")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "RX1" input
+			(at 140.97 182.88 0)
+			(uuid "0e548740-d2f6-4c25-b005-dcd4afa4c741")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(pin "TX1" input
+			(at 140.97 185.42 0)
+			(uuid "e8c9ce56-9dcf-4a9e-b373-e2ef5accd0e0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(page "7")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 152.4 173.99)
+		(size 22.86 20.32)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+		)
+		(fill
+			(color 0 0 0 0)
+		)
+		(uuid "b8d8fd1d-0a30-4b7d-ac57-549b73ec2592")
+		(property "Sheetname" "Enclosure Sheet"
+			(at 152.4 173.2784 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "Enclosure.kicad_sch"
+			(at 152.4 194.2596 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf"
+					(page "8")
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
+	(embedded_fonts no)
 )

--- a/PWA_REV2/RS232.kicad_sch
+++ b/PWA_REV2/RS232.kicad_sch
@@ -1,2568 +1,6315 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid 10594b9c-d1cb-47d8-a9c8-685ec6050c14)
-
-  (paper "A4")
-
-  (title_block
-    (title "KRAKE_PCB")
-    (date "2025-07-18")
-    (rev "2.0")
-    (company "PublicInvention")
-    (comment 1 "GNU Affero General Public License v3.0")
-    (comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
-    (comment 3 "https://github.com/PubInv/krake")
-    (comment 4 "Inherited from the GPAD")
-  )
-
-  (lib_symbols
-    (symbol "Device:C" (pin_numbers hide) (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C" (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Unpolarized capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "C_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_0_1"
-        (polyline
-          (pts
-            (xy -2.032 -0.762)
-            (xy 2.032 -0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.032 0.762)
-            (xy 2.032 0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "C_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:C_Polarized" (pin_numbers hide) (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C_Polarized" (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Polarized capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "CP_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_Polarized_0_1"
-        (rectangle (start -2.286 0.508) (end 2.286 1.016)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.778 2.286)
-            (xy -0.762 2.286)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 2.794)
-            (xy -1.27 1.778)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 2.286 -0.508) (end -2.286 -1.016)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "C_Polarized_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:R" (pin_numbers hide) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "R" (at 2.032 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "R" (at 0 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at -1.778 0 90)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "R res resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "R_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "R_0_1"
-        (rectangle (start -1.016 -2.54) (end 1.016 2.54)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "R_1_1"
-        (pin passive line (at 0 3.81 270) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GND_1" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "GND_1" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"GND\" , ground" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "GND_1_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 -1.27)
-            (xy 1.27 -1.27)
-            (xy 0 -2.54)
-            (xy -1.27 -1.27)
-            (xy 0 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "GND_1_1_1"
-        (pin power_in line (at 0 0 270) (length 0) hide
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:DE9_Receptacle_MountingHoles_wSIGNALnames" (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "J" (at 0 16.51 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "DE9_Receptacle_MountingHoles" (at 0 14.605 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" " ~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "connector receptacle female D-SUB DB9" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "9-pin female receptacle socket D-SUB connector, Mounting Hole" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "DSUB*Female*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "DE9_Receptacle_MountingHoles_wSIGNALnames_0_1"
-        (circle (center -1.778 -10.16) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center -1.778 -5.08) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center -1.778 0) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center -1.778 5.08) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center -1.778 10.16) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.81 -10.16)
-            (xy -2.54 -10.16)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.81 -7.62)
-            (xy 0.508 -7.62)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.81 -5.08)
-            (xy -2.54 -5.08)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.81 -2.54)
-            (xy 0.508 -2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.81 0)
-            (xy -2.54 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.81 2.54)
-            (xy 0.508 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.81 5.08)
-            (xy -2.54 5.08)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.81 7.62)
-            (xy 0.508 7.62)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.81 10.16)
-            (xy -2.54 10.16)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.81 13.335)
-            (xy -3.81 -13.335)
-            (xy 3.81 -9.525)
-            (xy 3.81 9.525)
-            (xy -3.81 13.335)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-        (circle (center 1.27 -7.62) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 1.27 -2.54) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 1.27 2.54) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 1.27 7.62) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "DE9_Receptacle_MountingHoles_wSIGNALnames_1_0"
-        (text "DSR" (at 2.54 6.35 0)
-          (effects (font (size 0.762 0.762)))
-        )
-        (text "RTS" (at 2.54 1.27 0)
-          (effects (font (size 0.762 0.762)))
-        )
-      )
-      (symbol "DE9_Receptacle_MountingHoles_wSIGNALnames_1_1"
-        (text "CTS" (at 2.54 -3.81 0)
-          (effects (font (size 0.762 0.762)))
-        )
-        (text "DCD" (at -2.54 8.89 0)
-          (effects (font (size 0.762 0.762)))
-        )
-        (text "DTR" (at -2.54 -6.35 0)
-          (effects (font (size 0.762 0.762)))
-        )
-        (text "GND" (at -2.54 -11.43 0)
-          (effects (font (size 0.762 0.762)))
-        )
-        (text "R" (at 2.54 -8.89 0)
-          (effects (font (size 0.762 0.762)))
-        )
-        (text "RXD" (at -2.54 3.81 0)
-          (effects (font (size 0.762 0.762)))
-        )
-        (text "TXD" (at -2.54 -1.27 0)
-          (effects (font (size 0.762 0.762)))
-        )
-        (pin passive line (at 0 -15.24 90) (length 3.81)
-          (name "PAD" (effects (font (size 1.27 1.27))))
-          (number "0" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 10.16 0) (length 3.81)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 5.08 0) (length 3.81)
-          (name "2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 0 0) (length 3.81)
-          (name "3" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 -5.08 0) (length 3.81)
-          (name "4" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 -10.16 0) (length 3.81)
-          (name "5" (effects (font (size 1.27 1.27))))
-          (number "5" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 7.62 0) (length 3.81)
-          (name "6" (effects (font (size 1.27 1.27))))
-          (number "6" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 2.54 0) (length 3.81)
-          (name "7" (effects (font (size 1.27 1.27))))
-          (number "7" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 -2.54 0) (length 3.81)
-          (name "8" (effects (font (size 1.27 1.27))))
-          (number "8" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 -7.62 0) (length 3.81)
-          (name "9" (effects (font (size 1.27 1.27))))
-          (number "9" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:MAX3232_InOrder" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
-      (property "Reference" "U?" (at 1.9559 29.845 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "MAX3232" (at 1.9559 27.305 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "Package_SO:SOIC-16_4.55x10.3mm_P1.27mm" (at -21.59 -10.16 0)
-        (effects (font (size 1.27 1.27)) (justify left) hide)
-      )
-      (property "Datasheet" "https://datasheets.maximintegrated.com/en/ds/MAX3222-MAX3241.pdf" (at 1.27 -12.7 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "rs232 uart transceiver line-driver" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "3.0V to 5.5V, Low-Power, up to 1Mbps, True RS-232 Transceivers Using Four 0.1μF External Capacitors" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "SOIC*P1.27mm* DIP*W7.62mm* TSSOP*4.4x5mm*P0.65mm*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "MAX3232_InOrder_0_0"
-        (text "RS232" (at -6.35 -2.54 0)
-          (effects (font (size 1.27 1.27)))
-        )
-        (text "RS232" (at -5.08 0 0)
-          (effects (font (size 1.27 1.27)))
-        )
-        (text "RS232" (at 5.08 12.7 0)
-          (effects (font (size 1.27 1.27)))
-        )
-        (text "RS232" (at 5.08 16.51 0)
-          (effects (font (size 1.27 1.27)))
-        )
-      )
-      (symbol "MAX3232_InOrder_0_1"
-        (rectangle (start -15.24 26.67) (end 15.24 -8.89)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-        (circle (center -0.635 -1.27) (radius 0.635)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (circle (center -0.635 3.81) (radius 0.635)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -7.62 15.24)
-            (xy -7.62 3.81)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -6.35 11.43)
-            (xy -6.35 7.62)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.54 -4.445)
-            (xy -9.525 -4.445)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.905 7.62)
-            (xy -6.35 7.62)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 -1.27)
-            (xy -6.35 -1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 3.81)
-            (xy -7.62 3.81)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 -4.445)
-            (xy 7.62 -4.445)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.175 7.62)
-            (xy 7.62 7.62)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.81 -1.27)
-            (xy 8.255 -1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.81 3.81)
-            (xy 8.255 3.81)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 7.62 15.24)
-            (xy -7.62 15.24)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 8.89 11.43)
-            (xy -6.35 11.43)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.54 -6.35)
-            (xy -2.54 -2.54)
-            (xy 1.27 -4.445)
-            (xy -2.54 -6.35)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.905 5.715)
-            (xy -1.905 9.525)
-            (xy 1.905 7.62)
-            (xy -1.905 5.715)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.81 -3.175)
-            (xy 3.81 0.635)
-            (xy 0 -1.27)
-            (xy 3.81 -3.175)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.81 1.905)
-            (xy 3.81 5.715)
-            (xy 0 3.81)
-            (xy 3.81 1.905)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (circle (center 1.905 -4.445) (radius 0.635)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (circle (center 2.54 7.62) (radius 0.635)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "MAX3232_InOrder_1_0"
-        (text "Charge\nPump" (at -5.08 20.32 0)
-          (effects (font (size 1.27 1.27)))
-        )
-        (text "Logic" (at 6.35 -2.54 0)
-          (effects (font (size 0.889 0.889)))
-        )
-        (text "Logic" (at 6.35 0 0)
-          (effects (font (size 0.889 0.889)))
-        )
-        (text "Logic" (at 6.35 5.08 0)
-          (effects (font (size 0.889 0.889)))
-        )
-        (text "Logic" (at 6.35 8.89 0)
-          (effects (font (size 0.889 0.889)))
-        )
-      )
-      (symbol "MAX3232_InOrder_1_1"
-        (polyline
-          (pts
-            (xy -8.89 24.13)
-            (xy -8.89 17.78)
-          )
-          (stroke (width 0.254) (type dot))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 17.78)
-            (xy -8.89 17.78)
-          )
-          (stroke (width 0.254) (type dot))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 24.13)
-            (xy -8.89 24.13)
-          )
-          (stroke (width 0.254) (type dot))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 24.13)
-            (xy -1.27 17.78)
-          )
-          (stroke (width 0.254) (type dot))
-          (fill (type none))
-        )
-        (pin passive line (at -20.32 22.86 0) (length 5.08)
-          (name "C1+" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 20.32 0 180) (length 5.08)
-          (name "T2IN" (effects (font (size 1.27 1.27))))
-          (number "10" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 20.32 3.81 180) (length 5.08)
-          (name "T1IN" (effects (font (size 1.27 1.27))))
-          (number "11" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at 20.32 7.62 180) (length 5.08)
-          (name "R1OUT" (effects (font (size 1.27 1.27))))
-          (number "12" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 20.32 11.43 180) (length 5.08)
-          (name "R1IN" (effects (font (size 1.27 1.27))))
-          (number "13" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at 20.32 15.24 180) (length 5.08)
-          (name "T1OUT" (effects (font (size 1.27 1.27))))
-          (number "14" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 20.32 19.05 180) (length 5.08)
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "15" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 20.32 22.86 180) (length 5.08)
-          (name "VCC" (effects (font (size 1.27 1.27))))
-          (number "16" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_out line (at -20.32 19.05 0) (length 5.08)
-          (name "VS+" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -20.32 15.24 0) (length 5.08)
-          (name "C1-" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -20.32 11.43 0) (length 5.08)
-          (name "C2+" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -20.32 7.62 0) (length 5.08)
-          (name "C2-" (effects (font (size 1.27 1.27))))
-          (number "5" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_out line (at -20.32 3.81 0) (length 5.08)
-          (name "VS-" (effects (font (size 1.27 1.27))))
-          (number "6" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at -20.32 0 0) (length 5.08)
-          (name "T2OUT" (effects (font (size 1.27 1.27))))
-          (number "7" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -20.32 -3.81 0) (length 5.08)
-          (name "R2IN" (effects (font (size 1.27 1.27))))
-          (number "8" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at 20.32 -3.81 180) (length 5.08)
-          (name "R2OUT" (effects (font (size 1.27 1.27))))
-          (number "9" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "power:+3.3V" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "+3.3V" (at 0 3.556 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"+3.3V\"" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "+3.3V_0_1"
-        (polyline
-          (pts
-            (xy -0.762 1.27)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.54)
-            (xy 0.762 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "+3.3V_1_1"
-        (pin power_in line (at 0 0 90) (length 0) hide
-          (name "+3.3V" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "power:PWR_FLAG" (power) (pin_numbers hide) (pin_names (offset 0) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "#FLG" (at 0 1.905 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "PWR_FLAG" (at 0 3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "flag power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Special symbol for telling ERC where power comes from" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "PWR_FLAG_0_0"
-        (pin power_out line (at 0 0 90) (length 0)
-          (name "pwr" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-      (symbol "PWR_FLAG_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 1.27)
-            (xy -1.016 1.905)
-            (xy 0 2.54)
-            (xy 1.016 1.905)
-            (xy 0 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-  )
-
-  (junction (at 176.53 78.74) (diameter 0) (color 0 0 0 0)
-    (uuid 14dd2558-c3c1-46c2-acea-1bc82dcc1c74)
-  )
-  (junction (at 80.01 124.46) (diameter 0) (color 0 0 0 0)
-    (uuid 3af23698-82f2-4c51-8355-f5ed2c3107c2)
-  )
-  (junction (at 171.45 74.93) (diameter 0) (color 0 0 0 0)
-    (uuid 3c5692ec-a167-41fb-8466-f579fa2e38c4)
-  )
-  (junction (at 176.53 74.93) (diameter 0) (color 0 0 0 0)
-    (uuid 72beaf47-8252-407c-9236-e390f47b9e3b)
-  )
-  (junction (at 167.64 74.93) (diameter 0) (color 0 0 0 0)
-    (uuid 914629a5-5972-440e-923d-dba09e11e501)
-  )
-  (junction (at 158.75 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 95e8b40f-dc2e-49b2-b8d0-d0e12df3c0de)
-  )
-  (junction (at 157.48 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid cbca69f0-26a7-4211-9317-4f2fd5cf7f4a)
-  )
-
-  (no_connect (at 187.96 134.62) (uuid 8e0b3938-1785-416a-995f-bf5341acbfd6))
-  (no_connect (at 187.96 116.84) (uuid d7ecec87-8df6-46bc-8125-cd50a6d17b95))
-
-  (wire (pts (xy 127 38.1) (xy 127 43.18))
-    (stroke (width 0) (type default))
-    (uuid 02b5aeaf-61fb-47c9-b0e1-0f809c7e5a59)
-  )
-  (wire (pts (xy 55.88 105.41) (xy 55.88 107.95))
-    (stroke (width 0) (type default))
-    (uuid 034983da-8d4f-4854-abab-1117ecd1cf2b)
-  )
-  (wire (pts (xy 138.43 38.1) (xy 138.43 43.18))
-    (stroke (width 0) (type default))
-    (uuid 061fc753-9df8-447a-be00-b2a3656cae17)
-  )
-  (wire (pts (xy 180.34 129.54) (xy 187.96 129.54))
-    (stroke (width 0) (type default))
-    (uuid 067618f6-4a6c-449b-97fb-b57609bcfff6)
-  )
-  (wire (pts (xy 69.85 107.95) (xy 69.85 99.06))
-    (stroke (width 0) (type default))
-    (uuid 0d16bf60-e781-4317-b0bb-a8a0544be7ff)
-  )
-  (wire (pts (xy 69.85 78.74) (xy 55.88 78.74))
-    (stroke (width 0) (type default))
-    (uuid 0f12ab80-08ad-4e6d-b67d-ce69a529d934)
-  )
-  (wire (pts (xy 76.2 142.24) (xy 157.48 142.24))
-    (stroke (width 0) (type default))
-    (uuid 12165d58-2c84-48d7-b6c0-3515f068e73a)
-  )
-  (wire (pts (xy 132.08 102.87) (xy 124.46 102.87))
-    (stroke (width 0) (type default))
-    (uuid 1645178f-a335-46b6-a3a1-a2baf2ac2729)
-  )
-  (wire (pts (xy 190.5 78.74) (xy 176.53 78.74))
-    (stroke (width 0) (type default))
-    (uuid 19fa5a8c-7e23-470b-9c20-d6361c0c2197)
-  )
-  (wire (pts (xy 124.46 106.68) (xy 138.43 106.68))
-    (stroke (width 0) (type default))
-    (uuid 1aad4147-6867-423f-a164-35eae5ba2c19)
-  )
-  (wire (pts (xy 179.07 74.93) (xy 176.53 74.93))
-    (stroke (width 0) (type default))
-    (uuid 1dccc49f-d5d3-43a3-8f10-e1943fffb020)
-  )
-  (wire (pts (xy 187.96 132.08) (xy 168.91 132.08))
-    (stroke (width 0) (type default))
-    (uuid 30149a93-3415-459c-8760-fa1d02d7a2f2)
-  )
-  (wire (pts (xy 161.29 132.08) (xy 157.48 132.08))
-    (stroke (width 0) (type default))
-    (uuid 30b14cf7-6071-4dce-9cb6-bba84de5ec71)
-  )
-  (wire (pts (xy 80.01 71.12) (xy 80.01 72.39))
-    (stroke (width 0) (type default))
-    (uuid 324cd861-ca17-43a1-82e6-7b7a36793a86)
-  )
-  (wire (pts (xy 132.08 38.1) (xy 132.08 43.18))
-    (stroke (width 0) (type default))
-    (uuid 37b68870-42ab-4345-af4e-1f2f14b94c45)
-  )
-  (wire (pts (xy 184.15 138.43) (xy 184.15 137.16))
-    (stroke (width 0) (type default))
-    (uuid 3adac475-69fd-4fe7-819e-2ea23ff70810)
-  )
-  (wire (pts (xy 179.07 124.46) (xy 187.96 124.46))
-    (stroke (width 0) (type default))
-    (uuid 3e19ea27-b7f2-450c-94bd-e72ff39462fd)
-  )
-  (wire (pts (xy 184.15 137.16) (xy 187.96 137.16))
-    (stroke (width 0) (type default))
-    (uuid 3f562a47-2a87-47c1-96bb-6688c60670da)
-  )
-  (wire (pts (xy 127 99.06) (xy 124.46 99.06))
-    (stroke (width 0) (type default))
-    (uuid 41a18c5c-7229-482e-be7b-8622855d2dc5)
-  )
-  (wire (pts (xy 147.32 127) (xy 160.02 127))
-    (stroke (width 0) (type default))
-    (uuid 41ae4f25-6189-45d3-87d8-0045c9208624)
-  )
-  (wire (pts (xy 83.82 83.82) (xy 69.85 83.82))
-    (stroke (width 0) (type default))
-    (uuid 41bde6ca-c9f8-4e68-8763-2fc9a04bf9b1)
-  )
-  (wire (pts (xy 176.53 88.9) (xy 176.53 87.63))
-    (stroke (width 0) (type default))
-    (uuid 4253414f-ccb1-4dd5-a997-820c7c8ff5fe)
-  )
-  (wire (pts (xy 168.91 142.24) (xy 179.07 142.24))
-    (stroke (width 0) (type default))
-    (uuid 430b4e3f-3551-46d1-9ecd-4f251e699e32)
-  )
-  (wire (pts (xy 167.64 127) (xy 187.96 127))
-    (stroke (width 0) (type default))
-    (uuid 446e7417-f6c8-48c9-8c8e-8cada1e235e5)
-  )
-  (wire (pts (xy 138.43 50.8) (xy 138.43 106.68))
-    (stroke (width 0) (type default))
-    (uuid 45398b76-0292-4602-a54e-17f2aa79e4b0)
-  )
-  (wire (pts (xy 158.75 149.86) (xy 161.29 149.86))
-    (stroke (width 0) (type default))
-    (uuid 462f1fea-3030-41a4-86bd-3dcbd84cbbcb)
-  )
-  (wire (pts (xy 124.46 87.63) (xy 129.54 87.63))
-    (stroke (width 0) (type default))
-    (uuid 4cd44d7d-a91d-458c-ac3d-c521a32cb1e5)
-  )
-  (wire (pts (xy 55.88 90.17) (xy 55.88 91.44))
-    (stroke (width 0) (type default))
-    (uuid 52150aa9-bc56-43de-ae8a-b530f584e43e)
-  )
-  (wire (pts (xy 69.85 99.06) (xy 83.82 99.06))
-    (stroke (width 0) (type default))
-    (uuid 544b7e56-6131-41ec-b1fd-d786f69bde49)
-  )
-  (wire (pts (xy 83.82 95.25) (xy 55.88 95.25))
-    (stroke (width 0) (type default))
-    (uuid 549862e4-fb04-4abe-b85c-9690d6d86af5)
-  )
-  (wire (pts (xy 176.53 137.16) (xy 168.91 137.16))
-    (stroke (width 0) (type default))
-    (uuid 5a0be15d-205f-4434-b9fe-b81ec5dbe255)
-  )
-  (wire (pts (xy 157.48 142.24) (xy 161.29 142.24))
-    (stroke (width 0) (type default))
-    (uuid 5a22b2ac-1903-4e8f-aa07-26e2f77569d6)
-  )
-  (wire (pts (xy 80.01 71.12) (xy 167.64 71.12))
-    (stroke (width 0) (type default))
-    (uuid 6674b2d4-e58f-46fe-bd00-0ee048b2d26e)
-  )
-  (wire (pts (xy 190.5 90.17) (xy 190.5 87.63))
-    (stroke (width 0) (type default))
-    (uuid 69555027-340e-49ad-9a83-14169bb616c0)
-  )
-  (wire (pts (xy 55.88 78.74) (xy 55.88 82.55))
-    (stroke (width 0) (type default))
-    (uuid 697deaee-573a-49e7-943d-38141bba50a0)
-  )
-  (wire (pts (xy 83.82 110.49) (xy 76.2 110.49))
-    (stroke (width 0) (type default))
-    (uuid 69b305b3-d9bf-483f-9d5d-fd46f67bddaa)
-  )
-  (wire (pts (xy 124.46 74.93) (xy 167.64 74.93))
-    (stroke (width 0) (type default))
-    (uuid 6ce0ed90-7828-4d8f-97f2-598840715f4f)
-  )
-  (wire (pts (xy 149.86 121.92) (xy 160.02 121.92))
-    (stroke (width 0) (type default))
-    (uuid 6d3b43fa-3248-4497-aa2f-87622140b772)
-  )
-  (wire (pts (xy 80.01 124.46) (xy 129.54 124.46))
-    (stroke (width 0) (type default))
-    (uuid 789e7ed9-d322-4e8b-a429-0a3d47993326)
-  )
-  (wire (pts (xy 124.46 95.25) (xy 147.32 95.25))
-    (stroke (width 0) (type default))
-    (uuid 7954110e-5cc7-4f61-9036-d13838f83a0f)
-  )
-  (wire (pts (xy 55.88 107.95) (xy 69.85 107.95))
-    (stroke (width 0) (type default))
-    (uuid 7f1eee0a-c934-4314-a5c7-d2040d652c57)
-  )
-  (wire (pts (xy 176.53 78.74) (xy 171.45 78.74))
-    (stroke (width 0) (type default))
-    (uuid 7fca1dfd-b182-46fe-b7af-da5d141cce20)
-  )
-  (wire (pts (xy 171.45 74.93) (xy 176.53 74.93))
-    (stroke (width 0) (type default))
-    (uuid 865311ce-e312-4235-b7ed-e6bf8c0fc686)
-  )
-  (wire (pts (xy 55.88 95.25) (xy 55.88 97.79))
-    (stroke (width 0) (type default))
-    (uuid 88301860-ee34-496f-bd67-a7cb4ab0df29)
-  )
-  (wire (pts (xy 176.53 80.01) (xy 176.53 78.74))
-    (stroke (width 0) (type default))
-    (uuid 89227f4f-f193-437f-9147-24dc200d0638)
-  )
-  (wire (pts (xy 80.01 124.46) (xy 80.01 127))
-    (stroke (width 0) (type default))
-    (uuid 8e6fbd99-8592-4e69-b487-837c51dc91a3)
-  )
-  (wire (pts (xy 176.53 67.31) (xy 176.53 74.93))
-    (stroke (width 0) (type default))
-    (uuid 922ad8a1-d2dd-46b2-a8df-bd78911fc665)
-  )
-  (wire (pts (xy 80.01 102.87) (xy 80.01 116.84))
-    (stroke (width 0) (type default))
-    (uuid 92ff9423-7d8a-4b83-b5c1-d46fa72d0515)
-  )
-  (wire (pts (xy 80.01 87.63) (xy 83.82 87.63))
-    (stroke (width 0) (type default))
-    (uuid 97e0e511-9022-4708-ab5d-045b0d3d98a7)
-  )
-  (wire (pts (xy 124.46 74.93) (xy 124.46 83.82))
-    (stroke (width 0) (type default))
-    (uuid 9a941f80-c45e-42ed-bd65-c5fbd9d4e810)
-  )
-  (wire (pts (xy 161.29 137.16) (xy 158.75 137.16))
-    (stroke (width 0) (type default))
-    (uuid 9f8f848f-9eb3-4b20-b7cb-99f29cee1e0b)
-  )
-  (wire (pts (xy 143.51 110.49) (xy 124.46 110.49))
-    (stroke (width 0) (type default))
-    (uuid a93c3f6f-9398-42c8-b4cf-69b0a0edee4f)
-  )
-  (wire (pts (xy 55.88 91.44) (xy 83.82 91.44))
-    (stroke (width 0) (type default))
-    (uuid a999632d-baf9-413d-b9b2-8d86c7cec258)
-  )
-  (wire (pts (xy 69.85 83.82) (xy 69.85 78.74))
-    (stroke (width 0) (type default))
-    (uuid aaabd674-1953-4017-bdc0-d3573fb841f5)
-  )
-  (wire (pts (xy 167.64 121.92) (xy 187.96 121.92))
-    (stroke (width 0) (type default))
-    (uuid ab6eaf4d-cc5d-484d-9ba1-b4f199722390)
-  )
-  (wire (pts (xy 129.54 87.63) (xy 129.54 124.46))
-    (stroke (width 0) (type default))
-    (uuid ae945efa-5c1a-4fd1-9ab5-1732779ea100)
-  )
-  (wire (pts (xy 179.07 142.24) (xy 179.07 124.46))
-    (stroke (width 0) (type default))
-    (uuid afe2f4bf-d3e2-42af-88bc-4af9af4b333f)
-  )
-  (wire (pts (xy 149.86 91.44) (xy 149.86 121.92))
-    (stroke (width 0) (type default))
-    (uuid ba802029-6d4e-4ba4-9e5f-843424c7dd56)
-  )
-  (wire (pts (xy 73.66 149.86) (xy 158.75 149.86))
-    (stroke (width 0) (type default))
-    (uuid bb182ec0-fe72-43ba-a920-853dc349e926)
-  )
-  (wire (pts (xy 180.34 149.86) (xy 180.34 129.54))
-    (stroke (width 0) (type default))
-    (uuid bb881327-1e63-4c4a-bc0d-6a56975ee32f)
-  )
-  (wire (pts (xy 190.5 80.01) (xy 190.5 78.74))
-    (stroke (width 0) (type default))
-    (uuid bcc7bea4-fea5-4e9e-9b50-28f731f86458)
-  )
-  (wire (pts (xy 176.53 119.38) (xy 176.53 137.16))
-    (stroke (width 0) (type default))
-    (uuid be5af32a-7a6e-4bcf-b0c6-1b7d8500a319)
-  )
-  (wire (pts (xy 143.51 50.8) (xy 143.51 110.49))
-    (stroke (width 0) (type default))
-    (uuid c0033cfe-24d9-41a0-ae9a-7feb0d51bb38)
-  )
-  (wire (pts (xy 147.32 95.25) (xy 147.32 127))
-    (stroke (width 0) (type default))
-    (uuid c16960aa-6734-471d-824a-f5356a329b40)
-  )
-  (wire (pts (xy 167.64 74.93) (xy 171.45 74.93))
-    (stroke (width 0) (type default))
-    (uuid c25ff826-1071-435e-aeea-57989328e0ee)
-  )
-  (wire (pts (xy 167.64 71.12) (xy 167.64 74.93))
-    (stroke (width 0) (type default))
-    (uuid c2c59eac-5440-4d41-8791-90f78343e949)
-  )
-  (wire (pts (xy 124.46 91.44) (xy 149.86 91.44))
-    (stroke (width 0) (type default))
-    (uuid c3e3c444-ad22-41a3-8295-f3ae73e80f85)
-  )
-  (wire (pts (xy 83.82 106.68) (xy 73.66 106.68))
-    (stroke (width 0) (type default))
-    (uuid cb1fbcf8-8331-48f0-8a90-356eb32d8f94)
-  )
-  (wire (pts (xy 157.48 132.08) (xy 157.48 142.24))
-    (stroke (width 0) (type default))
-    (uuid cc01e1de-8e53-4d73-865c-33b5f472b421)
-  )
-  (wire (pts (xy 76.2 110.49) (xy 76.2 142.24))
-    (stroke (width 0) (type default))
-    (uuid ccdc2686-f1b8-43b9-9b15-b42b5d8bed07)
-  )
-  (wire (pts (xy 194.31 74.93) (xy 186.69 74.93))
-    (stroke (width 0) (type default))
-    (uuid cf1de08b-9e93-47d2-9ccb-06527e5007f6)
-  )
-  (wire (pts (xy 158.75 137.16) (xy 158.75 149.86))
-    (stroke (width 0) (type default))
-    (uuid d2e030ef-7ffc-43a0-ae7d-0224b0730f65)
-  )
-  (wire (pts (xy 168.91 149.86) (xy 180.34 149.86))
-    (stroke (width 0) (type default))
-    (uuid db106546-2a22-4d61-8d80-5db7a9be2d33)
-  )
-  (wire (pts (xy 143.51 38.1) (xy 143.51 43.18))
-    (stroke (width 0) (type default))
-    (uuid de33f4e2-24e8-4fb5-8aab-2fc063f4852f)
-  )
-  (wire (pts (xy 132.08 50.8) (xy 132.08 102.87))
-    (stroke (width 0) (type default))
-    (uuid df419aa3-ca09-4e66-98ef-8e3a3d159260)
-  )
-  (wire (pts (xy 171.45 78.74) (xy 171.45 74.93))
-    (stroke (width 0) (type default))
-    (uuid ef16e293-8835-4fbc-9dee-d8f3e717c19a)
-  )
-  (wire (pts (xy 127 50.8) (xy 127 99.06))
-    (stroke (width 0) (type default))
-    (uuid f1d4af55-8d0e-4f0a-af29-f4cf32ffa608)
-  )
-  (wire (pts (xy 80.01 102.87) (xy 83.82 102.87))
-    (stroke (width 0) (type default))
-    (uuid f3a94260-9a23-4667-879b-a37a86735746)
-  )
-  (wire (pts (xy 73.66 106.68) (xy 73.66 149.86))
-    (stroke (width 0) (type default))
-    (uuid f78c621a-f162-434a-9a71-78970c016b80)
-  )
-  (wire (pts (xy 80.01 80.01) (xy 80.01 87.63))
-    (stroke (width 0) (type default))
-    (uuid f82ec5de-9a2c-49f2-8695-8f0712ba7e0f)
-  )
-  (wire (pts (xy 187.96 119.38) (xy 176.53 119.38))
-    (stroke (width 0) (type default))
-    (uuid fd80848d-84dd-4d5b-9e8e-678ddf640473)
-  )
-
-  (text "Place R702 near uControler TX1 pin.\nPlace R703 near uControler RTS1 pin."
-    (at 130.81 30.48 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 0903b68d-ef67-4bc7-bf6e-b726964195bb)
-  )
-  (text "NULL MODEM" (at 159.385 114.3 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 2861132a-7582-47eb-a28c-1bb747daad6c)
-  )
-  (text "DATA COMMUNICATIONS EQUIPMENT" (at 204.47 135.89 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid fa42bb90-3f98-4611-954e-6daa854d33ac)
-  )
-
-  (label "3v3RS232" (at 142.24 71.12 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 129a8fb3-3059-4322-a442-6c4263056eed)
-  )
-  (label "RS232_RX" (at 148.59 127 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 1e45dc95-6089-4496-8679-5222979ce657)
-  )
-  (label "RS232_TX" (at 149.86 121.92 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 570e9316-e65d-4e51-9cee-617ffc9c50b1)
-  )
-  (label "RS232_RTS" (at 147.32 149.86 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 5c204211-5bcb-42a5-b108-ad0d9528f4bf)
-  )
-  (label "DCE_RX" (at 168.91 121.92 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 81f39eed-e5f9-4d94-bc57-57f7939daff5)
-  )
-  (label "DCE_TX" (at 168.91 127 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid b003ed34-761e-40cb-b137-1c32872a6567)
-  )
-  (label "DCE_RTS" (at 168.91 142.24 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid d131b565-49f3-4a3c-9a77-081d49ce5cb1)
-  )
-  (label "DCE_CTS" (at 168.91 149.86 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid f6d136b2-43ca-47f3-b475-942c5dd95e48)
-  )
-  (label "RS232_CTS" (at 146.05 142.24 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid fc09cae2-27a7-48a4-bbec-37045b7fd31e)
-  )
-
-  (hierarchical_label "CTS1" (shape input) (at 143.51 38.1 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 47ef9bca-cd51-4cde-915a-36a519dcf0e4)
-  )
-  (hierarchical_label "TX1" (shape input) (at 132.08 38.1 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 61ac1c68-2294-400e-ad63-580e9a522e13)
-  )
-  (hierarchical_label "RX1" (shape input) (at 127 38.1 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid d1a5894f-69c2-441b-a0ef-b508c0a424d5)
-  )
-  (hierarchical_label "RTS1" (shape input) (at 138.43 38.1 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid dd6c4c5d-a118-49d8-9af7-a7633a08fe20)
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 195.58 142.24 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 00ad6793-66ba-42a8-abd4-61f63b15c5cc)
-    (property "Reference" "#PWR0108" (at 195.58 148.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 195.58 147.32 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 195.58 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 195.58 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d39bf19b-7e6d-4b2e-9397-e2e93bad7282))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "#PWR0703") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 132.08 46.99 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 08fee58d-3f8e-4075-bf89-111e38b84ed2)
-    (property "Reference" "R503" (at 130.175 46.99 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 131.445 41.91 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 130.302 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 132.08 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 132.08 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 132.08 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 132.08 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 132.08 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 132.08 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 132.08 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 132.08 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 132.08 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 132.08 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ef6b5a25-f81f-4f01-87d5-8e9323f8042b))
-    (pin "2" (uuid 2bda796f-e46d-4cb3-a135-3336fecc61e7))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "R702") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:DE9_Receptacle_MountingHoles_wSIGNALnames") (at 195.58 127 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0b9d48e5-7185-4768-9228-8eb1270cbfc5)
-    (property "Reference" "J?" (at 202.565 125.73 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "DE9_Receptacle_MountingHoles" (at 202.565 128.27 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Connector_Dsub:DSUB-9_Female_Horizontal_P2.77x2.84mm_EdgePinOffset9.90mm_Housed_MountingHolesOffset11.32mm" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" " ~" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "https://www.amazon.com/Pc-Accessories-Connectors-Connector-20-Pack/dp/B014IVD7L0/ref=sr_1_1" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "Connectors Pro" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.5" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "DB9 Male and Female D-Sub Solder Type Connector" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C3013509" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "LD09S13A4GX00LF" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Amphenol ICC (FCI)" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2" "DigiKey" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2 PN" "609-5189-ND" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2" "DigiKey" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2 PN" "609-5189-ND" (at 195.58 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "0" (uuid 57deef36-fbcf-40f1-a2c2-2c43f13cd08b))
-    (pin "1" (uuid fc23568a-c052-40aa-8431-0c91a2b668fc))
-    (pin "2" (uuid f471f01c-17c8-4c30-a7eb-b4a3d00c2c37))
-    (pin "3" (uuid c26ce978-5ee2-4cdd-898c-5c17894f27d9))
-    (pin "4" (uuid 85cf195d-e263-43c3-b5aa-8ce3d98fad71))
-    (pin "5" (uuid 6d6afaa9-ab51-4879-94bb-22890b979621))
-    (pin "6" (uuid bf44e150-bf31-4e98-816f-5f02f58007aa))
-    (pin "7" (uuid 215b4f74-88bc-4725-9287-2d4851710837))
-    (pin "8" (uuid 4f8d6373-2b4e-4498-8a22-22bb6caffd10))
-    (pin "9" (uuid fb73dc95-055d-4184-a0c4-4d0549cdc92f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "J?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "J701") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MAX3232_InOrder") (at 104.14 106.68 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3012f9f6-cd05-46cd-a12c-526bc1eead5d)
-    (property "Reference" "U?" (at 104.14 75.565 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "MAX3232CDR" (at 104.14 78.105 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Package_SO:SOIC-16_4.55x10.3mm_P1.27mm" (at 82.55 116.84 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.ti.com/lit/ds/symlink/max3232.pdf" (at 105.41 119.38 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 104.14 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" " MAX3232ID (JLCPCB Part # C354119)" (at 104.14 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 104.14 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 104.14 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "1.6050" (at 104.14 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "250Kbps Transceiver 2/2 SOIC-16 RS232 ICs ROHS MAX3232CDR" (at 104.14 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "MAX3232CDR" (at 104.14 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Texas Instruments" (at 104.14 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C45843" (at 104.14 106.68 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7c6ca529-4f0e-4c21-8562-70302cd5e26c))
-    (pin "10" (uuid 05d699ae-a9c0-4b5e-abff-378054a9f1b2))
-    (pin "11" (uuid f4d96ee8-8a6a-451f-aa12-76239ce20fa2))
-    (pin "12" (uuid b674d0f8-b5bb-4ff3-8504-2c283d913b64))
-    (pin "13" (uuid 3406cb53-b43b-426e-a714-0c8323341bac))
-    (pin "14" (uuid 5ebd8376-2c72-4841-bf26-2c58b11f6902))
-    (pin "15" (uuid 18d6971e-d8d9-49c3-9501-c1b30f3c7fc8))
-    (pin "16" (uuid e46a05d8-0903-45d3-9db8-a9e8129c508b))
-    (pin "2" (uuid c5927f90-f0bc-4336-9be3-50bb39898eef))
-    (pin "3" (uuid 9054ed43-0de1-4da5-ad27-982261eae9bf))
-    (pin "4" (uuid ff4d0609-4f97-48cb-b3fd-c0b8fadc631e))
-    (pin "5" (uuid 78a914f8-07c0-4653-97bd-88ff04a69596))
-    (pin "6" (uuid d568d89e-9f83-47b6-ab8c-8aa8b3018cb7))
-    (pin "7" (uuid 53e4236e-b142-49d2-a23e-e2f9c256e5ea))
-    (pin "8" (uuid 82cc1b37-1e14-46e5-9798-85f19cf66504))
-    (pin "9" (uuid ac050ef9-2f7e-4de5-bd7f-59e05ed75568))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "U?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "U701") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 165.1 132.08 90) (unit 1)
-    (in_bom no) (on_board yes) (dnp no)
-    (uuid 3f4ffe2d-d105-448a-8d69-4fc74d723c19)
-    (property "Reference" "R503" (at 161.29 130.81 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 167.005 130.175 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 165.1 133.858 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 165.1 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 165.1 132.08 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 165.1 132.08 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 165.1 132.08 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 165.1 132.08 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 165.1 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 165.1 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 165.1 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 165.1 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 165.1 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bd180c73-fdd8-47d1-95f2-405984eb8b4a))
-    (pin "2" (uuid 1af08d11-cbfd-49c1-86d2-f93881edc973))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "R707") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 80.01 127 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5042604e-37a3-44a9-9cfb-94efa2a94595)
-    (property "Reference" "#PWR0108" (at 80.01 133.35 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 80.01 132.08 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 80.01 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 80.01 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d3f178ff-df28-4dd0-8ac8-dd9fd605c17a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "#PWR0701") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C_Polarized") (at 176.53 83.82 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 6611b0c6-69ce-41a8-b164-ac88d0430930)
-    (property "Reference" "C?" (at 173.5328 82.6516 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "47uF 16V" (at 173.5328 84.963 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4" (at 175.5648 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 176.53 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 176.53 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2895272" (at 176.53 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "KNSCHA" (at 176.53 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RVT47UF16V67RV0019" (at 176.53 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 176.53 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.038" (at 176.53 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS" (at 176.53 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 176.53 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 176.53 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fe7474a5-cb20-466d-a575-71d4afc25598))
-    (pin "2" (uuid 55adf2ac-0695-4e0b-9b4e-747ccfb5d1ed))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "C705") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:PWR_FLAG") (at 176.53 67.31 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 66ac6758-655e-4184-857e-76e5991e1248)
-    (property "Reference" "#FLG03" (at 176.53 65.405 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "PWR_FLAG" (at 176.53 62.9158 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 176.53 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 176.53 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 332d15bc-627c-473d-b670-f84ce7cde69e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#FLG03") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "#FLG03") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 190.5 90.17 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6a72ef3b-8f2a-4d9d-9a2c-ca9c1595b3c0)
-    (property "Reference" "#PWR0108" (at 190.5 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 190.5 95.25 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 190.5 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 190.5 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 49df32c0-b366-43c6-8467-c289cfe93842))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "#PWR0705") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 165.1 149.86 90) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 6fd12613-1a77-41f1-b826-737f60be267b)
-    (property "Reference" "R503" (at 161.29 148.59 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 166.37 147.955 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 165.1 151.638 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 165.1 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 165.1 149.86 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 165.1 149.86 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 165.1 149.86 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 165.1 149.86 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 165.1 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 165.1 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 165.1 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 165.1 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 165.1 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid da10081e-5d40-4d2a-83ed-2731f4e1fbc2))
-    (pin "2" (uuid 952e52bb-b692-4eea-bdc0-12083ec55fa2))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "R710") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 190.5 83.82 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 7e447919-4b43-4358-a62a-d9d8021231f9)
-    (property "Reference" "C?" (at 187.579 82.6516 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 187.579 84.963 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 189.5348 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 190.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 190.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 190.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 190.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 190.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 190.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 190.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 190.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 190.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 190.5 83.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a56c5b34-888f-468f-84cf-d97bb02755c9))
-    (pin "2" (uuid 5f0e599e-f3a6-41c9-8beb-615bd7c475d0))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "C706") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 176.53 88.9 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8aeb79cf-6489-48d0-9597-d09f30f936ea)
-    (property "Reference" "#PWR0108" (at 176.53 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 176.53 93.98 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 176.53 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 176.53 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a6d4a015-6c62-4c54-984a-c04aaef9ca01))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "#PWR0704") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 138.43 46.99 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 8ee41fda-4178-4ff9-a24a-295353dfa890)
-    (property "Reference" "R503" (at 136.525 46.99 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 137.795 41.91 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 136.652 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 138.43 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 138.43 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 138.43 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 138.43 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 138.43 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 138.43 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 138.43 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 138.43 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 138.43 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 138.43 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f6dbe609-dca5-4c1d-8ebb-9a6cb79d1f38))
-    (pin "2" (uuid 83f2c0b6-598f-46dc-a71d-270b4aac471a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "R703") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 55.88 86.36 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid a4549acf-0061-4d58-9954-fa25467c6454)
-    (property "Reference" "C?" (at 58.801 85.1916 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 58.801 87.503 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 56.8452 90.17 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 55.88 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 55.88 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 55.88 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 55.88 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 55.88 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 55.88 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 55.88 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 55.88 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 55.88 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 55.88 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f378f3f1-fe86-44cf-8b54-9580c8b28a8d))
-    (pin "2" (uuid 2be670f3-b51f-475b-8188-0b0ea3218e55))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "C701") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 55.88 101.6 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid a4c91ef1-ce6e-4228-ac88-39a15878357d)
-    (property "Reference" "C?" (at 58.801 100.4316 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 58.801 102.743 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 56.8452 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 55.88 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 55.88 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 55.88 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 55.88 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 55.88 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 55.88 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 55.88 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 55.88 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 55.88 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 55.88 101.6 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 94a03cdd-31f3-4ebd-9747-1967eec40b1f))
-    (pin "2" (uuid 4a210d18-5353-4e39-b204-6774f8d91528))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "C702") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 143.51 46.99 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid a979b194-ca17-403c-a79a-29847f3eb1b2)
-    (property "Reference" "R503" (at 141.605 46.99 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 142.875 41.91 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 141.732 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 143.51 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 143.51 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 143.51 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 143.51 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 143.51 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 143.51 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 143.51 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 143.51 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 143.51 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 143.51 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d50fc2ed-1490-4fea-91c9-68ed1b38d804))
-    (pin "2" (uuid b6ff05a3-74f5-4a19-adc8-91f47fe748b0))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "R704") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 163.83 127 90) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid b2799b9b-5bf9-4c90-b771-e30fac62d2b5)
-    (property "Reference" "R503" (at 160.02 125.73 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 165.1 125.095 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 163.83 128.778 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 163.83 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 163.83 127 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 163.83 127 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 163.83 127 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 163.83 127 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 163.83 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 163.83 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 163.83 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 163.83 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 163.83 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bd922053-4cf1-45ee-9f64-0a356bd8bf65))
-    (pin "2" (uuid 63f1c730-7ff2-40d7-b02c-ef4a97a2c829))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "R706") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 182.88 74.93 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid c4fc6ee2-72b2-44bb-867e-552c8b1f6987)
-    (property "Reference" "R?" (at 184.15 69.85 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1R0" (at 182.88 72.39 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 182.88 73.152 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 182.88 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 182.88 74.93 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 182.88 74.93 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 182.88 74.93 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 182.88 74.93 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 182.88 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 182.88 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 182.88 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 182.88 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 182.88 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e44a732e-1ffc-4bf5-961f-b7c69253aeea))
-    (pin "2" (uuid 2748bd7e-5600-4ae6-bc5d-5fe64a82696f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "R711") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 165.1 142.24 90) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid c8739059-039d-4322-9274-41c69c1c7896)
-    (property "Reference" "R503" (at 161.29 140.97 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 166.37 140.335 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 165.1 144.018 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 165.1 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 165.1 142.24 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 165.1 142.24 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 165.1 142.24 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 165.1 142.24 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 165.1 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 165.1 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 165.1 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 165.1 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 165.1 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 54c5e885-a9cf-4f69-9ae6-19de54d06961))
-    (pin "2" (uuid 4da5b6e4-8980-4baa-9e6b-ab3b3b98de8f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "R709") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 165.1 137.16 90) (unit 1)
-    (in_bom no) (on_board yes) (dnp no)
-    (uuid cdae07aa-59c1-4998-843b-bbb709907349)
-    (property "Reference" "R503" (at 161.29 135.89 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 167.005 135.255 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 165.1 138.938 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 165.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 165.1 137.16 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 165.1 137.16 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 165.1 137.16 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 165.1 137.16 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 165.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 165.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 165.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 165.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 165.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 00b2e776-e944-4a34-a05f-3acae7650023))
-    (pin "2" (uuid fcfdbc3e-abcb-4c4d-ba1c-18c5820284bb))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "R708") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:+3.3V") (at 194.31 74.93 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d4df6555-18f7-4889-a0da-7085f717936d)
-    (property "Reference" "#PWR030" (at 194.31 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "+3.3V" (at 194.31 69.85 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 194.31 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 194.31 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e2c8de92-7f7f-41e3-bc0a-aa8da1af803e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR030") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "#PWR031") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 80.01 120.65 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid db7262c6-af7d-4bc9-bcd3-6e942a300a53)
-    (property "Reference" "C?" (at 82.931 119.4816 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 82.931 121.793 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 80.9752 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 80.01 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 80.01 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 80.01 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 80.01 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 80.01 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 80.01 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 80.01 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 80.01 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 80.01 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 80.01 120.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7027d8d0-3b77-4660-9c0b-c66947ed2b1a))
-    (pin "2" (uuid de433b44-20f2-4467-9510-2096b3629127))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "C704") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 127 46.99 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid e95a426d-92e8-46a0-bff4-9fb1629ac204)
-    (property "Reference" "R503" (at 125.095 46.99 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 126.365 41.91 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 125.222 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 127 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 127 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 127 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 127 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 127 46.99 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 127 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 127 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 127 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 127 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 127 46.99 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 58647e9d-71b0-4184-b0ae-4ade8db7dea0))
-    (pin "2" (uuid ef07ec00-7004-4d95-8580-014d57a04922))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "R701") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 184.15 138.43 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ecc8237d-0619-4e13-b9df-34e3c46b2af2)
-    (property "Reference" "#PWR0108" (at 184.15 144.78 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 184.15 143.51 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 184.15 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 184.15 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6f43bd4e-e42d-4687-9971-f6cb2db3c144))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "#PWR0702") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 163.83 121.92 90) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid f12fd984-5d31-496d-971b-aec2e8060d3f)
-    (property "Reference" "R503" (at 160.02 120.65 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 165.1 120.015 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 163.83 123.698 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 163.83 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 163.83 121.92 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 163.83 121.92 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 163.83 121.92 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 163.83 121.92 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 163.83 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 163.83 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 163.83 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 163.83 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 163.83 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d099bfa6-577d-415e-bab6-3383ea43d85d))
-    (pin "2" (uuid 90dfab4d-3828-4e21-8bd4-08b610dcda5b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "R705") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 80.01 76.2 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid f9ebfd17-93f1-45c6-99ab-ab5b14b70e8c)
-    (property "Reference" "C?" (at 82.931 75.0316 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 82.931 77.343 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 80.9752 80.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 80.01 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 80.01 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 80.01 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 80.01 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 80.01 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 80.01 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 80.01 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 80.01 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 80.01 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 80.01 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c79c84f6-2b92-4e38-b5c9-edd6ab3f702e))
-    (pin "2" (uuid 8681f4c7-33a9-4bc3-a1f5-09662c576ca5))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
-          (reference "C703") (unit 1)
-        )
-      )
-    )
-  )
+(kicad_sch
+	(version 20251012)
+	(generator "eeschema")
+	(generator_version "9.99")
+	(uuid "10594b9c-d1cb-47d8-a9c8-685ec6050c14")
+	(paper "A4")
+	(title_block
+		(title "KRAKE_PCB")
+		(date "2025-07-18")
+		(rev "2.0")
+		(company "PublicInvention")
+		(comment 1 "GNU Affero General Public License v3.0")
+		(comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
+		(comment 3 "https://github.com/PubInv/krake")
+		(comment 4 "Inherited from the GPAD")
+	)
+	(lib_symbols
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C_Polarized"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C_Polarized"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Polarized capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "CP_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_Polarized_0_1"
+				(rectangle
+					(start -2.286 0.508)
+					(end 2.286 1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 2.286) (xy -0.762 2.286)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 2.794) (xy -1.27 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 2.286 -0.508)
+					(end -2.286 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(symbol "C_Polarized_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GND_1"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND_1"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_1_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:DE9_Receptacle_MountingHoles_wSIGNALnames"
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "J"
+				(at 0 16.51 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "DE9_Receptacle_MountingHoles"
+				(at 0 14.605 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "9-pin female receptacle socket D-SUB connector, Mounting Hole"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "connector receptacle female D-SUB DB9"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "DSUB*Female*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "DE9_Receptacle_MountingHoles_wSIGNALnames_0_1"
+				(polyline
+					(pts
+						(xy -3.81 13.335) (xy -3.81 -13.335) (xy 3.81 -9.525) (xy 3.81 9.525) (xy -3.81 13.335)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.81 10.16) (xy -2.54 10.16)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.81 7.62) (xy 0.508 7.62)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.81 5.08) (xy -2.54 5.08)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.81 2.54) (xy 0.508 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.81 0) (xy -2.54 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.81 -2.54) (xy 0.508 -2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.81 -5.08) (xy -2.54 -5.08)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.81 -7.62) (xy 0.508 -7.62)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.81 -10.16) (xy -2.54 -10.16)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -1.778 10.16)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -1.778 5.08)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -1.778 0)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -1.778 -5.08)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -1.778 -10.16)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 1.27 7.62)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 1.27 2.54)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 1.27 -2.54)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 1.27 -7.62)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "DE9_Receptacle_MountingHoles_wSIGNALnames_1_0"
+				(text "DSR"
+					(at 2.54 6.35 0)
+					(effects
+						(font
+							(size 0.762 0.762)
+						)
+					)
+				)
+				(text "RTS"
+					(at 2.54 1.27 0)
+					(effects
+						(font
+							(size 0.762 0.762)
+						)
+					)
+				)
+			)
+			(symbol "DE9_Receptacle_MountingHoles_wSIGNALnames_1_1"
+				(text "DCD"
+					(at -2.54 8.89 0)
+					(effects
+						(font
+							(size 0.762 0.762)
+						)
+					)
+				)
+				(text "RXD"
+					(at -2.54 3.81 0)
+					(effects
+						(font
+							(size 0.762 0.762)
+						)
+					)
+				)
+				(text "TXD"
+					(at -2.54 -1.27 0)
+					(effects
+						(font
+							(size 0.762 0.762)
+						)
+					)
+				)
+				(text "DTR"
+					(at -2.54 -6.35 0)
+					(effects
+						(font
+							(size 0.762 0.762)
+						)
+					)
+				)
+				(text "GND"
+					(at -2.54 -11.43 0)
+					(effects
+						(font
+							(size 0.762 0.762)
+						)
+					)
+				)
+				(text "CTS"
+					(at 2.54 -3.81 0)
+					(effects
+						(font
+							(size 0.762 0.762)
+						)
+					)
+				)
+				(text "R"
+					(at 2.54 -8.89 0)
+					(effects
+						(font
+							(size 0.762 0.762)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -15.24 90)
+					(length 3.81)
+					(name "PAD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 10.16 0)
+					(length 3.81)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 5.08 0)
+					(length 3.81)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 0 0)
+					(length 3.81)
+					(name "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 -5.08 0)
+					(length 3.81)
+					(name "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 -10.16 0)
+					(length 3.81)
+					(name "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 7.62 0)
+					(length 3.81)
+					(name "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 2.54 0)
+					(length 3.81)
+					(name "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 -2.54 0)
+					(length 3.81)
+					(name "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 -7.62 0)
+					(length 3.81)
+					(name "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:MAX3232_InOrder"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "U?"
+				(at 1.9559 29.845 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "MAX3232"
+				(at 1.9559 27.305 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "Package_SO:SOIC-16_4.55x10.3mm_P1.27mm"
+				(at -21.59 -10.16 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "https://datasheets.maximintegrated.com/en/ds/MAX3222-MAX3241.pdf"
+				(at 1.27 -12.7 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "3.0V to 5.5V, Low-Power, up to 1Mbps, True RS-232 Transceivers Using Four 0.1μF External Capacitors"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "rs232 uart transceiver line-driver"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "SOIC*P1.27mm* DIP*W7.62mm* TSSOP*4.4x5mm*P0.65mm*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "MAX3232_InOrder_0_0"
+				(text "RS232"
+					(at -6.35 -2.54 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(text "RS232"
+					(at -5.08 0 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(text "RS232"
+					(at 5.08 16.51 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(text "RS232"
+					(at 5.08 12.7 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(symbol "MAX3232_InOrder_0_1"
+				(rectangle
+					(start -15.24 26.67)
+					(end 15.24 -8.89)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(polyline
+					(pts
+						(xy -7.62 15.24) (xy -7.62 3.81)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -6.35 11.43) (xy -6.35 7.62)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.54 -4.445) (xy -9.525 -4.445)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.54 -6.35) (xy -2.54 -2.54) (xy 1.27 -4.445) (xy -2.54 -6.35)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.905 7.62) (xy -6.35 7.62)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.905 5.715) (xy -1.905 9.525) (xy 1.905 7.62) (xy -1.905 5.715)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 3.81) (xy -7.62 3.81)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -6.35 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -0.635 3.81)
+					(radius 0.635)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -0.635 -1.27)
+					(radius 0.635)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 1.905 -4.445)
+					(radius 0.635)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.54 7.62)
+					(radius 0.635)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 -4.445) (xy 7.62 -4.445)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.175 7.62) (xy 7.62 7.62)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.81 3.81) (xy 8.255 3.81)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.81 1.905) (xy 3.81 5.715) (xy 0 3.81) (xy 3.81 1.905)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.81 -1.27) (xy 8.255 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.81 -3.175) (xy 3.81 0.635) (xy 0 -1.27) (xy 3.81 -3.175)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 7.62 15.24) (xy -7.62 15.24)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 8.89 11.43) (xy -6.35 11.43)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "MAX3232_InOrder_1_0"
+				(text "Charge\nPump"
+					(at -5.08 20.32 0)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(text "Logic"
+					(at 6.35 8.89 0)
+					(effects
+						(font
+							(size 0.889 0.889)
+						)
+					)
+				)
+				(text "Logic"
+					(at 6.35 5.08 0)
+					(effects
+						(font
+							(size 0.889 0.889)
+						)
+					)
+				)
+				(text "Logic"
+					(at 6.35 0 0)
+					(effects
+						(font
+							(size 0.889 0.889)
+						)
+					)
+				)
+				(text "Logic"
+					(at 6.35 -2.54 0)
+					(effects
+						(font
+							(size 0.889 0.889)
+						)
+					)
+				)
+			)
+			(symbol "MAX3232_InOrder_1_1"
+				(polyline
+					(pts
+						(xy -8.89 24.13) (xy -8.89 17.78)
+					)
+					(stroke
+						(width 0.254)
+						(type dot)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 24.13) (xy -8.89 24.13)
+					)
+					(stroke
+						(width 0.254)
+						(type dot)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 24.13) (xy -1.27 17.78)
+					)
+					(stroke
+						(width 0.254)
+						(type dot)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 17.78) (xy -8.89 17.78)
+					)
+					(stroke
+						(width 0.254)
+						(type dot)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -20.32 22.86 0)
+					(length 5.08)
+					(name "C1+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 20.32 0 180)
+					(length 5.08)
+					(name "T2IN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 20.32 3.81 180)
+					(length 5.08)
+					(name "T1IN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 20.32 7.62 180)
+					(length 5.08)
+					(name "R1OUT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 20.32 11.43 180)
+					(length 5.08)
+					(name "R1IN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 20.32 15.24 180)
+					(length 5.08)
+					(name "T1OUT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 20.32 19.05 180)
+					(length 5.08)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 20.32 22.86 180)
+					(length 5.08)
+					(name "VCC"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_out line
+					(at -20.32 19.05 0)
+					(length 5.08)
+					(name "VS+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -20.32 15.24 0)
+					(length 5.08)
+					(name "C1-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -20.32 11.43 0)
+					(length 5.08)
+					(name "C2+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -20.32 7.62 0)
+					(length 5.08)
+					(name "C2-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_out line
+					(at -20.32 3.81 0)
+					(length 5.08)
+					(name "VS-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at -20.32 0 0)
+					(length 5.08)
+					(name "T2OUT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -20.32 -3.81 0)
+					(length 5.08)
+					(name "R2IN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 20.32 -3.81 180)
+					(length 5.08)
+					(name "R2OUT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:+3.3V"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "+3.3V"
+				(at 0 3.556 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "+3.3V_0_1"
+				(polyline
+					(pts
+						(xy -0.762 1.27) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "+3.3V_1_1"
+				(pin power_in line
+					(at 0 0 90)
+					(length 0)
+					(hide yes)
+					(name "+3.3V"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:PWR_FLAG"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#FLG"
+				(at 0 1.905 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "PWR_FLAG"
+				(at 0 3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Special symbol for telling ERC where power comes from"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "flag power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_0"
+				(pin power_out line
+					(at 0 0 90)
+					(length 0)
+					(name "pwr"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(text "Place R702 near uControler TX1 pin.\nPlace R703 near uControler RTS1 pin."
+		(exclude_from_sim no)
+		(at 130.81 30.48 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "0903b68d-ef67-4bc7-bf6e-b726964195bb")
+	)
+	(text "NULL MODEM"
+		(exclude_from_sim no)
+		(at 159.385 114.3 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "2861132a-7582-47eb-a28c-1bb747daad6c")
+	)
+	(text "DATA COMMUNICATIONS EQUIPMENT"
+		(exclude_from_sim no)
+		(at 204.47 135.89 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "fa42bb90-3f98-4611-954e-6daa854d33ac")
+	)
+	(junction
+		(at 176.53 78.74)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "14dd2558-c3c1-46c2-acea-1bc82dcc1c74")
+	)
+	(junction
+		(at 80.01 124.46)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3af23698-82f2-4c51-8355-f5ed2c3107c2")
+	)
+	(junction
+		(at 171.45 74.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3c5692ec-a167-41fb-8466-f579fa2e38c4")
+	)
+	(junction
+		(at 176.53 74.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "72beaf47-8252-407c-9236-e390f47b9e3b")
+	)
+	(junction
+		(at 167.64 74.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "914629a5-5972-440e-923d-dba09e11e501")
+	)
+	(junction
+		(at 158.75 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "95e8b40f-dc2e-49b2-b8d0-d0e12df3c0de")
+	)
+	(junction
+		(at 157.48 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cbca69f0-26a7-4211-9317-4f2fd5cf7f4a")
+	)
+	(no_connect
+		(at 187.96 134.62)
+		(uuid "8e0b3938-1785-416a-995f-bf5341acbfd6")
+	)
+	(no_connect
+		(at 187.96 116.84)
+		(uuid "d7ecec87-8df6-46bc-8125-cd50a6d17b95")
+	)
+	(wire
+		(pts
+			(xy 127 38.1) (xy 127 43.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "02b5aeaf-61fb-47c9-b0e1-0f809c7e5a59")
+	)
+	(wire
+		(pts
+			(xy 55.88 105.41) (xy 55.88 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "034983da-8d4f-4854-abab-1117ecd1cf2b")
+	)
+	(wire
+		(pts
+			(xy 138.43 38.1) (xy 138.43 43.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "061fc753-9df8-447a-be00-b2a3656cae17")
+	)
+	(wire
+		(pts
+			(xy 180.34 129.54) (xy 187.96 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "067618f6-4a6c-449b-97fb-b57609bcfff6")
+	)
+	(wire
+		(pts
+			(xy 69.85 107.95) (xy 69.85 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0d16bf60-e781-4317-b0bb-a8a0544be7ff")
+	)
+	(wire
+		(pts
+			(xy 69.85 78.74) (xy 55.88 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0f12ab80-08ad-4e6d-b67d-ce69a529d934")
+	)
+	(wire
+		(pts
+			(xy 76.2 142.24) (xy 157.48 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12165d58-2c84-48d7-b6c0-3515f068e73a")
+	)
+	(wire
+		(pts
+			(xy 132.08 102.87) (xy 124.46 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1645178f-a335-46b6-a3a1-a2baf2ac2729")
+	)
+	(wire
+		(pts
+			(xy 190.5 78.74) (xy 176.53 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "19fa5a8c-7e23-470b-9c20-d6361c0c2197")
+	)
+	(wire
+		(pts
+			(xy 124.46 106.68) (xy 138.43 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1aad4147-6867-423f-a164-35eae5ba2c19")
+	)
+	(wire
+		(pts
+			(xy 179.07 74.93) (xy 176.53 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1dccc49f-d5d3-43a3-8f10-e1943fffb020")
+	)
+	(wire
+		(pts
+			(xy 187.96 132.08) (xy 168.91 132.08)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "30149a93-3415-459c-8760-fa1d02d7a2f2")
+	)
+	(wire
+		(pts
+			(xy 161.29 132.08) (xy 157.48 132.08)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "30b14cf7-6071-4dce-9cb6-bba84de5ec71")
+	)
+	(wire
+		(pts
+			(xy 80.01 71.12) (xy 80.01 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "324cd861-ca17-43a1-82e6-7b7a36793a86")
+	)
+	(wire
+		(pts
+			(xy 132.08 38.1) (xy 132.08 43.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "37b68870-42ab-4345-af4e-1f2f14b94c45")
+	)
+	(wire
+		(pts
+			(xy 184.15 138.43) (xy 184.15 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3adac475-69fd-4fe7-819e-2ea23ff70810")
+	)
+	(wire
+		(pts
+			(xy 179.07 124.46) (xy 187.96 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e19ea27-b7f2-450c-94bd-e72ff39462fd")
+	)
+	(wire
+		(pts
+			(xy 184.15 137.16) (xy 187.96 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f562a47-2a87-47c1-96bb-6688c60670da")
+	)
+	(wire
+		(pts
+			(xy 127 99.06) (xy 124.46 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "41a18c5c-7229-482e-be7b-8622855d2dc5")
+	)
+	(wire
+		(pts
+			(xy 147.32 127) (xy 160.02 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "41ae4f25-6189-45d3-87d8-0045c9208624")
+	)
+	(wire
+		(pts
+			(xy 83.82 83.82) (xy 69.85 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "41bde6ca-c9f8-4e68-8763-2fc9a04bf9b1")
+	)
+	(wire
+		(pts
+			(xy 176.53 88.9) (xy 176.53 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4253414f-ccb1-4dd5-a997-820c7c8ff5fe")
+	)
+	(wire
+		(pts
+			(xy 168.91 142.24) (xy 179.07 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "430b4e3f-3551-46d1-9ecd-4f251e699e32")
+	)
+	(wire
+		(pts
+			(xy 167.64 127) (xy 187.96 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "446e7417-f6c8-48c9-8c8e-8cada1e235e5")
+	)
+	(wire
+		(pts
+			(xy 138.43 50.8) (xy 138.43 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "45398b76-0292-4602-a54e-17f2aa79e4b0")
+	)
+	(wire
+		(pts
+			(xy 158.75 149.86) (xy 161.29 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "462f1fea-3030-41a4-86bd-3dcbd84cbbcb")
+	)
+	(wire
+		(pts
+			(xy 124.46 87.63) (xy 129.54 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4cd44d7d-a91d-458c-ac3d-c521a32cb1e5")
+	)
+	(wire
+		(pts
+			(xy 55.88 90.17) (xy 55.88 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "52150aa9-bc56-43de-ae8a-b530f584e43e")
+	)
+	(wire
+		(pts
+			(xy 69.85 99.06) (xy 83.82 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "544b7e56-6131-41ec-b1fd-d786f69bde49")
+	)
+	(wire
+		(pts
+			(xy 83.82 95.25) (xy 55.88 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "549862e4-fb04-4abe-b85c-9690d6d86af5")
+	)
+	(wire
+		(pts
+			(xy 176.53 137.16) (xy 168.91 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5a0be15d-205f-4434-b9fe-b81ec5dbe255")
+	)
+	(wire
+		(pts
+			(xy 157.48 142.24) (xy 161.29 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5a22b2ac-1903-4e8f-aa07-26e2f77569d6")
+	)
+	(wire
+		(pts
+			(xy 80.01 71.12) (xy 167.64 71.12)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6674b2d4-e58f-46fe-bd00-0ee048b2d26e")
+	)
+	(wire
+		(pts
+			(xy 190.5 90.17) (xy 190.5 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "69555027-340e-49ad-9a83-14169bb616c0")
+	)
+	(wire
+		(pts
+			(xy 55.88 78.74) (xy 55.88 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "697deaee-573a-49e7-943d-38141bba50a0")
+	)
+	(wire
+		(pts
+			(xy 83.82 110.49) (xy 76.2 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "69b305b3-d9bf-483f-9d5d-fd46f67bddaa")
+	)
+	(wire
+		(pts
+			(xy 124.46 74.93) (xy 167.64 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6ce0ed90-7828-4d8f-97f2-598840715f4f")
+	)
+	(wire
+		(pts
+			(xy 149.86 121.92) (xy 160.02 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6d3b43fa-3248-4497-aa2f-87622140b772")
+	)
+	(wire
+		(pts
+			(xy 80.01 124.46) (xy 129.54 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "789e7ed9-d322-4e8b-a429-0a3d47993326")
+	)
+	(wire
+		(pts
+			(xy 124.46 95.25) (xy 147.32 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7954110e-5cc7-4f61-9036-d13838f83a0f")
+	)
+	(wire
+		(pts
+			(xy 55.88 107.95) (xy 69.85 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7f1eee0a-c934-4314-a5c7-d2040d652c57")
+	)
+	(wire
+		(pts
+			(xy 176.53 78.74) (xy 171.45 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7fca1dfd-b182-46fe-b7af-da5d141cce20")
+	)
+	(wire
+		(pts
+			(xy 171.45 74.93) (xy 176.53 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "865311ce-e312-4235-b7ed-e6bf8c0fc686")
+	)
+	(wire
+		(pts
+			(xy 55.88 95.25) (xy 55.88 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "88301860-ee34-496f-bd67-a7cb4ab0df29")
+	)
+	(wire
+		(pts
+			(xy 176.53 80.01) (xy 176.53 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "89227f4f-f193-437f-9147-24dc200d0638")
+	)
+	(wire
+		(pts
+			(xy 80.01 124.46) (xy 80.01 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8e6fbd99-8592-4e69-b487-837c51dc91a3")
+	)
+	(wire
+		(pts
+			(xy 176.53 67.31) (xy 176.53 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "922ad8a1-d2dd-46b2-a8df-bd78911fc665")
+	)
+	(wire
+		(pts
+			(xy 80.01 102.87) (xy 80.01 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "92ff9423-7d8a-4b83-b5c1-d46fa72d0515")
+	)
+	(wire
+		(pts
+			(xy 80.01 87.63) (xy 83.82 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "97e0e511-9022-4708-ab5d-045b0d3d98a7")
+	)
+	(wire
+		(pts
+			(xy 124.46 74.93) (xy 124.46 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9a941f80-c45e-42ed-bd65-c5fbd9d4e810")
+	)
+	(wire
+		(pts
+			(xy 161.29 137.16) (xy 158.75 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9f8f848f-9eb3-4b20-b7cb-99f29cee1e0b")
+	)
+	(wire
+		(pts
+			(xy 143.51 110.49) (xy 124.46 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a93c3f6f-9398-42c8-b4cf-69b0a0edee4f")
+	)
+	(wire
+		(pts
+			(xy 55.88 91.44) (xy 83.82 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a999632d-baf9-413d-b9b2-8d86c7cec258")
+	)
+	(wire
+		(pts
+			(xy 69.85 83.82) (xy 69.85 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aaabd674-1953-4017-bdc0-d3573fb841f5")
+	)
+	(wire
+		(pts
+			(xy 167.64 121.92) (xy 187.96 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab6eaf4d-cc5d-484d-9ba1-b4f199722390")
+	)
+	(wire
+		(pts
+			(xy 129.54 87.63) (xy 129.54 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ae945efa-5c1a-4fd1-9ab5-1732779ea100")
+	)
+	(wire
+		(pts
+			(xy 179.07 142.24) (xy 179.07 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "afe2f4bf-d3e2-42af-88bc-4af9af4b333f")
+	)
+	(wire
+		(pts
+			(xy 149.86 91.44) (xy 149.86 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba802029-6d4e-4ba4-9e5f-843424c7dd56")
+	)
+	(wire
+		(pts
+			(xy 73.66 149.86) (xy 158.75 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb182ec0-fe72-43ba-a920-853dc349e926")
+	)
+	(wire
+		(pts
+			(xy 180.34 149.86) (xy 180.34 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb881327-1e63-4c4a-bc0d-6a56975ee32f")
+	)
+	(wire
+		(pts
+			(xy 190.5 80.01) (xy 190.5 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bcc7bea4-fea5-4e9e-9b50-28f731f86458")
+	)
+	(wire
+		(pts
+			(xy 176.53 119.38) (xy 176.53 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "be5af32a-7a6e-4bcf-b0c6-1b7d8500a319")
+	)
+	(wire
+		(pts
+			(xy 143.51 50.8) (xy 143.51 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c0033cfe-24d9-41a0-ae9a-7feb0d51bb38")
+	)
+	(wire
+		(pts
+			(xy 147.32 95.25) (xy 147.32 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c16960aa-6734-471d-824a-f5356a329b40")
+	)
+	(wire
+		(pts
+			(xy 167.64 74.93) (xy 171.45 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c25ff826-1071-435e-aeea-57989328e0ee")
+	)
+	(wire
+		(pts
+			(xy 167.64 71.12) (xy 167.64 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c2c59eac-5440-4d41-8791-90f78343e949")
+	)
+	(wire
+		(pts
+			(xy 124.46 91.44) (xy 149.86 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3e3c444-ad22-41a3-8295-f3ae73e80f85")
+	)
+	(wire
+		(pts
+			(xy 83.82 106.68) (xy 73.66 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb1fbcf8-8331-48f0-8a90-356eb32d8f94")
+	)
+	(wire
+		(pts
+			(xy 157.48 132.08) (xy 157.48 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cc01e1de-8e53-4d73-865c-33b5f472b421")
+	)
+	(wire
+		(pts
+			(xy 76.2 110.49) (xy 76.2 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ccdc2686-f1b8-43b9-9b15-b42b5d8bed07")
+	)
+	(wire
+		(pts
+			(xy 194.31 74.93) (xy 186.69 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cf1de08b-9e93-47d2-9ccb-06527e5007f6")
+	)
+	(wire
+		(pts
+			(xy 158.75 137.16) (xy 158.75 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2e030ef-7ffc-43a0-ae7d-0224b0730f65")
+	)
+	(wire
+		(pts
+			(xy 168.91 149.86) (xy 180.34 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db106546-2a22-4d61-8d80-5db7a9be2d33")
+	)
+	(wire
+		(pts
+			(xy 143.51 38.1) (xy 143.51 43.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de33f4e2-24e8-4fb5-8aab-2fc063f4852f")
+	)
+	(wire
+		(pts
+			(xy 132.08 50.8) (xy 132.08 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df419aa3-ca09-4e66-98ef-8e3a3d159260")
+	)
+	(wire
+		(pts
+			(xy 171.45 78.74) (xy 171.45 74.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef16e293-8835-4fbc-9dee-d8f3e717c19a")
+	)
+	(wire
+		(pts
+			(xy 127 50.8) (xy 127 99.06)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f1d4af55-8d0e-4f0a-af29-f4cf32ffa608")
+	)
+	(wire
+		(pts
+			(xy 80.01 102.87) (xy 83.82 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f3a94260-9a23-4667-879b-a37a86735746")
+	)
+	(wire
+		(pts
+			(xy 73.66 106.68) (xy 73.66 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f78c621a-f162-434a-9a71-78970c016b80")
+	)
+	(wire
+		(pts
+			(xy 80.01 80.01) (xy 80.01 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f82ec5de-9a2c-49f2-8695-8f0712ba7e0f")
+	)
+	(wire
+		(pts
+			(xy 187.96 119.38) (xy 176.53 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fd80848d-84dd-4d5b-9e8e-678ddf640473")
+	)
+	(label "3v3RS232"
+		(at 142.24 71.12 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "129a8fb3-3059-4322-a442-6c4263056eed")
+	)
+	(label "RS232_RX"
+		(at 148.59 127 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "1e45dc95-6089-4496-8679-5222979ce657")
+	)
+	(label "RS232_TX"
+		(at 149.86 121.92 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "570e9316-e65d-4e51-9cee-617ffc9c50b1")
+	)
+	(label "RS232_RTS"
+		(at 147.32 149.86 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "5c204211-5bcb-42a5-b108-ad0d9528f4bf")
+	)
+	(label "DCE_RX"
+		(at 168.91 121.92 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "81f39eed-e5f9-4d94-bc57-57f7939daff5")
+	)
+	(label "DCE_TX"
+		(at 168.91 127 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "b003ed34-761e-40cb-b137-1c32872a6567")
+	)
+	(label "DCE_RTS"
+		(at 168.91 142.24 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d131b565-49f3-4a3c-9a77-081d49ce5cb1")
+	)
+	(label "DCE_CTS"
+		(at 168.91 149.86 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f6d136b2-43ca-47f3-b475-942c5dd95e48")
+	)
+	(label "RS232_CTS"
+		(at 146.05 142.24 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "fc09cae2-27a7-48a4-bbec-37045b7fd31e")
+	)
+	(hierarchical_label "CTS1"
+		(shape input)
+		(at 143.51 38.1 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "47ef9bca-cd51-4cde-915a-36a519dcf0e4")
+	)
+	(hierarchical_label "TX1"
+		(shape input)
+		(at 132.08 38.1 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "61ac1c68-2294-400e-ad63-580e9a522e13")
+	)
+	(hierarchical_label "RX1"
+		(shape input)
+		(at 127 38.1 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d1a5894f-69c2-441b-a0ef-b508c0a424d5")
+	)
+	(hierarchical_label "RTS1"
+		(shape input)
+		(at 138.43 38.1 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "dd6c4c5d-a118-49d8-9af7-a7633a08fe20")
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 195.58 142.24 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "00ad6793-66ba-42a8-abd4-61f63b15c5cc")
+		(property "Reference" "#PWR0703"
+			(at 195.58 148.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 195.58 147.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 195.58 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 195.58 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d39bf19b-7e6d-4b2e-9397-e2e93bad7282")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "#PWR0703")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 132.08 46.99 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "08fee58d-3f8e-4075-bf89-111e38b84ed2")
+		(property "Reference" "R702"
+			(at 130.175 46.99 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 131.445 41.91 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 130.302 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 132.08 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 132.08 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 132.08 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 132.08 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 132.08 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 132.08 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 132.08 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 132.08 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 132.08 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 132.08 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ef6b5a25-f81f-4f01-87d5-8e9323f8042b")
+		)
+		(pin "2"
+			(uuid "2bda796f-e46d-4cb3-a135-3336fecc61e7")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "R702")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:DE9_Receptacle_MountingHoles_wSIGNALnames")
+		(at 195.58 127 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0b9d48e5-7185-4768-9228-8eb1270cbfc5")
+		(property "Reference" "J701"
+			(at 202.565 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "DE9_Receptacle_MountingHoles"
+			(at 202.565 128.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Connector_Dsub:DSUB-9_Female_Horizontal_P2.77x2.84mm_EdgePinOffset9.90mm_Housed_MountingHolesOffset11.32mm"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "DB9 Male and Female D-Sub Solder Type Connector"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" "https://www.amazon.com/Pc-Accessories-Connectors-Connector-20-Pack/dp/B014IVD7L0/ref=sr_1_1"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" "Connectors Pro"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.5"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C3013509"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "LD09S13A4GX00LF"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Amphenol ICC (FCI)"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2" "DigiKey"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2 PN" "609-5189-ND"
+			(at 195.58 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "0"
+			(uuid "57deef36-fbcf-40f1-a2c2-2c43f13cd08b")
+		)
+		(pin "1"
+			(uuid "fc23568a-c052-40aa-8431-0c91a2b668fc")
+		)
+		(pin "2"
+			(uuid "f471f01c-17c8-4c30-a7eb-b4a3d00c2c37")
+		)
+		(pin "3"
+			(uuid "c26ce978-5ee2-4cdd-898c-5c17894f27d9")
+		)
+		(pin "4"
+			(uuid "85cf195d-e263-43c3-b5aa-8ce3d98fad71")
+		)
+		(pin "5"
+			(uuid "6d6afaa9-ab51-4879-94bb-22890b979621")
+		)
+		(pin "6"
+			(uuid "bf44e150-bf31-4e98-816f-5f02f58007aa")
+		)
+		(pin "7"
+			(uuid "215b4f74-88bc-4725-9287-2d4851710837")
+		)
+		(pin "8"
+			(uuid "4f8d6373-2b4e-4498-8a22-22bb6caffd10")
+		)
+		(pin "9"
+			(uuid "fb73dc95-055d-4184-a0c4-4d0549cdc92f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "J701")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MAX3232_InOrder")
+		(at 104.14 106.68 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3012f9f6-cd05-46cd-a12c-526bc1eead5d")
+		(property "Reference" "U701"
+			(at 104.14 75.565 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "MAX3232CDR"
+			(at 104.14 78.105 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_SO:SOIC-16_4.55x10.3mm_P1.27mm"
+			(at 82.55 116.84 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.ti.com/lit/ds/symlink/max3232.pdf"
+			(at 105.41 119.38 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "250Kbps Transceiver 2/2 SOIC-16 RS232 ICs ROHS MAX3232CDR"
+			(at 104.14 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 104.14 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" " MAX3232ID (JLCPCB Part # C354119)"
+			(at 104.14 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 104.14 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 104.14 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "1.6050"
+			(at 104.14 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "MAX3232CDR"
+			(at 104.14 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Texas Instruments"
+			(at 104.14 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C45843"
+			(at 104.14 106.68 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7c6ca529-4f0e-4c21-8562-70302cd5e26c")
+		)
+		(pin "10"
+			(uuid "05d699ae-a9c0-4b5e-abff-378054a9f1b2")
+		)
+		(pin "11"
+			(uuid "f4d96ee8-8a6a-451f-aa12-76239ce20fa2")
+		)
+		(pin "12"
+			(uuid "b674d0f8-b5bb-4ff3-8504-2c283d913b64")
+		)
+		(pin "13"
+			(uuid "3406cb53-b43b-426e-a714-0c8323341bac")
+		)
+		(pin "14"
+			(uuid "5ebd8376-2c72-4841-bf26-2c58b11f6902")
+		)
+		(pin "15"
+			(uuid "18d6971e-d8d9-49c3-9501-c1b30f3c7fc8")
+		)
+		(pin "16"
+			(uuid "e46a05d8-0903-45d3-9db8-a9e8129c508b")
+		)
+		(pin "2"
+			(uuid "c5927f90-f0bc-4336-9be3-50bb39898eef")
+		)
+		(pin "3"
+			(uuid "9054ed43-0de1-4da5-ad27-982261eae9bf")
+		)
+		(pin "4"
+			(uuid "ff4d0609-4f97-48cb-b3fd-c0b8fadc631e")
+		)
+		(pin "5"
+			(uuid "78a914f8-07c0-4653-97bd-88ff04a69596")
+		)
+		(pin "6"
+			(uuid "d568d89e-9f83-47b6-ab8c-8aa8b3018cb7")
+		)
+		(pin "7"
+			(uuid "53e4236e-b142-49d2-a23e-e2f9c256e5ea")
+		)
+		(pin "8"
+			(uuid "82cc1b37-1e14-46e5-9798-85f19cf66504")
+		)
+		(pin "9"
+			(uuid "ac050ef9-2f7e-4de5-bd7f-59e05ed75568")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "U701")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 165.1 132.08 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "3f4ffe2d-d105-448a-8d69-4fc74d723c19")
+		(property "Reference" "R707"
+			(at 161.29 130.81 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 167.005 130.175 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 165.1 133.858 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 165.1 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 165.1 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 165.1 132.08 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 165.1 132.08 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 165.1 132.08 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 165.1 132.08 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 165.1 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 165.1 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 165.1 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 165.1 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "bd180c73-fdd8-47d1-95f2-405984eb8b4a")
+		)
+		(pin "2"
+			(uuid "1af08d11-cbfd-49c1-86d2-f93881edc973")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "R707")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 80.01 127 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5042604e-37a3-44a9-9cfb-94efa2a94595")
+		(property "Reference" "#PWR0701"
+			(at 80.01 133.35 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 80.01 132.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 80.01 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 80.01 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 80.01 127 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d3f178ff-df28-4dd0-8ac8-dd9fd605c17a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "#PWR0701")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Polarized")
+		(at 176.53 83.82 0)
+		(mirror y)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6611b0c6-69ce-41a8-b164-ac88d0430930")
+		(property "Reference" "C705"
+			(at 173.5328 82.6516 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "47uF 16V"
+			(at 173.5328 84.963 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4"
+			(at 175.5648 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 176.53 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS"
+			(at 176.53 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 176.53 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2895272"
+			(at 176.53 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "KNSCHA"
+			(at 176.53 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RVT47UF16V67RV0019"
+			(at 176.53 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 176.53 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.038"
+			(at 176.53 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 176.53 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 176.53 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "fe7474a5-cb20-466d-a575-71d4afc25598")
+		)
+		(pin "2"
+			(uuid "55adf2ac-0695-4e0b-9b4e-747ccfb5d1ed")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "C705")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 176.53 67.31 0)
+		(mirror y)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "66ac6758-655e-4184-857e-76e5991e1248")
+		(property "Reference" "#FLG03"
+			(at 176.53 65.405 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 176.53 62.9158 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 176.53 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 176.53 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 176.53 67.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "332d15bc-627c-473d-b670-f84ce7cde69e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "#FLG03")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 190.5 90.17 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6a72ef3b-8f2a-4d9d-9a2c-ca9c1595b3c0")
+		(property "Reference" "#PWR0705"
+			(at 190.5 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 190.5 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 190.5 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 190.5 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 190.5 90.17 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "49df32c0-b366-43c6-8467-c289cfe93842")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "#PWR0705")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 165.1 149.86 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6fd12613-1a77-41f1-b826-737f60be267b")
+		(property "Reference" "R710"
+			(at 161.29 148.59 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 166.37 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 165.1 151.638 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 165.1 149.86 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 165.1 149.86 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 165.1 149.86 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 165.1 149.86 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 165.1 149.86 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 165.1 149.86 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 165.1 149.86 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 165.1 149.86 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 165.1 149.86 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 165.1 149.86 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "da10081e-5d40-4d2a-83ed-2731f4e1fbc2")
+		)
+		(pin "2"
+			(uuid "952e52bb-b692-4eea-bdc0-12083ec55fa2")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "R710")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 190.5 83.82 0)
+		(mirror y)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "7e447919-4b43-4358-a62a-d9d8021231f9")
+		(property "Reference" "C706"
+			(at 187.579 82.6516 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 187.579 84.963 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 189.5348 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 190.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 190.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 190.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 190.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 190.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 190.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 190.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 190.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 190.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 190.5 83.82 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a56c5b34-888f-468f-84cf-d97bb02755c9")
+		)
+		(pin "2"
+			(uuid "5f0e599e-f3a6-41c9-8beb-615bd7c475d0")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "C706")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 176.53 88.9 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8aeb79cf-6489-48d0-9597-d09f30f936ea")
+		(property "Reference" "#PWR0704"
+			(at 176.53 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 176.53 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 176.53 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 176.53 88.9 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 176.53 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a6d4a015-6c62-4c54-984a-c04aaef9ca01")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "#PWR0704")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 138.43 46.99 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8ee41fda-4178-4ff9-a24a-295353dfa890")
+		(property "Reference" "R703"
+			(at 136.525 46.99 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 137.795 41.91 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 136.652 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 138.43 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 138.43 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 138.43 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 138.43 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 138.43 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 138.43 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 138.43 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 138.43 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 138.43 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 138.43 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f6dbe609-dca5-4c1d-8ebb-9a6cb79d1f38")
+		)
+		(pin "2"
+			(uuid "83f2c0b6-598f-46dc-a71d-270b4aac471a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "R703")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 55.88 86.36 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a4549acf-0061-4d58-9954-fa25467c6454")
+		(property "Reference" "C701"
+			(at 58.801 85.1916 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 58.801 87.503 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 56.8452 90.17 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 55.88 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 55.88 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 55.88 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 55.88 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 55.88 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 55.88 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 55.88 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 55.88 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 55.88 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 55.88 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f378f3f1-fe86-44cf-8b54-9580c8b28a8d")
+		)
+		(pin "2"
+			(uuid "2be670f3-b51f-475b-8188-0b0ea3218e55")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "C701")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 55.88 101.6 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a4c91ef1-ce6e-4228-ac88-39a15878357d")
+		(property "Reference" "C702"
+			(at 58.801 100.4316 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 58.801 102.743 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 56.8452 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 55.88 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 55.88 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 55.88 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 55.88 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 55.88 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 55.88 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 55.88 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 55.88 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 55.88 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 55.88 101.6 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "94a03cdd-31f3-4ebd-9747-1967eec40b1f")
+		)
+		(pin "2"
+			(uuid "4a210d18-5353-4e39-b204-6774f8d91528")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "C702")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 143.51 46.99 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a979b194-ca17-403c-a79a-29847f3eb1b2")
+		(property "Reference" "R704"
+			(at 141.605 46.99 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 142.875 41.91 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 141.732 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 143.51 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 143.51 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 143.51 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 143.51 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 143.51 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 143.51 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 143.51 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 143.51 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 143.51 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 143.51 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d50fc2ed-1490-4fea-91c9-68ed1b38d804")
+		)
+		(pin "2"
+			(uuid "b6ff05a3-74f5-4a19-adc8-91f47fe748b0")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "R704")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 163.83 127 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b2799b9b-5bf9-4c90-b771-e30fac62d2b5")
+		(property "Reference" "R706"
+			(at 160.02 125.73 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 165.1 125.095 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 163.83 128.778 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 163.83 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 163.83 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 163.83 127 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 163.83 127 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 163.83 127 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 163.83 127 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 163.83 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 163.83 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 163.83 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 163.83 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "bd922053-4cf1-45ee-9f64-0a356bd8bf65")
+		)
+		(pin "2"
+			(uuid "63f1c730-7ff2-40d7-b02c-ef4a97a2c829")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "R706")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 182.88 74.93 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c4fc6ee2-72b2-44bb-867e-552c8b1f6987")
+		(property "Reference" "R711"
+			(at 184.15 69.85 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1R0"
+			(at 182.88 72.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 182.88 73.152 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 182.88 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 182.88 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 182.88 74.93 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 182.88 74.93 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 182.88 74.93 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 182.88 74.93 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 182.88 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 182.88 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 182.88 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 182.88 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e44a732e-1ffc-4bf5-961f-b7c69253aeea")
+		)
+		(pin "2"
+			(uuid "2748bd7e-5600-4ae6-bc5d-5fe64a82696f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "R711")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 165.1 142.24 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c8739059-039d-4322-9274-41c69c1c7896")
+		(property "Reference" "R709"
+			(at 161.29 140.97 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 166.37 140.335 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 165.1 144.018 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 165.1 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 165.1 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 165.1 142.24 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 165.1 142.24 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 165.1 142.24 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 165.1 142.24 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 165.1 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 165.1 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 165.1 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 165.1 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "54c5e885-a9cf-4f69-9ae6-19de54d06961")
+		)
+		(pin "2"
+			(uuid "4da5b6e4-8980-4baa-9e6b-ab3b3b98de8f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "R709")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 165.1 137.16 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "cdae07aa-59c1-4998-843b-bbb709907349")
+		(property "Reference" "R708"
+			(at 161.29 135.89 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 167.005 135.255 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 165.1 138.938 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 165.1 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 165.1 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 165.1 137.16 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 165.1 137.16 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 165.1 137.16 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 165.1 137.16 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 165.1 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 165.1 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 165.1 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 165.1 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "00b2e776-e944-4a34-a05f-3acae7650023")
+		)
+		(pin "2"
+			(uuid "fcfdbc3e-abcb-4c4d-ba1c-18c5820284bb")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "R708")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3.3V")
+		(at 194.31 74.93 0)
+		(mirror y)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d4df6555-18f7-4889-a0da-7085f717936d")
+		(property "Reference" "#PWR031"
+			(at 194.31 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "+3.3V"
+			(at 194.31 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 194.31 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 194.31 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 194.31 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e2c8de92-7f7f-41e3-bc0a-aa8da1af803e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "#PWR031")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 80.01 120.65 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "db7262c6-af7d-4bc9-bcd3-6e942a300a53")
+		(property "Reference" "C704"
+			(at 82.931 119.4816 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 82.931 121.793 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 80.9752 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 80.01 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 80.01 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 80.01 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 80.01 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 80.01 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 80.01 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 80.01 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 80.01 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 80.01 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 80.01 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7027d8d0-3b77-4660-9c0b-c66947ed2b1a")
+		)
+		(pin "2"
+			(uuid "de433b44-20f2-4467-9510-2096b3629127")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "C704")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 127 46.99 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e95a426d-92e8-46a0-bff4-9fb1629ac204")
+		(property "Reference" "R701"
+			(at 125.095 46.99 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 126.365 41.91 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 125.222 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 127 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 127 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 127 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 127 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 127 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 127 46.99 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 127 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 127 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 127 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 127 46.99 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "58647e9d-71b0-4184-b0ae-4ade8db7dea0")
+		)
+		(pin "2"
+			(uuid "ef07ec00-7004-4d95-8580-014d57a04922")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "R701")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 184.15 138.43 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ecc8237d-0619-4e13-b9df-34e3c46b2af2")
+		(property "Reference" "#PWR0702"
+			(at 184.15 144.78 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 184.15 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 184.15 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 184.15 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 184.15 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6f43bd4e-e42d-4687-9971-f6cb2db3c144")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "#PWR0702")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 163.83 121.92 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f12fd984-5d31-496d-971b-aec2e8060d3f")
+		(property "Reference" "R705"
+			(at 160.02 120.65 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 165.1 120.015 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 163.83 123.698 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 163.83 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 163.83 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 163.83 121.92 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 163.83 121.92 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 163.83 121.92 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 163.83 121.92 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 163.83 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 163.83 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 163.83 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 163.83 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d099bfa6-577d-415e-bab6-3383ea43d85d")
+		)
+		(pin "2"
+			(uuid "90dfab4d-3828-4e21-8bd4-08b610dcda5b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "R705")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 80.01 76.2 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f9ebfd17-93f1-45c6-99ab-ab5b14b70e8c")
+		(property "Reference" "C703"
+			(at 82.931 75.0316 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 82.931 77.343 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 80.9752 80.01 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 80.01 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 80.01 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 80.01 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 80.01 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 80.01 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 80.01 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 80.01 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 80.01 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 80.01 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 80.01 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c79c84f6-2b92-4e38-b5c9-edd6ab3f702e")
+		)
+		(pin "2"
+			(uuid "8681f4c7-33a9-4bc3-a1f5-09662c576ca5")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/b048976a-3284-45ec-9285-06d31a0a2b0c"
+					(reference "C703")
+					(unit 1)
+				)
+			)
+		)
+	)
 )

--- a/PWA_REV2/SPI Peripherial.kicad_sch
+++ b/PWA_REV2/SPI Peripherial.kicad_sch
@@ -1,3821 +1,8862 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid 249434d3-348d-41c5-9fd4-a9406a7b7520)
-
-  (paper "A4")
-
-  (title_block
-    (title "KRAKE_PCB")
-    (date "2025-07-18")
-    (rev "2.0")
-    (company "PublicInvention")
-    (comment 1 "GNU Affero General Public License v3.0")
-    (comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
-    (comment 3 "https://github.com/PubInv/krake")
-    (comment 4 "Inherited from the GPAD")
-  )
-
-  (lib_symbols
-    (symbol "Connector:TestPoint" (pin_numbers hide) (pin_names (offset 0.762) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "TP" (at 0 6.858 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "TestPoint" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "test point tp" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "test point" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "Pin* Test*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "TestPoint_0_1"
-        (circle (center 0 3.302) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "TestPoint_1_1"
-        (pin passive line (at 0 0 90) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:C" (pin_numbers hide) (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C" (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Unpolarized capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "C_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_0_1"
-        (polyline
-          (pts
-            (xy -2.032 -0.762)
-            (xy 2.032 -0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.032 0.762)
-            (xy 2.032 0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "C_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:Polyfuse_Small" (pin_numbers hide) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "F" (at -1.905 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "Polyfuse_Small" (at 1.905 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 1.27 -5.08 0)
-        (effects (font (size 1.27 1.27)) (justify left) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "resettable fuse PTC PPTC polyfuse polyswitch" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Resettable fuse, polymeric positive temperature coefficient, small symbol" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "*polyfuse* *PTC*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "Polyfuse_Small_0_1"
-        (rectangle (start -0.508 1.27) (end 0.508 -1.27)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.54)
-            (xy 0 -2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.016 1.27)
-            (xy -1.016 0.762)
-            (xy 1.016 -0.762)
-            (xy 1.016 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "Polyfuse_Small_1_1"
-        (pin passive line (at 0 2.54 270) (length 0.635)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -2.54 90) (length 0.635)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:R" (pin_numbers hide) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "R" (at 2.032 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "R" (at 0 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at -1.778 0 90)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "R res resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "R_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "R_0_1"
-        (rectangle (start -1.016 -2.54) (end 1.016 2.54)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "R_1_1"
-        (pin passive line (at 0 3.81 270) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Diode:BAT54S" (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at 2.54 -5.08 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "BAT54S" (at -6.35 3.175 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 1.905 3.175 0)
-        (effects (font (size 1.27 1.27)) (justify left) hide)
-      )
-      (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds11005.pdf" (at -3.048 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "schottky diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Vr 30V, If 200mA, Dual schottky barrier diode, in series, SOT-323" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "SOT?23*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "BAT54S_0_1"
-        (polyline
-          (pts
-            (xy -3.81 0)
-            (xy -1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.175 -1.27)
-            (xy -3.175 -1.016)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.54 -1.27)
-            (xy -3.175 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.54 -1.27)
-            (xy -2.54 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.54 1.27)
-            (xy -1.905 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.905 0)
-            (xy 1.905 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.905 1.27)
-            (xy -1.905 1.016)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 0)
-            (xy 3.81 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.175 -1.27)
-            (xy 3.175 -1.016)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.81 -1.27)
-            (xy 3.175 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.81 -1.27)
-            (xy 3.81 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.81 1.27)
-            (xy 4.445 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 4.445 1.27)
-            (xy 4.445 1.016)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -4.445 1.27)
-            (xy -4.445 -1.27)
-            (xy -2.54 0)
-            (xy -4.445 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.905 1.27)
-            (xy 1.905 -1.27)
-            (xy 3.81 0)
-            (xy 1.905 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 0 0) (radius 0.254)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "BAT54S_1_1"
-        (pin passive line (at -7.62 0 0) (length 3.81)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 7.62 0 180) (length 3.81)
-          (name "K" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -5.08 90) (length 5.08)
-          (name "COM" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GND_1" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "GND_1" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"GND\" , ground" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "GND_1_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 -1.27)
-            (xy 1.27 -1.27)
-            (xy 0 -2.54)
-            (xy -1.27 -1.27)
-            (xy 0 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "GND_1_1_1"
-        (pin power_in line (at 0 0 270) (length 0) hide
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:RJ12_6P6C_HORZ" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
-      (property "Reference" "J401" (at 1.4478 16.6878 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "RJ12_6P6C_HORZ" (at 1.4478 14.3764 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "GeneralPurposeAlarmDevicePCB:RJ12_Amphenol_54601" (at 0 0.635 90)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811141146_TE-Connectivity-5555165-1_C305981.pdf" (at 0 0.635 90)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1 PN" "C305981" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 1" "JLCPCB" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 2" "Digikey" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Distributor 2 PN" "A31422-ND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer" "TE Connectivity" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Description" "Jack Modular Connector 6p6c (RJ11, RJ12, RJ14, RJ25) 90° Angle (Right) Unshielded Cat3" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Assembly Type" "" (at 1.4478 12.065 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "MPN" "5555165-1" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "AssemblyType" "HAND" (at 0 0 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Cost" "0.8901" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "MPN 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Manufacturer 2" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "6P6C RJ female connector" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "RJ connector, 6P6C (6 positions 6 connected), RJ12/RJ18/RJ25" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "6P6C* RJ12* RJ18* RJ25*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "RJ12_6P6C_HORZ_0_1"
-        (polyline
-          (pts
-            (xy -6.35 -1.905)
-            (xy -5.08 -1.905)
-            (xy -5.08 -1.905)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -6.35 -0.635)
-            (xy -5.08 -0.635)
-            (xy -5.08 -0.635)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -6.35 0.635)
-            (xy -5.08 0.635)
-            (xy -5.08 0.635)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -6.35 1.905)
-            (xy -5.08 1.905)
-            (xy -5.08 1.905)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -6.35 3.175)
-            (xy -5.08 3.175)
-            (xy -5.08 3.175)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -5.08 4.445)
-            (xy -6.35 4.445)
-            (xy -6.35 4.445)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -6.35 -4.445)
-            (xy -6.35 6.985)
-            (xy 3.81 6.985)
-            (xy 3.81 4.445)
-            (xy 5.08 4.445)
-            (xy 5.08 3.175)
-            (xy 6.35 3.175)
-            (xy 6.35 -0.635)
-            (xy 5.08 -0.635)
-            (xy 5.08 -1.905)
-            (xy 3.81 -1.905)
-            (xy 3.81 -4.445)
-            (xy -6.35 -4.445)
-            (xy -6.35 -4.445)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 7.62 10.16) (end -7.62 -7.62)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-      )
-      (symbol "RJ12_6P6C_HORZ_1_1"
-        (pin passive line (at 10.16 -5.08 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 10.16 -2.54 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 10.16 0 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 10.16 2.54 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 10.16 5.08 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "5" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 10.16 7.62 180) (length 2.54)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "6" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Transistor_FET:BSS138" (pin_names hide) (in_bom yes) (on_board yes)
-      (property "Reference" "Q" (at 5.08 1.905 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "BSS138" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 5.08 -1.905 0)
-        (effects (font (size 1.27 1.27) italic) (justify left) hide)
-      )
-      (property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) (justify left) hide)
-      )
-      (property "ki_keywords" "N-Channel MOSFET" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "50V Vds, 0.22A Id, N-Channel MOSFET, SOT-23" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "SOT?23*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "BSS138_0_1"
-        (polyline
-          (pts
-            (xy 0.254 0)
-            (xy -2.54 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.254 1.905)
-            (xy 0.254 -1.905)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.762 -1.27)
-            (xy 0.762 -2.286)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.762 0.508)
-            (xy 0.762 -0.508)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.762 2.286)
-            (xy 0.762 1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 2.54)
-            (xy 2.54 1.778)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 -2.54)
-            (xy 2.54 0)
-            (xy 0.762 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0.762 -1.778)
-            (xy 3.302 -1.778)
-            (xy 3.302 1.778)
-            (xy 0.762 1.778)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.016 0)
-            (xy 2.032 0.381)
-            (xy 2.032 -0.381)
-            (xy 1.016 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (polyline
-          (pts
-            (xy 2.794 0.508)
-            (xy 2.921 0.381)
-            (xy 3.683 0.381)
-            (xy 3.81 0.254)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 3.302 0.381)
-            (xy 2.921 -0.254)
-            (xy 3.683 -0.254)
-            (xy 3.302 0.381)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 1.651 0) (radius 2.794)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (circle (center 2.54 -1.778) (radius 0.254)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (circle (center 2.54 1.778) (radius 0.254)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "BSS138_1_1"
-        (pin input line (at -5.08 0 0) (length 2.54)
-          (name "G" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 -5.08 90) (length 2.54)
-          (name "S" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 5.08 270) (length 2.54)
-          (name "D" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-  )
-
-  (junction (at 210.82 27.94) (diameter 0) (color 0 0 0 0)
-    (uuid 07367cbb-64c5-428f-9384-a182fc8f884a)
-  )
-  (junction (at 130.81 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 0962d6ab-0d3b-44c4-86ad-50dcc4c67b8a)
-  )
-  (junction (at 215.9 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 1b8b1aca-cce7-49a6-bdb1-c7fb3e53ab99)
-  )
-  (junction (at 156.21 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 1e7ce0f5-f546-4557-85ad-416568c68d9f)
-  )
-  (junction (at 128.27 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 244b25f0-d8e8-4ea4-b5f0-e1fd494074a2)
-  )
-  (junction (at 210.82 130.81) (diameter 0) (color 0 0 0 0)
-    (uuid 24d4dd1f-6aeb-4ca2-85d7-435258ed6108)
-  )
-  (junction (at 233.68 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 24e53566-9a0e-4a21-a141-419615162207)
-  )
-  (junction (at 215.9 115.57) (diameter 0) (color 0 0 0 0)
-    (uuid 3557e5f2-d7a3-4877-8cf3-7beb2e97388d)
-  )
-  (junction (at 143.51 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 376fca63-1d9a-4d8f-8385-185bcdadba29)
-  )
-  (junction (at 161.29 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 37da3952-9e99-4792-8c63-c43db56ce7a9)
-  )
-  (junction (at 140.97 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 44ec5b95-688c-4605-965a-287d975346e1)
-  )
-  (junction (at 238.76 33.02) (diameter 0) (color 0 0 0 0)
-    (uuid 47f20896-cd39-4991-b1f0-f323671e669e)
-  )
-  (junction (at 236.22 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 520bf5f8-1242-439e-8255-12536b5b95a4)
-  )
-  (junction (at 107.95 87.63) (diameter 0) (color 0 0 0 0)
-    (uuid 5b9e8d5f-231b-41e4-bb11-c9be5efdd5e3)
-  )
-  (junction (at 86.36 96.52) (diameter 0) (color 0 0 0 0)
-    (uuid 5e1e56b7-4b55-4b49-9bf8-23bb3f4c6448)
-  )
-  (junction (at 161.29 33.02) (diameter 0) (color 0 0 0 0)
-    (uuid 6da1a61c-a9b3-4487-bf13-de5f6faab3ef)
-  )
-  (junction (at 168.91 87.63) (diameter 0) (color 0 0 0 0)
-    (uuid 7d0cc1ec-b80b-46c2-95df-bc99a26bb7dc)
-  )
-  (junction (at 191.77 72.39) (diameter 0) (color 0 0 0 0)
-    (uuid 99087240-2dc4-4738-b333-d7e65dccd934)
-  )
-  (junction (at 115.57 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 9a02720f-64a1-46f3-9a6f-c03872d4ba48)
-  )
-  (junction (at 220.98 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 9be1741b-cd78-44c2-96a0-851b6b04cf63)
-  )
-  (junction (at 130.81 78.74) (diameter 0) (color 0 0 0 0)
-    (uuid a4c6ae4c-2231-482e-89e8-eae3108db765)
-  )
-  (junction (at 111.76 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid a7483703-f70f-47a2-ae3c-781cff8b2d44)
-  )
-  (junction (at 133.35 114.3) (diameter 0) (color 0 0 0 0)
-    (uuid ab761f86-2405-47c9-903d-dd8e562c6cf4)
-  )
-  (junction (at 93.98 76.2) (diameter 0) (color 0 0 0 0)
-    (uuid b7010b8f-b42a-4eb5-a399-290c65c3b5d7)
-  )
-  (junction (at 198.12 130.81) (diameter 0) (color 0 0 0 0)
-    (uuid c692ddd6-360d-4000-803a-00aad39a24bd)
-  )
-  (junction (at 62.23 96.52) (diameter 0) (color 0 0 0 0)
-    (uuid d5c14f31-6a6a-4d89-93de-3977d9694928)
-  )
-  (junction (at 116.84 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid d890d725-9cf2-42be-9087-7797ee1e3632)
-  )
-  (junction (at 194.31 130.81) (diameter 0) (color 0 0 0 0)
-    (uuid dfd35729-0c5d-4f1d-973d-f6de558ef96e)
-  )
-  (junction (at 76.2 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid dfebb91e-5501-493f-a784-3052adebec2b)
-  )
-  (junction (at 231.14 26.67) (diameter 0) (color 0 0 0 0)
-    (uuid e063b820-08aa-46b2-bc5e-02e5ce6f41b4)
-  )
-  (junction (at 213.36 130.81) (diameter 0) (color 0 0 0 0)
-    (uuid ed9b61b0-3b3d-4837-863b-34d45d05996f)
-  )
-
-  (wire (pts (xy 133.35 121.92) (xy 133.35 114.3))
-    (stroke (width 0) (type default))
-    (uuid 0130001d-23a6-45bd-8f39-de4ca45d597f)
-  )
-  (wire (pts (xy 130.81 129.54) (xy 133.35 129.54))
-    (stroke (width 0) (type default))
-    (uuid 046edc5e-62d7-4286-ad82-72ec2f2c4347)
-  )
-  (wire (pts (xy 93.98 76.2) (xy 102.87 76.2))
-    (stroke (width 0) (type default))
-    (uuid 061dee90-28db-4012-92a8-8a4758191156)
-  )
-  (wire (pts (xy 168.91 87.63) (xy 168.91 121.92))
-    (stroke (width 0) (type default))
-    (uuid 091765f4-56cb-4f16-9cc4-06982639d9b3)
-  )
-  (wire (pts (xy 161.29 40.64) (xy 161.29 33.02))
-    (stroke (width 0) (type default))
-    (uuid 09654536-5305-4204-bfcb-a3e0ac6e4317)
-  )
-  (wire (pts (xy 233.68 48.26) (xy 236.22 48.26))
-    (stroke (width 0) (type default))
-    (uuid 0a808448-ae7b-4052-a652-1bb511525737)
-  )
-  (wire (pts (xy 124.46 48.26) (xy 125.73 48.26))
-    (stroke (width 0) (type default))
-    (uuid 0ae94ce8-182b-41f8-abaf-bf1e33e67158)
-  )
-  (wire (pts (xy 85.09 60.96) (xy 76.2 60.96))
-    (stroke (width 0) (type default))
-    (uuid 0afb22ef-bfc1-4022-876e-1fd643f4e07d)
-  )
-  (wire (pts (xy 62.23 96.52) (xy 74.93 96.52))
-    (stroke (width 0) (type default))
-    (uuid 0c510a1d-ba6f-45fc-a21a-53ebe8e03ec9)
-  )
-  (wire (pts (xy 44.45 78.74) (xy 130.81 78.74))
-    (stroke (width 0) (type default))
-    (uuid 0d49ac6c-d56e-414f-992f-830b2196bf4e)
-  )
-  (wire (pts (xy 215.9 48.26) (xy 215.9 72.39))
-    (stroke (width 0) (type default))
-    (uuid 0d96b626-6297-4b6d-8d2f-f79cbf2e58b6)
-  )
-  (wire (pts (xy 138.43 33.02) (xy 138.43 39.37))
-    (stroke (width 0) (type default))
-    (uuid 0d9eb85c-0868-40d7-84ae-91a0a6a533e8)
-  )
-  (wire (pts (xy 231.14 26.67) (xy 210.82 26.67))
-    (stroke (width 0) (type default))
-    (uuid 0e4339da-cbcf-4f84-a52f-730383596728)
-  )
-  (wire (pts (xy 199.39 130.81) (xy 198.12 130.81))
-    (stroke (width 0) (type default))
-    (uuid 0fcf08af-d372-4a11-94e9-e9e1608851eb)
-  )
-  (wire (pts (xy 148.59 33.02) (xy 148.59 40.64))
-    (stroke (width 0) (type default))
-    (uuid 101e0a56-dd76-40c4-9547-6498e60601e0)
-  )
-  (wire (pts (xy 100.33 87.63) (xy 100.33 83.82))
-    (stroke (width 0) (type default))
-    (uuid 13235fce-e0ee-486b-a9e4-6b3c0b3e8441)
-  )
-  (wire (pts (xy 191.77 72.39) (xy 215.9 72.39))
-    (stroke (width 0) (type default))
-    (uuid 14f1bb75-58e3-4726-b25e-01dcd66ff0de)
-  )
-  (wire (pts (xy 128.27 137.16) (xy 128.27 129.54))
-    (stroke (width 0) (type default))
-    (uuid 1a77e59c-b05b-458b-a618-aa43976e7bae)
-  )
-  (wire (pts (xy 232.41 48.26) (xy 233.68 48.26))
-    (stroke (width 0) (type default))
-    (uuid 1a85c645-0952-4a79-8bf8-f80444e82461)
-  )
-  (wire (pts (xy 153.67 72.39) (xy 191.77 72.39))
-    (stroke (width 0) (type default))
-    (uuid 1d729098-6566-4064-b092-11d233dc8e66)
-  )
-  (wire (pts (xy 226.06 33.02) (xy 226.06 40.64))
-    (stroke (width 0) (type default))
-    (uuid 2349880a-19c2-47de-8a2c-c0ed38df7bfe)
-  )
-  (wire (pts (xy 203.2 138.43) (xy 198.12 138.43))
-    (stroke (width 0) (type default))
-    (uuid 2424bf34-6d8e-410f-b4f7-0c445f9abe84)
-  )
-  (wire (pts (xy 168.91 63.5) (xy 168.91 48.26))
-    (stroke (width 0) (type default))
-    (uuid 2a61a554-4480-4211-8b4d-2e197aba419a)
-  )
-  (wire (pts (xy 130.81 129.54) (xy 130.81 96.52))
-    (stroke (width 0) (type default))
-    (uuid 2aa6ff75-01ca-40b8-a4b1-20b8c81b6f59)
-  )
-  (wire (pts (xy 140.97 48.26) (xy 143.51 48.26))
-    (stroke (width 0) (type default))
-    (uuid 2e2e5ff7-b464-4490-aea8-7f55a7cfd296)
-  )
-  (wire (pts (xy 181.61 49.53) (xy 184.15 49.53))
-    (stroke (width 0) (type default))
-    (uuid 2e4e10e9-4ce9-4352-919b-a13b8737b511)
-  )
-  (wire (pts (xy 226.06 40.64) (xy 227.33 40.64))
-    (stroke (width 0) (type default))
-    (uuid 3069727e-80a5-4fd5-864e-2701ce4a8967)
-  )
-  (wire (pts (xy 233.68 55.88) (xy 233.68 48.26))
-    (stroke (width 0) (type default))
-    (uuid 30df3ef7-8d7b-437e-b5e2-e7ecce793d5a)
-  )
-  (wire (pts (xy 111.76 96.52) (xy 111.76 129.54))
-    (stroke (width 0) (type default))
-    (uuid 330d4f58-f463-444d-8d90-5ad3c06abded)
-  )
-  (wire (pts (xy 92.71 60.96) (xy 116.84 60.96))
-    (stroke (width 0) (type default))
-    (uuid 354c3978-957d-4192-981a-22f4392f717d)
-  )
-  (wire (pts (xy 231.14 21.59) (xy 231.14 26.67))
-    (stroke (width 0) (type default))
-    (uuid 38073b2e-80e4-4050-8e8c-d1ee16a5233c)
-  )
-  (wire (pts (xy 110.49 67.31) (xy 102.87 67.31))
-    (stroke (width 0) (type default))
-    (uuid 3915bb7e-d350-4a71-9d3d-3f8ed80bc61c)
-  )
-  (wire (pts (xy 116.84 60.96) (xy 140.97 60.96))
-    (stroke (width 0) (type default))
-    (uuid 3df81617-ce3c-4f36-9e35-e47acdc18bff)
-  )
-  (wire (pts (xy 236.22 55.88) (xy 245.11 55.88))
-    (stroke (width 0) (type default))
-    (uuid 3f70f9a4-8fc5-4ba7-a880-4050d5a8e5da)
-  )
-  (wire (pts (xy 76.2 124.46) (xy 78.74 124.46))
-    (stroke (width 0) (type default))
-    (uuid 42d7c879-a174-4b79-8cdc-dc7ee7cdb558)
-  )
-  (wire (pts (xy 236.22 55.88) (xy 236.22 48.26))
-    (stroke (width 0) (type default))
-    (uuid 4441d282-ce0c-48a1-9485-da166f516015)
-  )
-  (wire (pts (xy 161.29 33.02) (xy 148.59 33.02))
-    (stroke (width 0) (type default))
-    (uuid 462f950b-8974-4b0f-b093-ea6646437d2d)
-  )
-  (wire (pts (xy 86.36 96.52) (xy 82.55 96.52))
-    (stroke (width 0) (type default))
-    (uuid 4cf24c2e-e4da-44b9-b677-ff9cdcc7805c)
-  )
-  (wire (pts (xy 128.27 129.54) (xy 130.81 129.54))
-    (stroke (width 0) (type default))
-    (uuid 4e0fd08d-6d74-4c07-9967-2cd0e6dcb8ac)
-  )
-  (wire (pts (xy 238.76 33.02) (xy 226.06 33.02))
-    (stroke (width 0) (type default))
-    (uuid 4f7fe4f1-9d43-4dbc-9df0-eb5b7ba01a72)
-  )
-  (wire (pts (xy 44.45 96.52) (xy 62.23 96.52))
-    (stroke (width 0) (type default))
-    (uuid 510d5b46-6350-49c9-a4ed-8a7b182b8acc)
-  )
-  (wire (pts (xy 130.81 78.74) (xy 139.7 78.74))
-    (stroke (width 0) (type default))
-    (uuid 5355e7c0-4d6f-4341-83f9-33e7cc0ffc05)
-  )
-  (wire (pts (xy 116.84 53.34) (xy 116.84 60.96))
-    (stroke (width 0) (type default))
-    (uuid 5994a3a7-f132-4c28-9d96-0e7d6d87781c)
-  )
-  (wire (pts (xy 143.51 48.26) (xy 144.78 48.26))
-    (stroke (width 0) (type default))
-    (uuid 5b605db0-55ae-438e-9d4e-1bf60b46e126)
-  )
-  (wire (pts (xy 215.9 48.26) (xy 220.98 48.26))
-    (stroke (width 0) (type default))
-    (uuid 5c039127-6103-4b30-8621-43240a2da17f)
-  )
-  (wire (pts (xy 44.45 86.36) (xy 44.45 96.52))
-    (stroke (width 0) (type default))
-    (uuid 5e64a0c5-b9ba-4ffd-a75d-7c4442ce0eb3)
-  )
-  (wire (pts (xy 139.7 72.39) (xy 146.05 72.39))
-    (stroke (width 0) (type default))
-    (uuid 5eeb645d-53bf-472e-8df4-b3cde95a6972)
-  )
-  (wire (pts (xy 226.06 55.88) (xy 220.98 55.88))
-    (stroke (width 0) (type default))
-    (uuid 60c71762-ee91-435d-8fa7-cf1d4176b2c9)
-  )
-  (wire (pts (xy 100.33 83.82) (xy 44.45 83.82))
-    (stroke (width 0) (type default))
-    (uuid 645319d2-9417-4abe-a097-3b25e34bdea2)
-  )
-  (wire (pts (xy 44.45 73.66) (xy 64.77 73.66))
-    (stroke (width 0) (type default))
-    (uuid 64f77451-ff0a-49eb-9f98-acc8eede7d03)
-  )
-  (wire (pts (xy 222.25 48.26) (xy 220.98 48.26))
-    (stroke (width 0) (type default))
-    (uuid 67ed233e-18d0-4d07-9806-37659684a78d)
-  )
-  (wire (pts (xy 115.57 67.31) (xy 245.11 67.31))
-    (stroke (width 0) (type default))
-    (uuid 6cc7c3a3-6835-4166-8574-3411c288aa28)
-  )
-  (wire (pts (xy 100.33 87.63) (xy 107.95 87.63))
-    (stroke (width 0) (type default))
-    (uuid 6e41b6aa-e59c-4ce6-9299-a2fe24ba7ef7)
-  )
-  (wire (pts (xy 215.9 123.19) (xy 215.9 115.57))
-    (stroke (width 0) (type default))
-    (uuid 7196b78c-b2eb-4a51-90bc-ece424f2d760)
-  )
-  (wire (pts (xy 86.36 96.52) (xy 86.36 119.38))
-    (stroke (width 0) (type default))
-    (uuid 730a9f0a-7f56-4555-b1c9-52441e13419d)
-  )
-  (wire (pts (xy 102.87 67.31) (xy 102.87 76.2))
-    (stroke (width 0) (type default))
-    (uuid 74373168-84e2-46bd-bc19-8000b17142be)
-  )
-  (wire (pts (xy 238.76 40.64) (xy 238.76 33.02))
-    (stroke (width 0) (type default))
-    (uuid 74460a26-72ea-4959-838e-9a628ee855dd)
-  )
-  (wire (pts (xy 194.31 130.81) (xy 198.12 130.81))
-    (stroke (width 0) (type default))
-    (uuid 74d005b6-f9bf-4e9a-b38f-73f1b443a166)
-  )
-  (wire (pts (xy 238.76 33.02) (xy 245.11 33.02))
-    (stroke (width 0) (type default))
-    (uuid 7780fb2a-f732-4deb-8d11-3ea1bb49aba4)
-  )
-  (wire (pts (xy 168.91 48.26) (xy 161.29 48.26))
-    (stroke (width 0) (type default))
-    (uuid 789ec5fa-be78-45ce-9352-f48923f70453)
-  )
-  (wire (pts (xy 148.59 40.64) (xy 149.86 40.64))
-    (stroke (width 0) (type default))
-    (uuid 78b4ba0b-7190-4622-aae9-409539efccd4)
-  )
-  (wire (pts (xy 210.82 26.67) (xy 210.82 27.94))
-    (stroke (width 0) (type default))
-    (uuid 7cfd1a86-6e29-4458-b926-6e1f3eede7cf)
-  )
-  (wire (pts (xy 203.2 115.57) (xy 203.2 123.19))
-    (stroke (width 0) (type default))
-    (uuid 7f078d92-a5c4-4ccf-9145-968d7597c99e)
-  )
-  (wire (pts (xy 143.51 55.88) (xy 143.51 48.26))
-    (stroke (width 0) (type default))
-    (uuid 8229b4fd-c235-48d2-8c1f-f489a253162d)
-  )
-  (wire (pts (xy 187.96 129.54) (xy 187.96 130.81))
-    (stroke (width 0) (type default))
-    (uuid 83b5cf1f-949d-48d4-886b-11c5dbbe54df)
-  )
-  (wire (pts (xy 106.68 48.26) (xy 109.22 48.26))
-    (stroke (width 0) (type default))
-    (uuid 842b3d7a-0549-41cb-b888-5312221d99b5)
-  )
-  (wire (pts (xy 121.92 114.3) (xy 121.92 121.92))
-    (stroke (width 0) (type default))
-    (uuid 84eda99b-bb4d-4bff-a892-2dcc13b1b08c)
-  )
-  (wire (pts (xy 76.2 60.96) (xy 64.77 60.96))
-    (stroke (width 0) (type default))
-    (uuid 86b51052-5345-40d0-b0cd-687df88317db)
-  )
-  (wire (pts (xy 215.9 115.57) (xy 222.25 115.57))
-    (stroke (width 0) (type default))
-    (uuid 8c76a18f-f624-443a-9270-ba9c455c967d)
-  )
-  (wire (pts (xy 115.57 137.16) (xy 115.57 129.54))
-    (stroke (width 0) (type default))
-    (uuid 8ce0bf86-9e54-455a-a5a2-ccb74903376c)
-  )
-  (wire (pts (xy 86.36 96.52) (xy 111.76 96.52))
-    (stroke (width 0) (type default))
-    (uuid 91c42464-6fe6-40d7-958f-c4aeefec07f7)
-  )
-  (wire (pts (xy 210.82 48.26) (xy 215.9 48.26))
-    (stroke (width 0) (type default))
-    (uuid 932d962e-a13c-42f8-88a7-937c3ef5636e)
-  )
-  (wire (pts (xy 209.55 130.81) (xy 210.82 130.81))
-    (stroke (width 0) (type default))
-    (uuid 93b66cf0-c30d-4dab-b4c0-8ea64f453c1e)
-  )
-  (wire (pts (xy 215.9 115.57) (xy 203.2 115.57))
-    (stroke (width 0) (type default))
-    (uuid 99e47af5-5138-45de-83b9-c19ba6a1ef5c)
-  )
-  (wire (pts (xy 64.77 60.96) (xy 64.77 73.66))
-    (stroke (width 0) (type default))
-    (uuid 9b48e4b0-a717-4e6e-a42c-b131feadf849)
-  )
-  (wire (pts (xy 158.75 127) (xy 161.29 127))
-    (stroke (width 0) (type default))
-    (uuid 9c976b3b-058c-4363-91e9-aadcc16568dd)
-  )
-  (wire (pts (xy 203.2 123.19) (xy 204.47 123.19))
-    (stroke (width 0) (type default))
-    (uuid 9d89a70b-8af7-444e-971c-ea7308aa1221)
-  )
-  (wire (pts (xy 76.2 57.15) (xy 76.2 60.96))
-    (stroke (width 0) (type default))
-    (uuid 9e6f819b-c71b-4447-a9c8-6da02b173183)
-  )
-  (wire (pts (xy 187.96 130.81) (xy 194.31 130.81))
-    (stroke (width 0) (type default))
-    (uuid 9f80230c-c25d-4587-8475-792076e9e8ef)
-  )
-  (wire (pts (xy 44.45 81.28) (xy 53.34 81.28))
-    (stroke (width 0) (type default))
-    (uuid a4f2adc0-e4b3-4ec4-affd-76cb3182a1ff)
-  )
-  (wire (pts (xy 161.29 33.02) (xy 166.37 33.02))
-    (stroke (width 0) (type default))
-    (uuid a52c4e18-bcf0-4fad-9e56-87c58d9af55b)
-  )
-  (wire (pts (xy 107.95 87.63) (xy 119.38 87.63))
-    (stroke (width 0) (type default))
-    (uuid a6bc22a4-29e5-4757-a2fc-eca355fa7f0f)
-  )
-  (wire (pts (xy 213.36 130.81) (xy 215.9 130.81))
-    (stroke (width 0) (type default))
-    (uuid a889520c-05e8-405d-b121-e49ef45cd1bd)
-  )
-  (wire (pts (xy 106.68 114.3) (xy 106.68 121.92))
-    (stroke (width 0) (type default))
-    (uuid ab9cac80-ffb3-4240-bbee-40a27dde644f)
-  )
-  (wire (pts (xy 205.74 27.94) (xy 210.82 27.94))
-    (stroke (width 0) (type default))
-    (uuid b0ee56e2-3fdd-4f84-b7e9-056b77c7392a)
-  )
-  (wire (pts (xy 93.98 124.46) (xy 95.25 124.46))
-    (stroke (width 0) (type default))
-    (uuid b192457b-4d9f-4310-bcd9-90d3e23a22d5)
-  )
-  (wire (pts (xy 168.91 63.5) (xy 245.11 63.5))
-    (stroke (width 0) (type default))
-    (uuid b7717cc9-a46c-4051-8479-b85e0e3e844b)
-  )
-  (wire (pts (xy 62.23 95.25) (xy 62.23 96.52))
-    (stroke (width 0) (type default))
-    (uuid b8ebebc7-2ef0-4431-8110-3ccca5aa4846)
-  )
-  (wire (pts (xy 148.59 55.88) (xy 143.51 55.88))
-    (stroke (width 0) (type default))
-    (uuid b90d6df6-f354-4004-9d70-39383a7bbbe3)
-  )
-  (wire (pts (xy 130.81 96.52) (xy 245.11 96.52))
-    (stroke (width 0) (type default))
-    (uuid ba30920f-1d8e-418b-8cc4-7d6267ef431e)
-  )
-  (wire (pts (xy 138.43 46.99) (xy 138.43 48.26))
-    (stroke (width 0) (type default))
-    (uuid bdcaeb74-4d33-488f-a278-e4be854e5212)
-  )
-  (wire (pts (xy 194.31 87.63) (xy 194.31 130.81))
-    (stroke (width 0) (type default))
-    (uuid be09e264-8dfe-4b16-b7fc-d573ef0d5745)
-  )
-  (wire (pts (xy 111.76 129.54) (xy 115.57 129.54))
-    (stroke (width 0) (type default))
-    (uuid bfb3cd7b-61d2-4216-8006-d5115ca6758a)
-  )
-  (wire (pts (xy 106.68 129.54) (xy 111.76 129.54))
-    (stroke (width 0) (type default))
-    (uuid bff88e6a-85c0-48da-8de8-18456beb534b)
-  )
-  (wire (pts (xy 116.84 129.54) (xy 115.57 129.54))
-    (stroke (width 0) (type default))
-    (uuid c5c17c67-01f2-4a40-892b-efa3c938b87f)
-  )
-  (wire (pts (xy 245.11 26.67) (xy 231.14 26.67))
-    (stroke (width 0) (type default))
-    (uuid c956ec99-78c0-4563-a8ee-28a7c6c6447a)
-  )
-  (wire (pts (xy 133.35 114.3) (xy 139.7 114.3))
-    (stroke (width 0) (type default))
-    (uuid cd376e5c-2f9d-4712-8eb7-cbd173e08903)
-  )
-  (wire (pts (xy 199.39 49.53) (xy 200.66 49.53))
-    (stroke (width 0) (type default))
-    (uuid cf1fa8c8-c53c-4044-a2b2-43dd827e0261)
-  )
-  (wire (pts (xy 187.96 115.57) (xy 187.96 121.92))
-    (stroke (width 0) (type default))
-    (uuid d27b7943-268a-4276-9112-26e1cd1f3863)
-  )
-  (wire (pts (xy 133.35 114.3) (xy 121.92 114.3))
-    (stroke (width 0) (type default))
-    (uuid d382c20c-86e3-4207-be07-d1c7e5d7e572)
-  )
-  (wire (pts (xy 213.36 87.63) (xy 245.11 87.63))
-    (stroke (width 0) (type default))
-    (uuid d3e7f981-9b0d-47d7-8a95-59de16876d90)
-  )
-  (wire (pts (xy 220.98 55.88) (xy 220.98 48.26))
-    (stroke (width 0) (type default))
-    (uuid d5336e82-039e-4281-bcb2-6c592970c7cb)
-  )
-  (wire (pts (xy 140.97 60.96) (xy 140.97 48.26))
-    (stroke (width 0) (type default))
-    (uuid d57c8aff-7b6e-45a2-a307-55f706ce909d)
-  )
-  (wire (pts (xy 139.7 72.39) (xy 139.7 78.74))
-    (stroke (width 0) (type default))
-    (uuid daa4181e-ea46-4f04-9373-a1f28ed37d46)
-  )
-  (wire (pts (xy 210.82 130.81) (xy 213.36 130.81))
-    (stroke (width 0) (type default))
-    (uuid dbb10e53-7bc1-4781-ac6d-49172080848b)
-  )
-  (wire (pts (xy 210.82 138.43) (xy 210.82 130.81))
-    (stroke (width 0) (type default))
-    (uuid dc17a375-0e85-4aee-95ca-28107b38ac13)
-  )
-  (wire (pts (xy 176.53 127) (xy 177.8 127))
-    (stroke (width 0) (type default))
-    (uuid de479f7b-edf6-42cb-8092-b42a18315c8a)
-  )
-  (wire (pts (xy 154.94 48.26) (xy 156.21 48.26))
-    (stroke (width 0) (type default))
-    (uuid decd049c-807b-42da-84ff-d9fb98012057)
-  )
-  (wire (pts (xy 210.82 27.94) (xy 210.82 40.64))
-    (stroke (width 0) (type default))
-    (uuid e1193f6d-cabb-43a4-8ebf-08740839d8ac)
-  )
-  (wire (pts (xy 236.22 48.26) (xy 238.76 48.26))
-    (stroke (width 0) (type default))
-    (uuid e2588106-fde2-40c8-b62c-ff6fbab4bd87)
-  )
-  (wire (pts (xy 168.91 87.63) (xy 194.31 87.63))
-    (stroke (width 0) (type default))
-    (uuid ec602115-019e-46b0-859f-5f957fa755b3)
-  )
-  (wire (pts (xy 156.21 55.88) (xy 156.21 48.26))
-    (stroke (width 0) (type default))
-    (uuid ec947fa6-547c-4d21-be64-dfe733c26842)
-  )
-  (wire (pts (xy 156.21 48.26) (xy 161.29 48.26))
-    (stroke (width 0) (type default))
-    (uuid f1efce15-0142-4297-9b32-855d5b821bd7)
-  )
-  (wire (pts (xy 127 129.54) (xy 128.27 129.54))
-    (stroke (width 0) (type default))
-    (uuid f222186c-6812-47d4-8b9d-75c1546aba8b)
-  )
-  (wire (pts (xy 213.36 87.63) (xy 213.36 130.81))
-    (stroke (width 0) (type default))
-    (uuid f23937e9-ace7-4433-8992-bd2ccccc62c0)
-  )
-  (wire (pts (xy 191.77 54.61) (xy 191.77 72.39))
-    (stroke (width 0) (type default))
-    (uuid f555e9f3-5708-467a-8829-6da9f4f5622a)
-  )
-  (wire (pts (xy 127 87.63) (xy 168.91 87.63))
-    (stroke (width 0) (type default))
-    (uuid f7cd4cf9-0d64-4743-8b52-a76aa3b5572c)
-  )
-  (wire (pts (xy 140.97 48.26) (xy 138.43 48.26))
-    (stroke (width 0) (type default))
-    (uuid f89539be-c211-4c63-b9c4-babba974f911)
-  )
-  (wire (pts (xy 198.12 138.43) (xy 198.12 130.81))
-    (stroke (width 0) (type default))
-    (uuid f8a43f4a-30df-416f-b0ed-b28b0d050f60)
-  )
-  (wire (pts (xy 120.65 137.16) (xy 115.57 137.16))
-    (stroke (width 0) (type default))
-    (uuid f8cbfcf6-383e-4b9d-99b8-6867b8f5bd96)
-  )
-  (wire (pts (xy 44.45 76.2) (xy 93.98 76.2))
-    (stroke (width 0) (type default))
-    (uuid fc2efe0e-8c51-422d-8c79-fa2919156400)
-  )
-
-  (image (at 248.92 179.07) (scale 0.75)
-    (uuid 9c26c501-ef3b-49d9-bdd3-e368e1e72b08)
-    (data
-      iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz
-      AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h
-      aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73
-      +/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA
-      xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y
-      Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h
-      xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO
-      GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful
-      fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv
-      4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ
-      EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R
-      Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM
-      vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H
-      cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0
-      6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT
-      O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA
-      4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86
-      sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+
-      oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/
-      55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0
-      qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+
-      KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn
-      Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4
-      mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii
-      P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr
-      voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6
-      bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO
-      h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da
-      4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y
-      YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC
-      0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP
-      SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb
-      WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw
-      v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay
-      PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX
-      Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh
-      oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD
-      7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da
-      43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l
-      zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl
-      pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS
-      H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV
-      ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY
-      MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2
-      NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx
-      fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl
-      tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew
-      iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj
-      jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI
-      cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo
-      XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R
-      9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv
-      8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV
-      RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY
-      l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf
-      YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN
-      EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU
-      sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z
-      7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs
-      OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs
-      qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7
-      G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6
-      wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7
-      zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln
-      Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX
-      apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk
-      lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw
-      TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb
-      54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID
-      qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd
-      P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l
-      UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD
-      zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH
-      Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1
-      QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/
-      ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX
-      08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC
-      KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ
-      SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu
-      h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp
-      VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf
-      G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK
-      dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO
-      uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2
-      DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn
-      byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc
-      dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N
-      iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP
-      NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4
-      wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8
-      K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s
-      xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS
-      Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC
-      Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5
-      m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm
-      aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj
-      gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn
-      p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL
-      ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx
-      u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+
-      FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa
-      ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h
-      1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj
-      DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy
-      +Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj
-      wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj
-      7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ
-      lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN
-      2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY
-      CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi
-      mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E
-      uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x
-      j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD
-      45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO
-      4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni
-      buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY
-      HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH
-      NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ
-      azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N
-      SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP
-      hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe
-      nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4
-      b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN
-      xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S
-      pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq
-      3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB
-      Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL
-      4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw
-      qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX
-      9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n
-      frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/
-      eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK
-      TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u
-      RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9
-      DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j
-      2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx
-      BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy
-      91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7
-      jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw
-      pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ
-      cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M
-      xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23
-      7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8
-      D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw
-      YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu
-      QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs
-      uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA
-      PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6
-      yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN
-      xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq
-      JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT
-      +HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg
-      hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K
-      hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt
-      g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z
-      5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf
-      u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO
-      Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG
-      gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK
-      hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x
-      moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56
-      KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp
-      ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz
-      eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO
-      0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA
-      BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ
-      2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB
-      4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF
-      6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI
-      gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv
-      OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt
-      8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI
-      bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM
-      500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4
-      CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V
-      aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5
-      yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF
-      zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss
-      tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q
-      r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj
-      xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h
-      6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y
-      9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE
-      XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh
-      oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk
-      Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4
-      ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW
-      zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr
-      wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV
-      BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7
-      LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr
-      owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX
-      hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j
-      1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF
-      5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw
-      a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6
-      Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN
-      +SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds
-      lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ
-      i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu
-      fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy
-      r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28
-      dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az
-      70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk
-      EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL
-      p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf
-      nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA
-      ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c
-      q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu
-      Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR
-      TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53
-      en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA
-      x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ
-      t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+
-      R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf
-      5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH
-      e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG
-      po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh
-      6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln
-      9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU
-      xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ
-      rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W
-      lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb
-      afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs
-      FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR
-      OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC
-      P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp
-      EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh
-      6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK
-      GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ
-      hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s
-      amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+
-      fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij
-      TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv
-      I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf
-      kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ
-      BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD
-      9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn
-      jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8
-      I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI
-      8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs
-      Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN
-      MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5
-      2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU
-      2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss
-      ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m
-      sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq
-      LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT
-      tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9
-      oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p
-      zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu
-      WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy
-      diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX
-      ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY
-      5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau
-      Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7
-      oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG
-      xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q
-      zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik
-      sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN
-      ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc
-      MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E
-      YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3
-      bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz
-      DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC
-      TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES
-      3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K
-      Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd
-      b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5
-      99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys
-      7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa
-      Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e
-      8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1
-      vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK
-      VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4
-      ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD
-      CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4
-      qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr
-      1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe
-      GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK
-      yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj
-      po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO
-      Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF
-      tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D
-      mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM
-      eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN
-      veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu
-      5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL
-      Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t
-      rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl
-      sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx
-      mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG
-      PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk
-      Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk
-      caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO
-      jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS
-      gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E
-      OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+
-      p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO
-      cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM
-      S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc
-      vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3
-      boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn
-      DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD
-      90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw
-      0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT
-      5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI
-      7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP
-      QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw
-      oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E
-      mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/
-      N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm
-      vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC
-      +OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp
-      gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz
-      gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni
-      R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3
-      j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo
-      BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl
-      IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4
-      jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA
-      Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS
-      AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz
-      6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H
-      qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp
-      cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa
-      M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv
-      4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M
-      IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD
-      Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r
-      un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr
-      2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/
-      kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF
-      7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8
-      YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk
-      zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp
-      8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF
-      o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt
-      Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA
-      hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx
-      LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk
-      iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2
-      HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5
-      K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo
-      XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/
-      D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j
-      MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c
-      O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB
-      fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X
-      /V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI
-      a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe
-      L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37
-      zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY
-      BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg==
-    )
-  )
-
-  (text "3v3 to 5v level shifter" (at 127 60.325 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 12b2a282-9cd5-4832-98ba-b901bbad1863)
-  )
-  (text "At this interface we have a 5v logic levels." (at 18.415 69.215 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 38560f87-51b3-4528-9e8c-2da63dc3e29f)
-  )
-  (text "Place near Clamp Diodes" (at 188.595 25.4 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 546a7984-5e79-427f-9756-9f76db0b11d8)
-  )
-  (text "  5v to 3v3level shifter" (at 179.705 142.24 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 6a5cd73f-ce79-41c7-891a-15c33489c889)
-  )
-  (text "  5v to 3v3level shifter" (at 97.79 141.605 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid d75a281f-36da-44b4-823e-2df5f5ae9da7)
-  )
-  (text "SPI Peripherial Interface" (at 18.415 23.495 0)
-    (effects (font (size 2.54 2.54)) (justify left bottom))
-    (uuid de7d0d01-1029-4296-b896-1a7caeed1b3f)
-  )
-  (text "these are 3v3 logic levels" (at 238.76 25.4 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid f1a433a9-e07b-464a-8438-20bbb5282b82)
-  )
-  (text "ESD protection circuit" (at 177.165 41.275 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid f7b0b2e9-e9ae-4b7e-aaa7-4be254bfd97c)
-  )
-  (text "  5v to 3v3level shifter" (at 201.295 60.325 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid f9c8b035-20b3-4f99-ae30-2e7a3e805e64)
-  )
-
-  (label "SS" (at 44.45 87.63 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 45c7ad2d-9639-45aa-8445-ba36d1d37fc9)
-  )
-  (label "MOSI" (at 44.45 83.82 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 55e45be9-9977-4e43-99cb-a71acf12abfc)
-  )
-  (label "+12in" (at 44.45 76.2 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid aa423027-d060-466a-a3cb-db138a49db11)
-  )
-  (label "MISO" (at 44.45 73.66 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid b8cc4456-8c6e-45d1-8ba6-69584c059225)
-  )
-  (label "SCK" (at 44.45 78.74 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid b9236818-f843-4393-b271-dc9c17a725ef)
-  )
-
-  (hierarchical_label "3V3Raw" (shape input) (at 245.11 33.02 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 0739c5c0-ed1b-4f4b-977c-ded8b9ba233f)
-  )
-  (hierarchical_label "5VRaw" (shape input) (at 200.66 49.53 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 0fc66b8b-10cb-4171-842c-2331cba9a8f8)
-  )
-  (hierarchical_label "CIPO" (shape output) (at 245.11 63.5 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 184583a6-8059-421b-be6b-4638d55c1a87)
-  )
-  (hierarchical_label "5VRaw" (shape input) (at 95.25 124.46 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 18a6e06d-0e97-4864-a34e-a076236849b8)
-  )
-  (hierarchical_label "5VRaw" (shape input) (at 125.73 48.26 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 2400cb84-7160-4a4d-8e5f-478bea9fbefd)
-  )
-  (hierarchical_label "ControllerVcc" (shape passive) (at 245.11 67.31 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 4301347d-d4d6-44d6-badb-a64ab4849e0c)
-  )
-  (hierarchical_label "nCS" (shape input) (at 245.11 96.52 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 44fb4782-ea07-4f12-99c7-94918abd668f)
-  )
-  (hierarchical_label "3V3Raw" (shape input) (at 166.37 33.02 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 5db98748-ccf6-4e8b-acad-074ab5d54c33)
-  )
-  (hierarchical_label "5VRaw" (shape input) (at 177.8 127 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 6b0c34e4-851c-4db3-aee5-1ce45833dce7)
-  )
-  (hierarchical_label "5VRaw" (shape input) (at 138.43 33.02 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 6e3460f9-d2ed-4dbd-8519-251aff90ced8)
-  )
-  (hierarchical_label "SCK" (shape input) (at 245.11 55.88 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 7c92ac38-1389-4375-a961-4ae75e93c487)
-  )
-  (hierarchical_label "5VRaw" (shape input) (at 106.68 114.3 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 80ad984e-36fd-46cb-b82e-afa3e96be9f2)
-  )
-  (hierarchical_label "5VRaw" (shape input) (at 245.11 26.67 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 8a97fbc1-f1c4-4169-a25a-4565b6c62fa3)
-  )
-  (hierarchical_label "3V3Raw" (shape input) (at 139.7 114.3 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid b1f7168e-9348-4548-b5be-ba69f10bc186)
-  )
-  (hierarchical_label "5VRaw" (shape input) (at 187.96 115.57 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid baae37bf-aacc-4316-8b7f-a7756d5d22f5)
-  )
-  (hierarchical_label "3V3Raw" (shape input) (at 222.25 115.57 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid dc5a044e-81dd-4ddc-80e8-eff8b3ec702c)
-  )
-  (hierarchical_label "COPI" (shape input) (at 245.11 87.63 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid ebff7e57-0b79-4bee-bce2-8fd494ab80aa)
-  )
-
-  (symbol (lib_id "Device:R") (at 88.9 60.96 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b96d5b)
-    (property "Reference" "R401" (at 87.63 55.88 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 88.9 58.42 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 88.9 59.182 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 88.9 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 88.9 60.96 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 88.9 60.96 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 88.9 60.96 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 88.9 60.96 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 88.9 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 88.9 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 88.9 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 88.9 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 88.9 60.96 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8566a35c-9a7e-435b-a2b8-c7e0449d0312))
-    (pin "2" (uuid 2d54ab1f-7e31-4242-a60c-41c6b8c03ee5))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R401") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 149.86 72.39 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b96d66)
-    (property "Reference" "R402" (at 150.495 69.85 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 150.495 74.93 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 149.86 70.612 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 149.86 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 149.86 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 149.86 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 149.86 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 149.86 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 149.86 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 149.86 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 149.86 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 149.86 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 149.86 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 418c8df4-e55e-4a29-bf77-c34a92b580f8))
-    (pin "2" (uuid 1b7347ad-e28b-4b3e-8416-f9274b5e7a98))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R402") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 123.19 87.63 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b96d71)
-    (property "Reference" "R403" (at 121.92 82.55 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 123.19 85.09 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 123.19 85.852 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 123.19 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 123.19 87.63 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 123.19 87.63 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 123.19 87.63 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 123.19 87.63 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 123.19 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 123.19 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 123.19 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 123.19 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 123.19 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid de2c5dd2-8efe-47ee-aab0-337b12bb5432))
-    (pin "2" (uuid 17af62e2-fd93-4380-a51d-2299488c5b84))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R403") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 78.74 96.52 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062b96d7c)
-    (property "Reference" "R404" (at 77.47 91.44 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 78.74 93.98 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 78.74 94.742 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 78.74 96.52 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 78.74 96.52 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 78.74 96.52 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 78.74 96.52 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 37e4d13c-da5b-4593-999d-c25438609042))
-    (pin "2" (uuid e4d36ba4-afd7-42c7-9f49-42ccd2d01617))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R404") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:RJ12_6P6C_HORZ") (at 34.29 81.28 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062d0d90d)
-    (property "Reference" "J401" (at 35.7378 64.5922 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "RJ12_6P6C_HORZ" (at 35.7378 66.9036 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:RJ12_Amphenol_54601" (at 34.29 80.645 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811141146_TE-Connectivity-5555165-1_C305981.pdf" (at 34.29 80.645 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 34.29 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C305981" (at 34.29 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2" "Digikey" (at 34.29 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 2 PN" "A31422-ND" (at 34.29 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TE Connectivity" (at 34.29 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Jack Modular Connector 6p6c (RJ11, RJ12, RJ14, RJ25) 90° Angle (Right) Unshielded Cat3" (at 34.29 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Assembly Type" "" (at 35.7378 69.215 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "MPN" "5555165-1" (at 34.29 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 34.29 81.28 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Cost" "0.8901" (at 34.29 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 34.29 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 34.29 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 81710cd4-378d-4f8f-b2bb-2e35d4cef32f))
-    (pin "2" (uuid f3f077b4-17d5-49f6-a8e3-1d4a0386b55c))
-    (pin "3" (uuid c7894986-df0b-4c6e-b6e2-9efbc37d5804))
-    (pin "4" (uuid 4ed6e6c8-e00e-4d6f-9e36-72aafd133f28))
-    (pin "5" (uuid 732a3d58-0a27-465b-af9e-5ccbaf1c421b))
-    (pin "6" (uuid 5ca97cee-e7a0-44c0-bffd-71164902d969))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "J401") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:Polyfuse_Small") (at 113.03 67.31 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-0000630ab448)
-    (property "Reference" "F401" (at 116.84 66.04 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "Polyfuse_Small_1A" (at 114.3 69.85 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Fuse:Fuse_0603_1608Metric" (at 107.95 68.58 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Datasheet" "~" (at 113.03 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Littelfuse" (at 113.03 67.31 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "0603L100SLYR" (at 113.03 67.31 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 113.03 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.2448" (at 113.03 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "6V 1A 50A -40℃~+85℃ 1.8A 40mΩ 300ms 120mΩ 0603 Resettable Fuses ROHS" (at 113.03 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 113.03 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C207017" (at 113.03 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 113.03 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 113.03 67.31 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a588700c-e22c-4877-8918-a2136f022684))
-    (pin "2" (uuid c174269c-3aba-4055-beba-d85356de1e04))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "F401") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 187.96 125.73 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 034819a1-fe87-4b6f-86ec-88f40193ea95)
-    (property "Reference" "R?" (at 185.42 121.92 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 184.15 127 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 186.182 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 187.96 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 187.96 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 187.96 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 187.96 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 187.96 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 187.96 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 187.96 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 187.96 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 187.96 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 187.96 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 24584903-25c1-4146-ac83-5da1482e6914))
-    (pin "2" (uuid 45aa6c0b-bae7-46e2-8aa9-5a8e6d9d940e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R319") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 231.14 21.59 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0350c407-71b9-4d55-9788-c8e58295126e)
-    (property "Reference" "TP?" (at 226.06 13.97 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "5VRaw" (at 226.06 16.51 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 236.22 21.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 236.22 21.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 231.14 21.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings ROHS red" (at 231.14 21.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 231.14 21.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 231.14 21.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 231.14 21.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 231.14 21.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 231.14 21.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 231.14 21.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 231.14 21.59 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ee192def-c8c2-448f-8cc4-f39c00766a26))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "TP306") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:BAT54S") (at 168.91 127 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0c0d530e-9ef2-4d24-9a3b-dd6cb1e1093a)
-    (property "Reference" "D?" (at 168.91 133.35 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "BAT54S" (at 168.91 130.81 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 170.815 130.175 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds11005.pdf" (at 165.862 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C47546" (at 168.91 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0098" (at 168.91 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "30V 1 pair in series 800mV@100mA 200mA SOT-23 Schottky Diodes ROHS" (at 168.91 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 168.91 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "BAT54S,215" (at 168.91 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Nexperia" (at 168.91 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 168.91 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 168.91 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 168.91 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 55941a78-742b-4a06-8da9-c3a2a84fa370))
-    (pin "2" (uuid db232f65-6e40-49e5-ac21-dcaa87cf11a8))
-    (pin "3" (uuid bde4bda7-5e87-402f-8efa-64c5f1d09aa0))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "D?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "D303") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 207.01 138.43 90) (mirror x) (unit 1)
-    (in_bom no) (on_board yes) (dnp no)
-    (uuid 0d6401d6-eb2d-4870-9a8a-b09816c219a8)
-    (property "Reference" "R?" (at 210.82 135.89 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 207.01 140.97 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 207.01 136.652 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 207.01 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 207.01 138.43 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 207.01 138.43 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 207.01 138.43 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 207.01 138.43 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 207.01 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 207.01 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 207.01 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 207.01 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 207.01 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1f24e855-042f-4912-98d4-a3cb72ba04cd))
-    (pin "2" (uuid 39fd4308-7ef4-4c07-9572-171c4d753a7b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R320") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:BAT54S") (at 86.36 124.46 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 16c10c86-0535-48f7-bcda-21bd542151de)
-    (property "Reference" "D?" (at 86.36 130.81 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "BAT54S" (at 86.36 128.27 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 88.265 127.635 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds11005.pdf" (at 83.312 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C47546" (at 86.36 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0098" (at 86.36 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "30V 1 pair in series 800mV@100mA 200mA SOT-23 Schottky Diodes ROHS" (at 86.36 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 86.36 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "BAT54S,215" (at 86.36 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Nexperia" (at 86.36 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 86.36 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 86.36 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 86.36 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 189a5b3d-997e-442d-a155-a92eacb29124))
-    (pin "2" (uuid 3d75d955-0adb-4b63-859e-863919680b22))
-    (pin "3" (uuid d4256258-2b66-40f3-b5d1-beed656eff52))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "D?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "D301") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Transistor_FET:BSS138") (at 227.33 45.72 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 1e2fde0f-aa8a-4aa2-943d-23221ba7a220)
-    (property "Reference" "Q?" (at 224.79 44.45 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "BSS138" (at 231.14 52.07 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 229.235 50.8 0)
-      (effects (font (size 1.27 1.27) italic) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF" (at 227.33 45.72 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Description" "N-Channel Enhancement Mode Field Effect Transistor" (at 227.33 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 227.33 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C400505" (at 227.33 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd" (at 227.33 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "BSS138" (at 227.33 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 227.33 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0196" (at 227.33 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 227.33 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 227.33 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a5a631f2-09eb-4692-9a5b-d7379d02071d))
-    (pin "2" (uuid 73a3c99a-6ed9-4095-a8d9-7edcb3301bdc))
-    (pin "3" (uuid a18e3081-5dbc-4a0a-8c18-9a40c5143454))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "Q?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "Q305") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 53.34 81.28 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 3437063a-6972-47ef-9b64-8dee716b77b0)
-    (property "Reference" "#PWR0108" (at 53.34 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 57.15 82.55 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 53.34 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 53.34 81.28 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ad61fa30-ec22-4944-be66-3e749fae90df))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "#PWR0301") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 76.2 124.46 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3fa0f74a-e737-4819-a384-87eff901429f)
-    (property "Reference" "#PWR0108" (at 76.2 130.81 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 76.2 129.54 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 76.2 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 76.2 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c7b86d1d-9183-43cc-b0a5-a61d51c2ddc5))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "#PWR0306") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 93.98 76.2 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 4fccccd4-5e5f-4770-971a-cf8a350a7b81)
-    (property "Reference" "TP404" (at 93.98 69.85 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "+12in" (at 95.25 72.39 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 93.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 93.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 93.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 93.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 93.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 93.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 93.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 93.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 93.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 68d1a795-5dbf-43a9-8ce2-0b350b256215))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP404") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP107") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "TP302") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 106.68 125.73 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 50c2a832-4bce-4ede-94a0-3fec839db716)
-    (property "Reference" "R?" (at 104.14 121.92 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 102.87 127 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 104.902 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 106.68 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 106.68 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 106.68 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 106.68 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 106.68 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 106.68 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 106.68 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 106.68 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 106.68 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 106.68 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3873f775-a066-436d-8c9a-f397eaf90871))
-    (pin "2" (uuid 188469bf-9fb2-40ca-9fcf-4ff282f83072))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R313") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 76.2 57.15 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 54d30c15-312d-4eda-a40a-3d4458521ed0)
-    (property "Reference" "TP404" (at 76.2 50.8 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "CIPO" (at 77.47 53.34 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 81.28 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 81.28 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 76.2 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 76.2 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 76.2 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 76.2 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 76.2 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 76.2 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 76.2 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 76.2 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 76.2 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0a749866-cc24-43c3-88de-2a81e00c719a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP404") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP107") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "TP301") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:BAT54S") (at 116.84 48.26 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5923f833-dfe1-4017-9347-c28e5771709d)
-    (property "Reference" "D?" (at 116.84 41.91 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "BAT54S" (at 116.84 44.45 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 118.745 45.085 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds11005.pdf" (at 113.792 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C47546" (at 116.84 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0098" (at 116.84 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "30V 1 pair in series 800mV@100mA 200mA SOT-23 Schottky Diodes ROHS" (at 116.84 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 116.84 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "BAT54S,215" (at 116.84 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Nexperia" (at 116.84 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 116.84 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 116.84 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 116.84 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2f1112ed-215a-4cc0-aceb-f2c26967cb0c))
-    (pin "2" (uuid a1a5dc6a-ada6-417c-aad7-a24b3a417961))
-    (pin "3" (uuid e4e0decd-589c-4a8b-941e-aee9632f72b2))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "D?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "D302") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Transistor_FET:BSS138") (at 121.92 127 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 5ddb57eb-a878-4d18-90b3-a112997d27a0)
-    (property "Reference" "Q?" (at 119.38 125.73 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "BSS138" (at 125.73 133.35 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 123.825 132.08 0)
-      (effects (font (size 1.27 1.27) italic) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF" (at 121.92 127 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Description" "N-Channel Enhancement Mode Field Effect Transistor" (at 121.92 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 121.92 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C400505" (at 121.92 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd" (at 121.92 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "BSS138" (at 121.92 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 121.92 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0196" (at 121.92 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 121.92 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 121.92 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid df38cf49-dc62-47ff-ac4f-38cb165b82ab))
-    (pin "2" (uuid 3444cf44-01d8-41ee-8a6b-c61cacf1518f))
-    (pin "3" (uuid e8d79f14-a348-4540-a770-23c834018ad9))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "Q?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "Q302") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 205.74 31.75 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 784b70db-3493-41b8-a771-54837dc8fcc8)
-    (property "Reference" "C103" (at 202.819 32.9184 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 202.819 30.607 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 204.7748 27.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 205.74 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 205.74 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 205.74 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 205.74 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 205.74 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 205.74 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 205.74 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 205.74 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 205.74 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 205.74 31.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6bd10dfe-b0b8-4c48-a59e-2966a89d8749))
-    (pin "2" (uuid 84eac7e2-12b3-4ce7-afb6-e426a4f1d40c))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "C103") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "C303") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 130.81 78.74 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 7dcdbb7b-c183-42dc-b9e0-065e211cba88)
-    (property "Reference" "TP404" (at 130.81 72.39 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "SCK" (at 132.08 74.93 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 135.89 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 135.89 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 130.81 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 130.81 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 130.81 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 130.81 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 130.81 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 130.81 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 130.81 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 130.81 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 130.81 78.74 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7b465f41-244a-4d92-b2ef-5c5b2877fee9))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP404") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP107") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "TP303") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 215.9 127 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 7e78b475-f596-4c7e-a471-eb9af1198c24)
-    (property "Reference" "R?" (at 213.36 123.19 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 212.09 128.27 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 214.122 127 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 215.9 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 215.9 127 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 215.9 127 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 215.9 127 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 215.9 127 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 215.9 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 215.9 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 215.9 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 215.9 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 215.9 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c01363bf-a440-4f17-9916-e3156cced0da))
-    (pin "2" (uuid 103c0308-32e8-41f2-813e-e968b785dbc0))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R322") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 133.35 125.73 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 80795a5d-db6d-4cd9-9d24-6fa607634bd1)
-    (property "Reference" "R?" (at 130.81 121.92 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 129.54 127 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 131.572 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 133.35 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 133.35 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 133.35 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 133.35 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 133.35 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 133.35 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 133.35 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 133.35 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 133.35 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 133.35 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1cf584d4-cee0-43ec-a259-201bd59882da))
-    (pin "2" (uuid 59730bcd-84fc-4e8a-a644-f4e97c91b177))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R315") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 106.68 48.26 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 88d23423-5d86-4a6c-a0b4-529ae96c8d0d)
-    (property "Reference" "#PWR0108" (at 106.68 54.61 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 106.68 53.34 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 106.68 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 106.68 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d36b11e8-8b6a-4918-9cf6-36564fc9a41b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "#PWR0302") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:BAT54S") (at 191.77 49.53 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 979ea98a-fcb1-4ac8-84a6-60a2a29d6b96)
-    (property "Reference" "D?" (at 191.77 43.18 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "BAT54S" (at 191.77 45.72 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 193.675 46.355 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds11005.pdf" (at 188.722 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C47546" (at 191.77 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0098" (at 191.77 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "30V 1 pair in series 800mV@100mA 200mA SOT-23 Schottky Diodes ROHS" (at 191.77 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 191.77 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "BAT54S,215" (at 191.77 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Nexperia" (at 191.77 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 191.77 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 191.77 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 191.77 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 40b793d8-69d0-4d30-ad08-dfd65498c5e9))
-    (pin "2" (uuid bc7bc5cb-0379-452c-827b-c348ca47c243))
-    (pin "3" (uuid f3f3d08f-e45d-4958-9cf5-3e917f7d36f0))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "D?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "D304") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 152.4 55.88 90) (mirror x) (unit 1)
-    (in_bom no) (on_board yes) (dnp no)
-    (uuid 9c30ac61-de20-4b77-b8c6-f4dc12768634)
-    (property "Reference" "R?" (at 156.21 53.34 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 152.4 58.42 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 152.4 54.102 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 152.4 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 152.4 55.88 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 152.4 55.88 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 152.4 55.88 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 152.4 55.88 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 152.4 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 152.4 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 152.4 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 152.4 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 152.4 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ce1d12cc-75b7-4d90-8ee4-a3812a9af4b9))
-    (pin "2" (uuid 9708f4fd-c1fa-424a-bb06-23fd81647b23))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R317") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 138.43 43.18 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid a1fb2b37-414d-47ee-85ac-2cf51a10fa09)
-    (property "Reference" "R?" (at 135.89 39.37 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 136.652 43.18 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 138.43 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 138.43 43.18 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 138.43 43.18 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 138.43 43.18 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 138.43 43.18 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 138.43 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 138.43 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 138.43 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 138.43 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 138.43 43.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c1fa227a-3eb9-4ea0-8c75-e733639848dc))
-    (pin "2" (uuid 4979d160-9ad3-42b4-be8b-9c9cca35578b))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R316") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 107.95 87.63 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid a8a844dd-869e-4522-ad0c-4b050bafbd4b)
-    (property "Reference" "TP404" (at 107.95 81.28 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "COPI" (at 109.22 83.82 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 113.03 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 113.03 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 107.95 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 107.95 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 107.95 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 107.95 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 107.95 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 107.95 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 107.95 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 107.95 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 107.95 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid de28d98d-5761-457b-a76c-e8efab4df57f))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP404") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP107") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "TP304") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 181.61 49.53 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ae391940-95de-4206-bea8-95c8699c0964)
-    (property "Reference" "#PWR0108" (at 181.61 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 181.61 54.61 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 181.61 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 181.61 49.53 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 81805470-2a95-4f01-ad44-5e6e7baf8dc7))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "#PWR0304") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 158.75 127 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b549d127-52f5-4cc8-964d-f467cb8efe76)
-    (property "Reference" "#PWR0108" (at 158.75 133.35 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 158.75 132.08 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 158.75 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 158.75 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2595f1dc-c65e-47ad-b6b2-d1daf090cfa7))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "#PWR0307") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Transistor_FET:BSS138") (at 149.86 45.72 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid b6a81a2c-69bf-4a34-ad7b-8620e2c11e51)
-    (property "Reference" "Q?" (at 147.32 44.45 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "BSS138" (at 153.67 52.07 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 151.765 50.8 0)
-      (effects (font (size 1.27 1.27) italic) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF" (at 149.86 45.72 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Description" "N-Channel Enhancement Mode Field Effect Transistor" (at 149.86 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 149.86 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C400505" (at 149.86 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd" (at 149.86 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "BSS138" (at 149.86 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 149.86 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0196" (at 149.86 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 149.86 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 149.86 45.72 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1f133650-d298-4a2d-a473-19c038f03041))
-    (pin "2" (uuid 22086d8f-b2c6-4eaa-a769-74984f1d8002))
-    (pin "3" (uuid b5c7cc41-c156-468e-9ca1-d33b3f4d3167))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "Q?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "Q303") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Transistor_FET:BSS138") (at 204.47 128.27 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid b70d63d5-7455-4818-9d60-b0a039eeef8b)
-    (property "Reference" "Q?" (at 201.93 127 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "BSS138" (at 208.28 134.62 90)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 206.375 133.35 0)
-      (effects (font (size 1.27 1.27) italic) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF" (at 204.47 128.27 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Description" "N-Channel Enhancement Mode Field Effect Transistor" (at 204.47 128.27 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 204.47 128.27 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C400505" (at 204.47 128.27 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd" (at 204.47 128.27 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "BSS138" (at 204.47 128.27 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 204.47 128.27 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0196" (at 204.47 128.27 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 204.47 128.27 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 204.47 128.27 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f35898d1-068f-475d-9da6-45a6ac4b8489))
-    (pin "2" (uuid da7c3c5a-81f9-4b30-891a-967b193590cc))
-    (pin "3" (uuid d288e01d-437f-4f76-882d-cdbb0c9eaf2c))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "Q?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "Q304") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 62.23 95.25 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid c94e4c51-69a4-4358-86be-23140a160b53)
-    (property "Reference" "TP404" (at 62.23 88.9 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "SS" (at 63.5 91.44 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 67.31 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 67.31 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 62.23 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 62.23 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 62.23 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 62.23 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 62.23 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 62.23 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 62.23 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 62.23 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 62.23 95.25 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 459adfd1-63a4-492d-8111-840d1521bf9a))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP404") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP107") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "TP305") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 210.82 44.45 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid caa8231d-f117-46fb-b263-12f89d97874d)
-    (property "Reference" "R?" (at 208.28 40.64 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 207.01 45.72 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 209.042 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 210.82 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 210.82 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 210.82 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 210.82 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 210.82 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 210.82 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 210.82 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 210.82 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 210.82 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 210.82 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 15fb0a73-fd3a-4e33-a905-4869488c7df8))
-    (pin "2" (uuid 0b63a367-299c-4e96-a3dc-f5bbb3f7a892))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R321") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 238.76 44.45 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid d8791e85-46b7-4be5-b7bb-60b32684911e)
-    (property "Reference" "R?" (at 236.22 40.64 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 234.95 45.72 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 236.982 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 238.76 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 238.76 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 238.76 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 238.76 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 238.76 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 238.76 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 238.76 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 238.76 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 238.76 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 238.76 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d256676a-0bfd-4199-9600-3c2443db0236))
-    (pin "2" (uuid ff42c371-2885-439c-af7c-01e58c7556fc))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R324") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 229.87 55.88 90) (mirror x) (unit 1)
-    (in_bom no) (on_board yes) (dnp no)
-    (uuid daa40512-8008-48fe-949a-13231cda87dc)
-    (property "Reference" "R?" (at 233.68 53.34 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 229.87 58.42 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 229.87 54.102 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 229.87 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 229.87 55.88 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 229.87 55.88 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 229.87 55.88 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 229.87 55.88 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 229.87 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 229.87 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 229.87 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 229.87 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 229.87 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bd6f0909-441b-474d-bb52-ccd38f510554))
-    (pin "2" (uuid 35f5990e-7a06-481c-9b51-fae038181580))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R323") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 205.74 35.56 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid dc1c087d-ad7b-4812-ade8-61b9da2847ae)
-    (property "Reference" "#PWR0108" (at 205.74 41.91 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 205.74 40.64 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 205.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 205.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5b2f03fb-220b-4d4c-82d2-ce83013a0626))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "#PWR0305") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 161.29 44.45 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid e5d5d818-5174-4a52-b94b-f13ac2536016)
-    (property "Reference" "R?" (at 158.75 40.64 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 157.48 45.72 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 159.512 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 161.29 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 161.29 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 161.29 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 161.29 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 161.29 44.45 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 161.29 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 161.29 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 161.29 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 161.29 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 161.29 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 898d34e7-e395-4016-90ba-b074c8fb0e38))
-    (pin "2" (uuid 875b4cd3-72e5-441d-bf75-4f3a27a689a5))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R318") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 124.46 137.16 90) (mirror x) (unit 1)
-    (in_bom no) (on_board yes) (dnp no)
-    (uuid ec4c867a-4ea3-4451-b568-403661971f15)
-    (property "Reference" "R?" (at 128.27 134.62 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "DNI" (at 124.46 139.7 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 124.46 135.382 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 124.46 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 124.46 137.16 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 124.46 137.16 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 124.46 137.16 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 124.46 137.16 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 124.46 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 124.46 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 124.46 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 124.46 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 124.46 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a3f3292d-8b81-4915-8288-703fcdc1e5b8))
-    (pin "2" (uuid abc00f6a-5bd1-4d18-bd13-25abb90348ef))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "R?") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
-          (reference "R314") (unit 1)
-        )
-      )
-    )
-  )
+(kicad_sch
+	(version 20251012)
+	(generator "eeschema")
+	(generator_version "9.99")
+	(uuid "249434d3-348d-41c5-9fd4-a9406a7b7520")
+	(paper "A4")
+	(title_block
+		(title "KRAKE_PCB")
+		(date "2025-07-18")
+		(rev "2.0")
+		(company "PublicInvention")
+		(comment 1 "GNU Affero General Public License v3.0")
+		(comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
+		(comment 3 "https://github.com/PubInv/krake")
+		(comment 4 "Inherited from the GPAD")
+	)
+	(lib_symbols
+		(symbol "Connector:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 5.08 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 5.08 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:Polyfuse_Small"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "F"
+				(at -1.905 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Polyfuse_Small"
+				(at 1.905 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 1.27 -5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resettable fuse, polymeric positive temperature coefficient, small symbol"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "resettable fuse PTC PPTC polyfuse polyswitch"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "*polyfuse* *PTC*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "Polyfuse_Small_0_1"
+				(polyline
+					(pts
+						(xy -1.016 1.27) (xy -1.016 0.762) (xy 1.016 -0.762) (xy 1.016 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -0.508 1.27)
+					(end 0.508 -1.27)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0 -2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "Polyfuse_Small_1_1"
+				(pin passive line
+					(at 0 2.54 270)
+					(length 0.635)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -2.54 90)
+					(length 0.635)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Diode:BAT54S"
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "D"
+				(at 2.54 -5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "BAT54S"
+				(at -6.35 3.175 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+				(at 1.905 3.175 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds11005.pdf"
+				(at -3.048 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Vr 30V, If 200mA, Dual schottky barrier diode, in series, SOT-323"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "schottky diode"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "SOT?23*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "BAT54S_0_1"
+				(polyline
+					(pts
+						(xy -4.445 1.27) (xy -4.445 -1.27) (xy -2.54 0) (xy -4.445 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.81 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.175 -1.27) (xy -3.175 -1.016)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.54 1.27) (xy -1.905 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.54 -1.27) (xy -3.175 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.54 -1.27) (xy -2.54 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.905 1.27) (xy -1.905 1.016)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.905 0) (xy 1.905 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 0)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy 3.81 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.905 1.27) (xy 1.905 -1.27) (xy 3.81 0) (xy 1.905 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.175 -1.27) (xy 3.175 -1.016)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.81 1.27) (xy 4.445 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.81 -1.27) (xy 3.175 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.81 -1.27) (xy 3.81 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 4.445 1.27) (xy 4.445 1.016)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "BAT54S_1_1"
+				(pin passive line
+					(at -7.62 0 0)
+					(length 3.81)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 7.62 0 180)
+					(length 3.81)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -5.08 90)
+					(length 5.08)
+					(name "COM"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GND_1"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND_1"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_1_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:RJ12_6P6C_HORZ"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "J401"
+				(at 1.4478 16.6878 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "RJ12_6P6C_HORZ"
+				(at 1.4478 14.3764 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "GeneralPurposeAlarmDevicePCB:RJ12_Amphenol_54601"
+				(at 0 0.635 90)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811141146_TE-Connectivity-5555165-1_C305981.pdf"
+				(at 0 0.635 90)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "RJ connector, 6P6C (6 positions 6 connected), RJ12/RJ18/RJ25"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1 PN" "C305981"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 1" "JLCPCB"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 2" "Digikey"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Distributor 2 PN" "A31422-ND"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer" "TE Connectivity"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Assembly Type" ""
+				(at 1.4478 12.065 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN" "5555165-1"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "AssemblyType" "HAND"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Cost" "0.8901"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "MPN 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Manufacturer 2" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "6P6C RJ female connector"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "6P6C* RJ12* RJ18* RJ25*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "RJ12_6P6C_HORZ_0_1"
+				(polyline
+					(pts
+						(xy -6.35 3.175) (xy -5.08 3.175) (xy -5.08 3.175)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -6.35 1.905) (xy -5.08 1.905) (xy -5.08 1.905)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -6.35 0.635) (xy -5.08 0.635) (xy -5.08 0.635)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -6.35 -0.635) (xy -5.08 -0.635) (xy -5.08 -0.635)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -6.35 -1.905) (xy -5.08 -1.905) (xy -5.08 -1.905)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -6.35 -4.445) (xy -6.35 6.985) (xy 3.81 6.985) (xy 3.81 4.445) (xy 5.08 4.445) (xy 5.08 3.175)
+						(xy 6.35 3.175) (xy 6.35 -0.635) (xy 5.08 -0.635) (xy 5.08 -1.905) (xy 3.81 -1.905) (xy 3.81 -4.445)
+						(xy -6.35 -4.445) (xy -6.35 -4.445)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -5.08 4.445) (xy -6.35 4.445) (xy -6.35 4.445)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 7.62 10.16)
+					(end -7.62 -7.62)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+			)
+			(symbol "RJ12_6P6C_HORZ_1_1"
+				(pin passive line
+					(at 10.16 -5.08 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 10.16 -2.54 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 10.16 0 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 10.16 2.54 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 10.16 5.08 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 10.16 7.62 180)
+					(length 2.54)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Transistor_FET:BSS138"
+			(pin_names
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "Q"
+				(at 5.08 1.905 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "BSS138"
+				(at 5.08 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+				(at 5.08 -1.905 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Description" "50V Vds, 0.22A Id, N-Channel MOSFET, SOT-23"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "N-Channel MOSFET"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "SOT?23*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "BSS138_0_1"
+				(polyline
+					(pts
+						(xy 0.254 1.905) (xy 0.254 -1.905)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.254 0) (xy -2.54 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 2.286) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 0.508) (xy 0.762 -0.508)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 -1.27) (xy 0.762 -2.286)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 -1.778) (xy 3.302 -1.778) (xy 3.302 1.778) (xy 0.762 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.016 0) (xy 2.032 0.381) (xy 2.032 -0.381) (xy 1.016 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(circle
+					(center 1.651 0)
+					(radius 2.794)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 2.54) (xy 2.54 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.54 1.778)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(circle
+					(center 2.54 -1.778)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 -2.54) (xy 2.54 0) (xy 0.762 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.794 0.508) (xy 2.921 0.381) (xy 3.683 0.381) (xy 3.81 0.254)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.302 0.381) (xy 2.921 -0.254) (xy 3.683 -0.254) (xy 3.302 0.381)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "BSS138_1_1"
+				(pin input line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "G"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 -5.08 90)
+					(length 2.54)
+					(name "S"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 5.08 270)
+					(length 2.54)
+					(name "D"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(text "3v3 to 5v level shifter"
+		(exclude_from_sim no)
+		(at 127 60.325 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "12b2a282-9cd5-4832-98ba-b901bbad1863")
+	)
+	(text "At this interface we have a 5v logic levels."
+		(exclude_from_sim no)
+		(at 18.415 69.215 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "38560f87-51b3-4528-9e8c-2da63dc3e29f")
+	)
+	(text "Place near Clamp Diodes"
+		(exclude_from_sim no)
+		(at 188.595 25.4 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "546a7984-5e79-427f-9756-9f76db0b11d8")
+	)
+	(text "  5v to 3v3level shifter"
+		(exclude_from_sim no)
+		(at 179.705 142.24 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "6a5cd73f-ce79-41c7-891a-15c33489c889")
+	)
+	(text "  5v to 3v3level shifter"
+		(exclude_from_sim no)
+		(at 97.79 141.605 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d75a281f-36da-44b4-823e-2df5f5ae9da7")
+	)
+	(text "SPI Peripherial Interface"
+		(exclude_from_sim no)
+		(at 18.415 23.495 0)
+		(effects
+			(font
+				(size 2.54 2.54)
+			)
+			(justify left bottom)
+		)
+		(uuid "de7d0d01-1029-4296-b896-1a7caeed1b3f")
+	)
+	(text "these are 3v3 logic levels"
+		(exclude_from_sim no)
+		(at 238.76 25.4 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f1a433a9-e07b-464a-8438-20bbb5282b82")
+	)
+	(text "ESD protection circuit"
+		(exclude_from_sim no)
+		(at 177.165 41.275 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f7b0b2e9-e9ae-4b7e-aaa7-4be254bfd97c")
+	)
+	(text "  5v to 3v3level shifter"
+		(exclude_from_sim no)
+		(at 201.295 60.325 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f9c8b035-20b3-4f99-ae30-2e7a3e805e64")
+	)
+	(junction
+		(at 210.82 27.94)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "07367cbb-64c5-428f-9384-a182fc8f884a")
+	)
+	(junction
+		(at 130.81 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0962d6ab-0d3b-44c4-86ad-50dcc4c67b8a")
+	)
+	(junction
+		(at 215.9 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1b8b1aca-cce7-49a6-bdb1-c7fb3e53ab99")
+	)
+	(junction
+		(at 156.21 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1e7ce0f5-f546-4557-85ad-416568c68d9f")
+	)
+	(junction
+		(at 128.27 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "244b25f0-d8e8-4ea4-b5f0-e1fd494074a2")
+	)
+	(junction
+		(at 210.82 130.81)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "24d4dd1f-6aeb-4ca2-85d7-435258ed6108")
+	)
+	(junction
+		(at 233.68 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "24e53566-9a0e-4a21-a141-419615162207")
+	)
+	(junction
+		(at 215.9 115.57)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3557e5f2-d7a3-4877-8cf3-7beb2e97388d")
+	)
+	(junction
+		(at 143.51 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "376fca63-1d9a-4d8f-8385-185bcdadba29")
+	)
+	(junction
+		(at 161.29 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "37da3952-9e99-4792-8c63-c43db56ce7a9")
+	)
+	(junction
+		(at 140.97 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "44ec5b95-688c-4605-965a-287d975346e1")
+	)
+	(junction
+		(at 238.76 33.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "47f20896-cd39-4991-b1f0-f323671e669e")
+	)
+	(junction
+		(at 236.22 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "520bf5f8-1242-439e-8255-12536b5b95a4")
+	)
+	(junction
+		(at 107.95 87.63)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5b9e8d5f-231b-41e4-bb11-c9be5efdd5e3")
+	)
+	(junction
+		(at 86.36 96.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5e1e56b7-4b55-4b49-9bf8-23bb3f4c6448")
+	)
+	(junction
+		(at 161.29 33.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6da1a61c-a9b3-4487-bf13-de5f6faab3ef")
+	)
+	(junction
+		(at 168.91 87.63)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7d0cc1ec-b80b-46c2-95df-bc99a26bb7dc")
+	)
+	(junction
+		(at 191.77 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "99087240-2dc4-4738-b333-d7e65dccd934")
+	)
+	(junction
+		(at 115.57 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9a02720f-64a1-46f3-9a6f-c03872d4ba48")
+	)
+	(junction
+		(at 220.98 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9be1741b-cd78-44c2-96a0-851b6b04cf63")
+	)
+	(junction
+		(at 130.81 78.74)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a4c6ae4c-2231-482e-89e8-eae3108db765")
+	)
+	(junction
+		(at 111.76 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a7483703-f70f-47a2-ae3c-781cff8b2d44")
+	)
+	(junction
+		(at 133.35 114.3)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ab761f86-2405-47c9-903d-dd8e562c6cf4")
+	)
+	(junction
+		(at 93.98 76.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b7010b8f-b42a-4eb5-a399-290c65c3b5d7")
+	)
+	(junction
+		(at 198.12 130.81)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c692ddd6-360d-4000-803a-00aad39a24bd")
+	)
+	(junction
+		(at 62.23 96.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5c14f31-6a6a-4d89-93de-3977d9694928")
+	)
+	(junction
+		(at 116.84 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d890d725-9cf2-42be-9087-7797ee1e3632")
+	)
+	(junction
+		(at 194.31 130.81)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dfd35729-0c5d-4f1d-973d-f6de558ef96e")
+	)
+	(junction
+		(at 76.2 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dfebb91e-5501-493f-a784-3052adebec2b")
+	)
+	(junction
+		(at 231.14 26.67)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e063b820-08aa-46b2-bc5e-02e5ce6f41b4")
+	)
+	(junction
+		(at 213.36 130.81)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ed9b61b0-3b3d-4837-863b-34d45d05996f")
+	)
+	(wire
+		(pts
+			(xy 133.35 121.92) (xy 133.35 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0130001d-23a6-45bd-8f39-de4ca45d597f")
+	)
+	(wire
+		(pts
+			(xy 130.81 129.54) (xy 133.35 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "046edc5e-62d7-4286-ad82-72ec2f2c4347")
+	)
+	(wire
+		(pts
+			(xy 93.98 76.2) (xy 102.87 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "061dee90-28db-4012-92a8-8a4758191156")
+	)
+	(wire
+		(pts
+			(xy 168.91 87.63) (xy 168.91 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "091765f4-56cb-4f16-9cc4-06982639d9b3")
+	)
+	(wire
+		(pts
+			(xy 161.29 40.64) (xy 161.29 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "09654536-5305-4204-bfcb-a3e0ac6e4317")
+	)
+	(wire
+		(pts
+			(xy 233.68 48.26) (xy 236.22 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0a808448-ae7b-4052-a652-1bb511525737")
+	)
+	(wire
+		(pts
+			(xy 124.46 48.26) (xy 125.73 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0ae94ce8-182b-41f8-abaf-bf1e33e67158")
+	)
+	(wire
+		(pts
+			(xy 85.09 60.96) (xy 76.2 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0afb22ef-bfc1-4022-876e-1fd643f4e07d")
+	)
+	(wire
+		(pts
+			(xy 62.23 96.52) (xy 74.93 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0c510a1d-ba6f-45fc-a21a-53ebe8e03ec9")
+	)
+	(wire
+		(pts
+			(xy 44.45 78.74) (xy 130.81 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0d49ac6c-d56e-414f-992f-830b2196bf4e")
+	)
+	(wire
+		(pts
+			(xy 215.9 48.26) (xy 215.9 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0d96b626-6297-4b6d-8d2f-f79cbf2e58b6")
+	)
+	(wire
+		(pts
+			(xy 138.43 33.02) (xy 138.43 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0d9eb85c-0868-40d7-84ae-91a0a6a533e8")
+	)
+	(wire
+		(pts
+			(xy 231.14 26.67) (xy 210.82 26.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0e4339da-cbcf-4f84-a52f-730383596728")
+	)
+	(wire
+		(pts
+			(xy 199.39 130.81) (xy 198.12 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0fcf08af-d372-4a11-94e9-e9e1608851eb")
+	)
+	(wire
+		(pts
+			(xy 148.59 33.02) (xy 148.59 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "101e0a56-dd76-40c4-9547-6498e60601e0")
+	)
+	(wire
+		(pts
+			(xy 100.33 87.63) (xy 100.33 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "13235fce-e0ee-486b-a9e4-6b3c0b3e8441")
+	)
+	(wire
+		(pts
+			(xy 191.77 72.39) (xy 215.9 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "14f1bb75-58e3-4726-b25e-01dcd66ff0de")
+	)
+	(wire
+		(pts
+			(xy 128.27 137.16) (xy 128.27 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1a77e59c-b05b-458b-a618-aa43976e7bae")
+	)
+	(wire
+		(pts
+			(xy 232.41 48.26) (xy 233.68 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1a85c645-0952-4a79-8bf8-f80444e82461")
+	)
+	(wire
+		(pts
+			(xy 153.67 72.39) (xy 191.77 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1d729098-6566-4064-b092-11d233dc8e66")
+	)
+	(wire
+		(pts
+			(xy 226.06 33.02) (xy 226.06 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2349880a-19c2-47de-8a2c-c0ed38df7bfe")
+	)
+	(wire
+		(pts
+			(xy 203.2 138.43) (xy 198.12 138.43)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2424bf34-6d8e-410f-b4f7-0c445f9abe84")
+	)
+	(wire
+		(pts
+			(xy 168.91 63.5) (xy 168.91 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a61a554-4480-4211-8b4d-2e197aba419a")
+	)
+	(wire
+		(pts
+			(xy 130.81 129.54) (xy 130.81 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2aa6ff75-01ca-40b8-a4b1-20b8c81b6f59")
+	)
+	(wire
+		(pts
+			(xy 140.97 48.26) (xy 143.51 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2e2e5ff7-b464-4490-aea8-7f55a7cfd296")
+	)
+	(wire
+		(pts
+			(xy 181.61 49.53) (xy 184.15 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2e4e10e9-4ce9-4352-919b-a13b8737b511")
+	)
+	(wire
+		(pts
+			(xy 226.06 40.64) (xy 227.33 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3069727e-80a5-4fd5-864e-2701ce4a8967")
+	)
+	(wire
+		(pts
+			(xy 233.68 55.88) (xy 233.68 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "30df3ef7-8d7b-437e-b5e2-e7ecce793d5a")
+	)
+	(wire
+		(pts
+			(xy 111.76 96.52) (xy 111.76 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "330d4f58-f463-444d-8d90-5ad3c06abded")
+	)
+	(wire
+		(pts
+			(xy 92.71 60.96) (xy 116.84 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "354c3978-957d-4192-981a-22f4392f717d")
+	)
+	(wire
+		(pts
+			(xy 231.14 21.59) (xy 231.14 26.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "38073b2e-80e4-4050-8e8c-d1ee16a5233c")
+	)
+	(wire
+		(pts
+			(xy 110.49 67.31) (xy 102.87 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3915bb7e-d350-4a71-9d3d-3f8ed80bc61c")
+	)
+	(wire
+		(pts
+			(xy 116.84 60.96) (xy 140.97 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3df81617-ce3c-4f36-9e35-e47acdc18bff")
+	)
+	(wire
+		(pts
+			(xy 236.22 55.88) (xy 245.11 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f70f9a4-8fc5-4ba7-a880-4050d5a8e5da")
+	)
+	(wire
+		(pts
+			(xy 76.2 124.46) (xy 78.74 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "42d7c879-a174-4b79-8cdc-dc7ee7cdb558")
+	)
+	(wire
+		(pts
+			(xy 236.22 55.88) (xy 236.22 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4441d282-ce0c-48a1-9485-da166f516015")
+	)
+	(wire
+		(pts
+			(xy 161.29 33.02) (xy 148.59 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "462f950b-8974-4b0f-b093-ea6646437d2d")
+	)
+	(wire
+		(pts
+			(xy 86.36 96.52) (xy 82.55 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4cf24c2e-e4da-44b9-b677-ff9cdcc7805c")
+	)
+	(wire
+		(pts
+			(xy 128.27 129.54) (xy 130.81 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e0fd08d-6d74-4c07-9967-2cd0e6dcb8ac")
+	)
+	(wire
+		(pts
+			(xy 238.76 33.02) (xy 226.06 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4f7fe4f1-9d43-4dbc-9df0-eb5b7ba01a72")
+	)
+	(wire
+		(pts
+			(xy 44.45 96.52) (xy 62.23 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "510d5b46-6350-49c9-a4ed-8a7b182b8acc")
+	)
+	(wire
+		(pts
+			(xy 130.81 78.74) (xy 139.7 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5355e7c0-4d6f-4341-83f9-33e7cc0ffc05")
+	)
+	(wire
+		(pts
+			(xy 116.84 53.34) (xy 116.84 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5994a3a7-f132-4c28-9d96-0e7d6d87781c")
+	)
+	(wire
+		(pts
+			(xy 143.51 48.26) (xy 144.78 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b605db0-55ae-438e-9d4e-1bf60b46e126")
+	)
+	(wire
+		(pts
+			(xy 215.9 48.26) (xy 220.98 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5c039127-6103-4b30-8621-43240a2da17f")
+	)
+	(wire
+		(pts
+			(xy 44.45 86.36) (xy 44.45 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5e64a0c5-b9ba-4ffd-a75d-7c4442ce0eb3")
+	)
+	(wire
+		(pts
+			(xy 139.7 72.39) (xy 146.05 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5eeb645d-53bf-472e-8df4-b3cde95a6972")
+	)
+	(wire
+		(pts
+			(xy 226.06 55.88) (xy 220.98 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60c71762-ee91-435d-8fa7-cf1d4176b2c9")
+	)
+	(wire
+		(pts
+			(xy 100.33 83.82) (xy 44.45 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "645319d2-9417-4abe-a097-3b25e34bdea2")
+	)
+	(wire
+		(pts
+			(xy 44.45 73.66) (xy 64.77 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "64f77451-ff0a-49eb-9f98-acc8eede7d03")
+	)
+	(wire
+		(pts
+			(xy 222.25 48.26) (xy 220.98 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "67ed233e-18d0-4d07-9806-37659684a78d")
+	)
+	(wire
+		(pts
+			(xy 115.57 67.31) (xy 245.11 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6cc7c3a3-6835-4166-8574-3411c288aa28")
+	)
+	(wire
+		(pts
+			(xy 100.33 87.63) (xy 107.95 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6e41b6aa-e59c-4ce6-9299-a2fe24ba7ef7")
+	)
+	(wire
+		(pts
+			(xy 215.9 123.19) (xy 215.9 115.57)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7196b78c-b2eb-4a51-90bc-ece424f2d760")
+	)
+	(wire
+		(pts
+			(xy 86.36 96.52) (xy 86.36 119.38)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "730a9f0a-7f56-4555-b1c9-52441e13419d")
+	)
+	(wire
+		(pts
+			(xy 102.87 67.31) (xy 102.87 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "74373168-84e2-46bd-bc19-8000b17142be")
+	)
+	(wire
+		(pts
+			(xy 238.76 40.64) (xy 238.76 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "74460a26-72ea-4959-838e-9a628ee855dd")
+	)
+	(wire
+		(pts
+			(xy 194.31 130.81) (xy 198.12 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "74d005b6-f9bf-4e9a-b38f-73f1b443a166")
+	)
+	(wire
+		(pts
+			(xy 238.76 33.02) (xy 245.11 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7780fb2a-f732-4deb-8d11-3ea1bb49aba4")
+	)
+	(wire
+		(pts
+			(xy 168.91 48.26) (xy 161.29 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "789ec5fa-be78-45ce-9352-f48923f70453")
+	)
+	(wire
+		(pts
+			(xy 148.59 40.64) (xy 149.86 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "78b4ba0b-7190-4622-aae9-409539efccd4")
+	)
+	(wire
+		(pts
+			(xy 210.82 26.67) (xy 210.82 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7cfd1a86-6e29-4458-b926-6e1f3eede7cf")
+	)
+	(wire
+		(pts
+			(xy 203.2 115.57) (xy 203.2 123.19)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7f078d92-a5c4-4ccf-9145-968d7597c99e")
+	)
+	(wire
+		(pts
+			(xy 143.51 55.88) (xy 143.51 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8229b4fd-c235-48d2-8c1f-f489a253162d")
+	)
+	(wire
+		(pts
+			(xy 187.96 129.54) (xy 187.96 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "83b5cf1f-949d-48d4-886b-11c5dbbe54df")
+	)
+	(wire
+		(pts
+			(xy 106.68 48.26) (xy 109.22 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "842b3d7a-0549-41cb-b888-5312221d99b5")
+	)
+	(wire
+		(pts
+			(xy 121.92 114.3) (xy 121.92 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "84eda99b-bb4d-4bff-a892-2dcc13b1b08c")
+	)
+	(wire
+		(pts
+			(xy 76.2 60.96) (xy 64.77 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "86b51052-5345-40d0-b0cd-687df88317db")
+	)
+	(wire
+		(pts
+			(xy 215.9 115.57) (xy 222.25 115.57)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8c76a18f-f624-443a-9270-ba9c455c967d")
+	)
+	(wire
+		(pts
+			(xy 115.57 137.16) (xy 115.57 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8ce0bf86-9e54-455a-a5a2-ccb74903376c")
+	)
+	(wire
+		(pts
+			(xy 86.36 96.52) (xy 111.76 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91c42464-6fe6-40d7-958f-c4aeefec07f7")
+	)
+	(wire
+		(pts
+			(xy 210.82 48.26) (xy 215.9 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "932d962e-a13c-42f8-88a7-937c3ef5636e")
+	)
+	(wire
+		(pts
+			(xy 209.55 130.81) (xy 210.82 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "93b66cf0-c30d-4dab-b4c0-8ea64f453c1e")
+	)
+	(wire
+		(pts
+			(xy 215.9 115.57) (xy 203.2 115.57)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "99e47af5-5138-45de-83b9-c19ba6a1ef5c")
+	)
+	(wire
+		(pts
+			(xy 64.77 60.96) (xy 64.77 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9b48e4b0-a717-4e6e-a42c-b131feadf849")
+	)
+	(wire
+		(pts
+			(xy 158.75 127) (xy 161.29 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c976b3b-058c-4363-91e9-aadcc16568dd")
+	)
+	(wire
+		(pts
+			(xy 203.2 123.19) (xy 204.47 123.19)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d89a70b-8af7-444e-971c-ea7308aa1221")
+	)
+	(wire
+		(pts
+			(xy 76.2 57.15) (xy 76.2 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9e6f819b-c71b-4447-a9c8-6da02b173183")
+	)
+	(wire
+		(pts
+			(xy 187.96 130.81) (xy 194.31 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9f80230c-c25d-4587-8475-792076e9e8ef")
+	)
+	(wire
+		(pts
+			(xy 44.45 81.28) (xy 53.34 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a4f2adc0-e4b3-4ec4-affd-76cb3182a1ff")
+	)
+	(wire
+		(pts
+			(xy 161.29 33.02) (xy 166.37 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a52c4e18-bcf0-4fad-9e56-87c58d9af55b")
+	)
+	(wire
+		(pts
+			(xy 107.95 87.63) (xy 119.38 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a6bc22a4-29e5-4757-a2fc-eca355fa7f0f")
+	)
+	(wire
+		(pts
+			(xy 213.36 130.81) (xy 215.9 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a889520c-05e8-405d-b121-e49ef45cd1bd")
+	)
+	(wire
+		(pts
+			(xy 106.68 114.3) (xy 106.68 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab9cac80-ffb3-4240-bbee-40a27dde644f")
+	)
+	(wire
+		(pts
+			(xy 205.74 27.94) (xy 210.82 27.94)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b0ee56e2-3fdd-4f84-b7e9-056b77c7392a")
+	)
+	(wire
+		(pts
+			(xy 93.98 124.46) (xy 95.25 124.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b192457b-4d9f-4310-bcd9-90d3e23a22d5")
+	)
+	(wire
+		(pts
+			(xy 168.91 63.5) (xy 245.11 63.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7717cc9-a46c-4051-8479-b85e0e3e844b")
+	)
+	(wire
+		(pts
+			(xy 62.23 95.25) (xy 62.23 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b8ebebc7-2ef0-4431-8110-3ccca5aa4846")
+	)
+	(wire
+		(pts
+			(xy 148.59 55.88) (xy 143.51 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b90d6df6-f354-4004-9d70-39383a7bbbe3")
+	)
+	(wire
+		(pts
+			(xy 130.81 96.52) (xy 245.11 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba30920f-1d8e-418b-8cc4-7d6267ef431e")
+	)
+	(wire
+		(pts
+			(xy 138.43 46.99) (xy 138.43 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bdcaeb74-4d33-488f-a278-e4be854e5212")
+	)
+	(wire
+		(pts
+			(xy 194.31 87.63) (xy 194.31 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "be09e264-8dfe-4b16-b7fc-d573ef0d5745")
+	)
+	(wire
+		(pts
+			(xy 111.76 129.54) (xy 115.57 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bfb3cd7b-61d2-4216-8006-d5115ca6758a")
+	)
+	(wire
+		(pts
+			(xy 106.68 129.54) (xy 111.76 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bff88e6a-85c0-48da-8de8-18456beb534b")
+	)
+	(wire
+		(pts
+			(xy 116.84 129.54) (xy 115.57 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c5c17c67-01f2-4a40-892b-efa3c938b87f")
+	)
+	(wire
+		(pts
+			(xy 245.11 26.67) (xy 231.14 26.67)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c956ec99-78c0-4563-a8ee-28a7c6c6447a")
+	)
+	(wire
+		(pts
+			(xy 133.35 114.3) (xy 139.7 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cd376e5c-2f9d-4712-8eb7-cbd173e08903")
+	)
+	(wire
+		(pts
+			(xy 199.39 49.53) (xy 200.66 49.53)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cf1fa8c8-c53c-4044-a2b2-43dd827e0261")
+	)
+	(wire
+		(pts
+			(xy 187.96 115.57) (xy 187.96 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d27b7943-268a-4276-9112-26e1cd1f3863")
+	)
+	(wire
+		(pts
+			(xy 133.35 114.3) (xy 121.92 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d382c20c-86e3-4207-be07-d1c7e5d7e572")
+	)
+	(wire
+		(pts
+			(xy 213.36 87.63) (xy 245.11 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d3e7f981-9b0d-47d7-8a95-59de16876d90")
+	)
+	(wire
+		(pts
+			(xy 220.98 55.88) (xy 220.98 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d5336e82-039e-4281-bcb2-6c592970c7cb")
+	)
+	(wire
+		(pts
+			(xy 140.97 60.96) (xy 140.97 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d57c8aff-7b6e-45a2-a307-55f706ce909d")
+	)
+	(wire
+		(pts
+			(xy 139.7 72.39) (xy 139.7 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "daa4181e-ea46-4f04-9373-a1f28ed37d46")
+	)
+	(wire
+		(pts
+			(xy 210.82 130.81) (xy 213.36 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dbb10e53-7bc1-4781-ac6d-49172080848b")
+	)
+	(wire
+		(pts
+			(xy 210.82 138.43) (xy 210.82 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dc17a375-0e85-4aee-95ca-28107b38ac13")
+	)
+	(wire
+		(pts
+			(xy 176.53 127) (xy 177.8 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de479f7b-edf6-42cb-8092-b42a18315c8a")
+	)
+	(wire
+		(pts
+			(xy 154.94 48.26) (xy 156.21 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "decd049c-807b-42da-84ff-d9fb98012057")
+	)
+	(wire
+		(pts
+			(xy 210.82 27.94) (xy 210.82 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e1193f6d-cabb-43a4-8ebf-08740839d8ac")
+	)
+	(wire
+		(pts
+			(xy 236.22 48.26) (xy 238.76 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e2588106-fde2-40c8-b62c-ff6fbab4bd87")
+	)
+	(wire
+		(pts
+			(xy 168.91 87.63) (xy 194.31 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ec602115-019e-46b0-859f-5f957fa755b3")
+	)
+	(wire
+		(pts
+			(xy 156.21 55.88) (xy 156.21 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ec947fa6-547c-4d21-be64-dfe733c26842")
+	)
+	(wire
+		(pts
+			(xy 156.21 48.26) (xy 161.29 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f1efce15-0142-4297-9b32-855d5b821bd7")
+	)
+	(wire
+		(pts
+			(xy 127 129.54) (xy 128.27 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f222186c-6812-47d4-8b9d-75c1546aba8b")
+	)
+	(wire
+		(pts
+			(xy 213.36 87.63) (xy 213.36 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f23937e9-ace7-4433-8992-bd2ccccc62c0")
+	)
+	(wire
+		(pts
+			(xy 191.77 54.61) (xy 191.77 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f555e9f3-5708-467a-8829-6da9f4f5622a")
+	)
+	(wire
+		(pts
+			(xy 127 87.63) (xy 168.91 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f7cd4cf9-0d64-4743-8b52-a76aa3b5572c")
+	)
+	(wire
+		(pts
+			(xy 140.97 48.26) (xy 138.43 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f89539be-c211-4c63-b9c4-babba974f911")
+	)
+	(wire
+		(pts
+			(xy 198.12 138.43) (xy 198.12 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f8a43f4a-30df-416f-b0ed-b28b0d050f60")
+	)
+	(wire
+		(pts
+			(xy 120.65 137.16) (xy 115.57 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f8cbfcf6-383e-4b9d-99b8-6867b8f5bd96")
+	)
+	(wire
+		(pts
+			(xy 44.45 76.2) (xy 93.98 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fc2efe0e-8c51-422d-8c79-fa2919156400")
+	)
+	(image
+		(at 248.92 179.07)
+		(scale 0.2225)
+		(uuid "9c26c501-ef3b-49d9-bdd3-e368e1e72b08")
+		(data "iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz"
+			"AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h"
+			"aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73"
+			"+/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA"
+			"xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y"
+			"Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h"
+			"xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO"
+			"GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful"
+			"fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv"
+			"4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ"
+			"EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R"
+			"Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM"
+			"vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H"
+			"cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0"
+			"6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT"
+			"O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA"
+			"4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86"
+			"sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+"
+			"oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/"
+			"55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0"
+			"qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+"
+			"KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn"
+			"Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4"
+			"mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii"
+			"P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr"
+			"voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6"
+			"bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO"
+			"h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da"
+			"4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y"
+			"YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC"
+			"0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP"
+			"SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb"
+			"WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw"
+			"v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay"
+			"PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX"
+			"Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh"
+			"oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD"
+			"7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da"
+			"43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l"
+			"zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl"
+			"pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS"
+			"H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV"
+			"ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY"
+			"MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2"
+			"NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx"
+			"fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl"
+			"tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew"
+			"iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj"
+			"jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI"
+			"cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo"
+			"XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R"
+			"9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv"
+			"8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV"
+			"RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY"
+			"l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf"
+			"YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN"
+			"EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU"
+			"sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z"
+			"7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs"
+			"OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs"
+			"qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7"
+			"G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6"
+			"wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7"
+			"zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln"
+			"Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX"
+			"apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk"
+			"lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw"
+			"TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb"
+			"54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID"
+			"qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd"
+			"P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l"
+			"UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD"
+			"zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH"
+			"Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1"
+			"QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/"
+			"ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX"
+			"08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC"
+			"KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ"
+			"SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu"
+			"h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp"
+			"VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf"
+			"G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK"
+			"dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO"
+			"uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2"
+			"DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn"
+			"byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc"
+			"dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N"
+			"iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP"
+			"NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4"
+			"wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8"
+			"K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s"
+			"xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS"
+			"Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC"
+			"Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5"
+			"m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm"
+			"aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj"
+			"gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn"
+			"p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL"
+			"ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx"
+			"u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+"
+			"FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa"
+			"ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h"
+			"1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj"
+			"DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy"
+			"+Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj"
+			"wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj"
+			"7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ"
+			"lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN"
+			"2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY"
+			"CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi"
+			"mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E"
+			"uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x"
+			"j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD"
+			"45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO"
+			"4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni"
+			"buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY"
+			"HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH"
+			"NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ"
+			"azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N"
+			"SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP"
+			"hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe"
+			"nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4"
+			"b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN"
+			"xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S"
+			"pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq"
+			"3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB"
+			"Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL"
+			"4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw"
+			"qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX"
+			"9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n"
+			"frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/"
+			"eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK"
+			"TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u"
+			"RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9"
+			"DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j"
+			"2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx"
+			"BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy"
+			"91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7"
+			"jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw"
+			"pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ"
+			"cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M"
+			"xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23"
+			"7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8"
+			"D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw"
+			"YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu"
+			"QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs"
+			"uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA"
+			"PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6"
+			"yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN"
+			"xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq"
+			"JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT"
+			"+HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg"
+			"hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K"
+			"hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt"
+			"g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z"
+			"5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf"
+			"u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO"
+			"Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG"
+			"gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK"
+			"hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x"
+			"moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56"
+			"KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp"
+			"ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz"
+			"eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO"
+			"0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA"
+			"BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ"
+			"2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB"
+			"4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF"
+			"6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI"
+			"gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv"
+			"OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt"
+			"8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI"
+			"bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM"
+			"500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4"
+			"CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V"
+			"aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5"
+			"yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF"
+			"zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss"
+			"tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q"
+			"r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj"
+			"xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h"
+			"6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y"
+			"9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE"
+			"XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh"
+			"oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk"
+			"Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4"
+			"ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW"
+			"zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr"
+			"wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV"
+			"BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7"
+			"LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr"
+			"owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX"
+			"hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j"
+			"1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF"
+			"5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw"
+			"a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6"
+			"Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN"
+			"+SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds"
+			"lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ"
+			"i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu"
+			"fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy"
+			"r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28"
+			"dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az"
+			"70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk"
+			"EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL"
+			"p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf"
+			"nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA"
+			"ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c"
+			"q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu"
+			"Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR"
+			"TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53"
+			"en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA"
+			"x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ"
+			"t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+"
+			"R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf"
+			"5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH"
+			"e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG"
+			"po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh"
+			"6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln"
+			"9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU"
+			"xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ"
+			"rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W"
+			"lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb"
+			"afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs"
+			"FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR"
+			"OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC"
+			"P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp"
+			"EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh"
+			"6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK"
+			"GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ"
+			"hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s"
+			"amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+"
+			"fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij"
+			"TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv"
+			"I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf"
+			"kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ"
+			"BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD"
+			"9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn"
+			"jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8"
+			"I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI"
+			"8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs"
+			"Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN"
+			"MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5"
+			"2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU"
+			"2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss"
+			"ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m"
+			"sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq"
+			"LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT"
+			"tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9"
+			"oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p"
+			"zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu"
+			"WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy"
+			"diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX"
+			"ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY"
+			"5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau"
+			"Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7"
+			"oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG"
+			"xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q"
+			"zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik"
+			"sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN"
+			"ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc"
+			"MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E"
+			"YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3"
+			"bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz"
+			"DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC"
+			"TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES"
+			"3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K"
+			"Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd"
+			"b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5"
+			"99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys"
+			"7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa"
+			"Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e"
+			"8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1"
+			"vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK"
+			"VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4"
+			"ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD"
+			"CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4"
+			"qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr"
+			"1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe"
+			"GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK"
+			"yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj"
+			"po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO"
+			"Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF"
+			"tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D"
+			"mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM"
+			"eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN"
+			"veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu"
+			"5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL"
+			"Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t"
+			"rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl"
+			"sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx"
+			"mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG"
+			"PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk"
+			"Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk"
+			"caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO"
+			"jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS"
+			"gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E"
+			"OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+"
+			"p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO"
+			"cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM"
+			"S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc"
+			"vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3"
+			"boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn"
+			"DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD"
+			"90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw"
+			"0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT"
+			"5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI"
+			"7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP"
+			"QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw"
+			"oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E"
+			"mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/"
+			"N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm"
+			"vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC"
+			"+OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp"
+			"gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz"
+			"gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni"
+			"R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3"
+			"j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo"
+			"BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl"
+			"IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4"
+			"jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA"
+			"Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS"
+			"AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz"
+			"6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H"
+			"qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp"
+			"cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa"
+			"M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv"
+			"4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M"
+			"IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD"
+			"Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r"
+			"un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr"
+			"2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/"
+			"kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF"
+			"7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8"
+			"YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk"
+			"zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp"
+			"8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF"
+			"o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt"
+			"Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA"
+			"hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx"
+			"LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk"
+			"iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2"
+			"HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5"
+			"K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo"
+			"XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/"
+			"D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j"
+			"MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c"
+			"O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB"
+			"fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X"
+			"/V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI"
+			"a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe"
+			"L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37"
+			"zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY"
+			"BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg=="
+		)
+	)
+	(label "SS"
+		(at 44.45 87.63 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "45c7ad2d-9639-45aa-8445-ba36d1d37fc9")
+	)
+	(label "MOSI"
+		(at 44.45 83.82 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "55e45be9-9977-4e43-99cb-a71acf12abfc")
+	)
+	(label "+12in"
+		(at 44.45 76.2 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "aa423027-d060-466a-a3cb-db138a49db11")
+	)
+	(label "MISO"
+		(at 44.45 73.66 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "b8cc4456-8c6e-45d1-8ba6-69584c059225")
+	)
+	(label "SCK"
+		(at 44.45 78.74 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "b9236818-f843-4393-b271-dc9c17a725ef")
+	)
+	(hierarchical_label "3V3Raw"
+		(shape input)
+		(at 245.11 33.02 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0739c5c0-ed1b-4f4b-977c-ded8b9ba233f")
+	)
+	(hierarchical_label "5VRaw"
+		(shape input)
+		(at 200.66 49.53 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "0fc66b8b-10cb-4171-842c-2331cba9a8f8")
+	)
+	(hierarchical_label "CIPO"
+		(shape output)
+		(at 245.11 63.5 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "184583a6-8059-421b-be6b-4638d55c1a87")
+	)
+	(hierarchical_label "5VRaw"
+		(shape input)
+		(at 95.25 124.46 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "18a6e06d-0e97-4864-a34e-a076236849b8")
+	)
+	(hierarchical_label "5VRaw"
+		(shape input)
+		(at 125.73 48.26 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2400cb84-7160-4a4d-8e5f-478bea9fbefd")
+	)
+	(hierarchical_label "ControllerVcc"
+		(shape passive)
+		(at 245.11 67.31 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4301347d-d4d6-44d6-badb-a64ab4849e0c")
+	)
+	(hierarchical_label "nCS"
+		(shape input)
+		(at 245.11 96.52 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "44fb4782-ea07-4f12-99c7-94918abd668f")
+	)
+	(hierarchical_label "3V3Raw"
+		(shape input)
+		(at 166.37 33.02 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5db98748-ccf6-4e8b-acad-074ab5d54c33")
+	)
+	(hierarchical_label "5VRaw"
+		(shape input)
+		(at 177.8 127 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6b0c34e4-851c-4db3-aee5-1ce45833dce7")
+	)
+	(hierarchical_label "5VRaw"
+		(shape input)
+		(at 138.43 33.02 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6e3460f9-d2ed-4dbd-8519-251aff90ced8")
+	)
+	(hierarchical_label "SCK"
+		(shape input)
+		(at 245.11 55.88 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "7c92ac38-1389-4375-a961-4ae75e93c487")
+	)
+	(hierarchical_label "5VRaw"
+		(shape input)
+		(at 106.68 114.3 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "80ad984e-36fd-46cb-b82e-afa3e96be9f2")
+	)
+	(hierarchical_label "5VRaw"
+		(shape input)
+		(at 245.11 26.67 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "8a97fbc1-f1c4-4169-a25a-4565b6c62fa3")
+	)
+	(hierarchical_label "3V3Raw"
+		(shape input)
+		(at 139.7 114.3 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "b1f7168e-9348-4548-b5be-ba69f10bc186")
+	)
+	(hierarchical_label "5VRaw"
+		(shape input)
+		(at 187.96 115.57 90)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "baae37bf-aacc-4316-8b7f-a7756d5d22f5")
+	)
+	(hierarchical_label "3V3Raw"
+		(shape input)
+		(at 222.25 115.57 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "dc5a044e-81dd-4ddc-80e8-eff8b3ec702c")
+	)
+	(hierarchical_label "COPI"
+		(shape input)
+		(at 245.11 87.63 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ebff7e57-0b79-4bee-bce2-8fd494ab80aa")
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 88.9 60.96 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b96d5b")
+		(property "Reference" "R401"
+			(at 87.63 55.88 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 88.9 58.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 88.9 59.182 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 88.9 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 88.9 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 88.9 60.96 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 88.9 60.96 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 88.9 60.96 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 88.9 60.96 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 88.9 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 88.9 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 88.9 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 88.9 60.96 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "8566a35c-9a7e-435b-a2b8-c7e0449d0312")
+		)
+		(pin "2"
+			(uuid "2d54ab1f-7e31-4242-a60c-41c6b8c03ee5")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R401")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 149.86 72.39 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b96d66")
+		(property "Reference" "R402"
+			(at 150.495 69.85 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 150.495 74.93 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 149.86 70.612 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 149.86 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 149.86 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 149.86 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 149.86 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 149.86 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 149.86 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 149.86 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 149.86 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 149.86 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 149.86 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "418c8df4-e55e-4a29-bf77-c34a92b580f8")
+		)
+		(pin "2"
+			(uuid "1b7347ad-e28b-4b3e-8416-f9274b5e7a98")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R402")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 123.19 87.63 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b96d71")
+		(property "Reference" "R403"
+			(at 121.92 82.55 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 123.19 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 123.19 85.852 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 123.19 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 123.19 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 123.19 87.63 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 123.19 87.63 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 123.19 87.63 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 123.19 87.63 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 123.19 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 123.19 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 123.19 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 123.19 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "de2c5dd2-8efe-47ee-aab0-337b12bb5432")
+		)
+		(pin "2"
+			(uuid "17af62e2-fd93-4380-a51d-2299488c5b84")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R403")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 78.74 96.52 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062b96d7c")
+		(property "Reference" "R404"
+			(at 77.47 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 78.74 93.98 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 78.74 94.742 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 78.74 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 78.74 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 78.74 96.52 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 78.74 96.52 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 78.74 96.52 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 78.74 96.52 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 78.74 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 78.74 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 78.74 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 78.74 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "37e4d13c-da5b-4593-999d-c25438609042")
+		)
+		(pin "2"
+			(uuid "e4d36ba4-afd7-42c7-9f49-42ccd2d01617")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R404")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:RJ12_6P6C_HORZ")
+		(at 34.29 81.28 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062d0d90d")
+		(property "Reference" "J401"
+			(at 35.7378 64.5922 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "RJ12_6P6C_HORZ"
+			(at 35.7378 66.9036 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:RJ12_Amphenol_54601"
+			(at 34.29 80.645 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://datasheet.lcsc.com/lcsc/1811141146_TE-Connectivity-5555165-1_C305981.pdf"
+			(at 34.29 80.645 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Jack Modular Connector 6p6c (RJ11, RJ12, RJ14, RJ25) 90° Angle (Right) Unshielded Cat3"
+			(at 34.29 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 34.29 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C305981"
+			(at 34.29 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2" "Digikey"
+			(at 34.29 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 2 PN" "A31422-ND"
+			(at 34.29 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TE Connectivity"
+			(at 34.29 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Assembly Type" ""
+			(at 35.7378 69.215 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "5555165-1"
+			(at 34.29 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 34.29 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.8901"
+			(at 34.29 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 34.29 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 34.29 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "81710cd4-378d-4f8f-b2bb-2e35d4cef32f")
+		)
+		(pin "2"
+			(uuid "f3f077b4-17d5-49f6-a8e3-1d4a0386b55c")
+		)
+		(pin "3"
+			(uuid "c7894986-df0b-4c6e-b6e2-9efbc37d5804")
+		)
+		(pin "4"
+			(uuid "4ed6e6c8-e00e-4d6f-9e36-72aafd133f28")
+		)
+		(pin "5"
+			(uuid "732a3d58-0a27-465b-af9e-5ccbaf1c421b")
+		)
+		(pin "6"
+			(uuid "5ca97cee-e7a0-44c0-bffd-71164902d969")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "J401")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:Polyfuse_Small")
+		(at 113.03 67.31 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-0000630ab448")
+		(property "Reference" "F401"
+			(at 116.84 66.04 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Polyfuse_Small_1A"
+			(at 114.3 69.85 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Fuse:Fuse_0603_1608Metric"
+			(at 107.95 68.58 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" ""
+			(at 113.03 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "6V 1A 50A -40℃~+85℃ 1.8A 40mΩ 300ms 120mΩ 0603 Resettable Fuses ROHS"
+			(at 113.03 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Littelfuse"
+			(at 113.03 67.31 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "0603L100SLYR"
+			(at 113.03 67.31 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 113.03 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.2448"
+			(at 113.03 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 113.03 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C207017"
+			(at 113.03 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 113.03 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 113.03 67.31 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a588700c-e22c-4877-8918-a2136f022684")
+		)
+		(pin "2"
+			(uuid "c174269c-3aba-4055-beba-d85356de1e04")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "F401")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 187.96 125.73 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "034819a1-fe87-4b6f-86ec-88f40193ea95")
+		(property "Reference" "R319"
+			(at 185.42 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 184.15 127 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 186.182 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 187.96 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 187.96 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 187.96 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 187.96 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 187.96 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 187.96 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 187.96 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 187.96 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 187.96 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 187.96 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "24584903-25c1-4146-ac83-5da1482e6914")
+		)
+		(pin "2"
+			(uuid "45aa6c0b-bae7-46e2-8aa9-5a8e6d9d940e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R319")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 231.14 21.59 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0350c407-71b9-4d55-9788-c8e58295126e")
+		(property "Reference" "TP306"
+			(at 226.06 13.97 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "5VRaw"
+			(at 226.06 16.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 236.22 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 236.22 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings ROHS red"
+			(at 231.14 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 231.14 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 231.14 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 231.14 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 231.14 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 231.14 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 231.14 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 231.14 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 231.14 21.59 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ee192def-c8c2-448f-8cc4-f39c00766a26")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "TP306")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:BAT54S")
+		(at 168.91 127 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0c0d530e-9ef2-4d24-9a3b-dd6cb1e1093a")
+		(property "Reference" "D303"
+			(at 168.91 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "BAT54S"
+			(at 168.91 130.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 170.815 130.175 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds11005.pdf"
+			(at 165.862 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "30V 1 pair in series 800mV@100mA 200mA SOT-23 Schottky Diodes ROHS"
+			(at 168.91 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C47546"
+			(at 168.91 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0098"
+			(at 168.91 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 168.91 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "BAT54S,215"
+			(at 168.91 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Nexperia"
+			(at 168.91 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 168.91 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 168.91 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 168.91 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "55941a78-742b-4a06-8da9-c3a2a84fa370")
+		)
+		(pin "2"
+			(uuid "db232f65-6e40-49e5-ac21-dcaa87cf11a8")
+		)
+		(pin "3"
+			(uuid "bde4bda7-5e87-402f-8efa-64c5f1d09aa0")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "D303")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 207.01 138.43 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "0d6401d6-eb2d-4870-9a8a-b09816c219a8")
+		(property "Reference" "R320"
+			(at 210.82 135.89 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 207.01 140.97 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 207.01 136.652 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 207.01 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 207.01 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 207.01 138.43 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 207.01 138.43 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 207.01 138.43 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 207.01 138.43 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 207.01 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 207.01 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 207.01 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 207.01 138.43 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "1f24e855-042f-4912-98d4-a3cb72ba04cd")
+		)
+		(pin "2"
+			(uuid "39fd4308-7ef4-4c07-9572-171c4d753a7b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R320")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:BAT54S")
+		(at 86.36 124.46 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "16c10c86-0535-48f7-bcda-21bd542151de")
+		(property "Reference" "D301"
+			(at 86.36 130.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "BAT54S"
+			(at 86.36 128.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 88.265 127.635 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds11005.pdf"
+			(at 83.312 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "30V 1 pair in series 800mV@100mA 200mA SOT-23 Schottky Diodes ROHS"
+			(at 86.36 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C47546"
+			(at 86.36 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0098"
+			(at 86.36 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 86.36 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "BAT54S,215"
+			(at 86.36 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Nexperia"
+			(at 86.36 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 86.36 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 86.36 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 86.36 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "189a5b3d-997e-442d-a155-a92eacb29124")
+		)
+		(pin "2"
+			(uuid "3d75d955-0adb-4b63-859e-863919680b22")
+		)
+		(pin "3"
+			(uuid "d4256258-2b66-40f3-b5d1-beed656eff52")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "D301")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Transistor_FET:BSS138")
+		(at 227.33 45.72 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1e2fde0f-aa8a-4aa2-943d-23221ba7a220")
+		(property "Reference" "Q305"
+			(at 224.79 44.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "BSS138"
+			(at 231.14 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 229.235 50.8 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF"
+			(at 227.33 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "N-Channel Enhancement Mode Field Effect Transistor"
+			(at 227.33 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 227.33 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C400505"
+			(at 227.33 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd"
+			(at 227.33 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "BSS138"
+			(at 227.33 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 227.33 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0196"
+			(at 227.33 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 227.33 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 227.33 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a5a631f2-09eb-4692-9a5b-d7379d02071d")
+		)
+		(pin "2"
+			(uuid "73a3c99a-6ed9-4095-a8d9-7edcb3301bdc")
+		)
+		(pin "3"
+			(uuid "a18e3081-5dbc-4a0a-8c18-9a40c5143454")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "Q305")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 53.34 81.28 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "3437063a-6972-47ef-9b64-8dee716b77b0")
+		(property "Reference" "#PWR0301"
+			(at 53.34 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 57.15 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 53.34 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 53.34 81.28 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ad61fa30-ec22-4944-be66-3e749fae90df")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "#PWR0301")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 76.2 124.46 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3fa0f74a-e737-4819-a384-87eff901429f")
+		(property "Reference" "#PWR0306"
+			(at 76.2 130.81 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 76.2 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 76.2 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 76.2 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 76.2 124.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c7b86d1d-9183-43cc-b0a5-a61d51c2ddc5")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "#PWR0306")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 93.98 76.2 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "4fccccd4-5e5f-4770-971a-cf8a350a7b81")
+		(property "Reference" "TP302"
+			(at 93.98 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "+12in"
+			(at 95.25 72.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 99.06 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 99.06 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 93.98 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 93.98 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 93.98 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 93.98 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 93.98 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 93.98 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 93.98 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 93.98 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 93.98 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "68d1a795-5dbf-43a9-8ce2-0b350b256215")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "TP302")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 106.68 125.73 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "50c2a832-4bce-4ede-94a0-3fec839db716")
+		(property "Reference" "R313"
+			(at 104.14 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 102.87 127 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 104.902 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 106.68 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 106.68 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 106.68 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 106.68 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 106.68 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 106.68 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 106.68 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 106.68 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 106.68 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 106.68 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "3873f775-a066-436d-8c9a-f397eaf90871")
+		)
+		(pin "2"
+			(uuid "188469bf-9fb2-40ca-9fcf-4ff282f83072")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R313")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 76.2 57.15 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "54d30c15-312d-4eda-a40a-3d4458521ed0")
+		(property "Reference" "TP301"
+			(at 76.2 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "CIPO"
+			(at 77.47 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 81.28 57.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 81.28 57.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 76.2 57.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 76.2 57.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 76.2 57.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 76.2 57.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 76.2 57.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 76.2 57.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 76.2 57.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 76.2 57.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 76.2 57.15 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "0a749866-cc24-43c3-88de-2a81e00c719a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "TP301")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:BAT54S")
+		(at 116.84 48.26 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5923f833-dfe1-4017-9347-c28e5771709d")
+		(property "Reference" "D302"
+			(at 116.84 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "BAT54S"
+			(at 116.84 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 118.745 45.085 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds11005.pdf"
+			(at 113.792 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "30V 1 pair in series 800mV@100mA 200mA SOT-23 Schottky Diodes ROHS"
+			(at 116.84 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C47546"
+			(at 116.84 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0098"
+			(at 116.84 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 116.84 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "BAT54S,215"
+			(at 116.84 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Nexperia"
+			(at 116.84 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 116.84 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 116.84 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 116.84 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "2f1112ed-215a-4cc0-aceb-f2c26967cb0c")
+		)
+		(pin "2"
+			(uuid "a1a5dc6a-ada6-417c-aad7-a24b3a417961")
+		)
+		(pin "3"
+			(uuid "e4e0decd-589c-4a8b-941e-aee9632f72b2")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "D302")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Transistor_FET:BSS138")
+		(at 121.92 127 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5ddb57eb-a878-4d18-90b3-a112997d27a0")
+		(property "Reference" "Q302"
+			(at 119.38 125.73 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "BSS138"
+			(at 125.73 133.35 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 123.825 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF"
+			(at 121.92 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "N-Channel Enhancement Mode Field Effect Transistor"
+			(at 121.92 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 121.92 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C400505"
+			(at 121.92 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd"
+			(at 121.92 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "BSS138"
+			(at 121.92 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 121.92 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0196"
+			(at 121.92 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 121.92 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 121.92 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "df38cf49-dc62-47ff-ac4f-38cb165b82ab")
+		)
+		(pin "2"
+			(uuid "3444cf44-01d8-41ee-8a6b-c61cacf1518f")
+		)
+		(pin "3"
+			(uuid "e8d79f14-a348-4540-a770-23c834018ad9")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "Q302")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 205.74 31.75 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "784b70db-3493-41b8-a771-54837dc8fcc8")
+		(property "Reference" "C303"
+			(at 202.819 32.9184 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 202.819 30.607 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 204.7748 27.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 205.74 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 205.74 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 205.74 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 205.74 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 205.74 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 205.74 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 205.74 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 205.74 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 205.74 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 205.74 31.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6bd10dfe-b0b8-4c48-a59e-2966a89d8749")
+		)
+		(pin "2"
+			(uuid "84eac7e2-12b3-4ce7-afb6-e426a4f1d40c")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "C303")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 130.81 78.74 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "7dcdbb7b-c183-42dc-b9e0-065e211cba88")
+		(property "Reference" "TP303"
+			(at 130.81 72.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "SCK"
+			(at 132.08 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 135.89 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 135.89 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 130.81 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 130.81 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 130.81 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 130.81 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 130.81 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 130.81 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 130.81 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 130.81 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 130.81 78.74 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7b465f41-244a-4d92-b2ef-5c5b2877fee9")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "TP303")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 215.9 127 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "7e78b475-f596-4c7e-a471-eb9af1198c24")
+		(property "Reference" "R322"
+			(at 213.36 123.19 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 212.09 128.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 214.122 127 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 215.9 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 215.9 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 215.9 127 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 215.9 127 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 215.9 127 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 215.9 127 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 215.9 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 215.9 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 215.9 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 215.9 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c01363bf-a440-4f17-9916-e3156cced0da")
+		)
+		(pin "2"
+			(uuid "103c0308-32e8-41f2-813e-e968b785dbc0")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R322")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 133.35 125.73 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "80795a5d-db6d-4cd9-9d24-6fa607634bd1")
+		(property "Reference" "R315"
+			(at 130.81 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 129.54 127 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 131.572 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 133.35 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 133.35 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 133.35 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 133.35 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 133.35 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 133.35 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 133.35 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 133.35 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 133.35 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 133.35 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "1cf584d4-cee0-43ec-a259-201bd59882da")
+		)
+		(pin "2"
+			(uuid "59730bcd-84fc-4e8a-a644-f4e97c91b177")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R315")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 106.68 48.26 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "88d23423-5d86-4a6c-a0b4-529ae96c8d0d")
+		(property "Reference" "#PWR0302"
+			(at 106.68 54.61 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 106.68 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 106.68 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 106.68 48.26 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 106.68 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d36b11e8-8b6a-4918-9cf6-36564fc9a41b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "#PWR0302")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:BAT54S")
+		(at 191.77 49.53 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "979ea98a-fcb1-4ac8-84a6-60a2a29d6b96")
+		(property "Reference" "D304"
+			(at 191.77 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "BAT54S"
+			(at 191.77 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 193.675 46.355 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds11005.pdf"
+			(at 188.722 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "30V 1 pair in series 800mV@100mA 200mA SOT-23 Schottky Diodes ROHS"
+			(at 191.77 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C47546"
+			(at 191.77 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0098"
+			(at 191.77 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 191.77 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "BAT54S,215"
+			(at 191.77 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Nexperia"
+			(at 191.77 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 191.77 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 191.77 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 191.77 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "40b793d8-69d0-4d30-ad08-dfd65498c5e9")
+		)
+		(pin "2"
+			(uuid "bc7bc5cb-0379-452c-827b-c348ca47c243")
+		)
+		(pin "3"
+			(uuid "f3f3d08f-e45d-4958-9cf5-3e917f7d36f0")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "D304")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 152.4 55.88 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "9c30ac61-de20-4b77-b8c6-f4dc12768634")
+		(property "Reference" "R317"
+			(at 156.21 53.34 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 152.4 58.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 152.4 54.102 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 152.4 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 152.4 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 152.4 55.88 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 152.4 55.88 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 152.4 55.88 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 152.4 55.88 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 152.4 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 152.4 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 152.4 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 152.4 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ce1d12cc-75b7-4d90-8ee4-a3812a9af4b9")
+		)
+		(pin "2"
+			(uuid "9708f4fd-c1fa-424a-bb06-23fd81647b23")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R317")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 138.43 43.18 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a1fb2b37-414d-47ee-85ac-2cf51a10fa09")
+		(property "Reference" "R316"
+			(at 135.89 39.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 136.652 43.18 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 138.43 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 138.43 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 138.43 43.18 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 138.43 43.18 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 138.43 43.18 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 138.43 43.18 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 138.43 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 138.43 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 138.43 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 138.43 43.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c1fa227a-3eb9-4ea0-8c75-e733639848dc")
+		)
+		(pin "2"
+			(uuid "4979d160-9ad3-42b4-be8b-9c9cca35578b")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R316")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 107.95 87.63 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a8a844dd-869e-4522-ad0c-4b050bafbd4b")
+		(property "Reference" "TP304"
+			(at 107.95 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "COPI"
+			(at 109.22 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 113.03 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 113.03 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 107.95 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 107.95 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 107.95 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 107.95 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 107.95 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 107.95 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 107.95 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 107.95 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 107.95 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "de28d98d-5761-457b-a76c-e8efab4df57f")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "TP304")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 181.61 49.53 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ae391940-95de-4206-bea8-95c8699c0964")
+		(property "Reference" "#PWR0304"
+			(at 181.61 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 181.61 54.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 181.61 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 181.61 49.53 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 181.61 49.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "81805470-2a95-4f01-ad44-5e6e7baf8dc7")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "#PWR0304")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 158.75 127 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b549d127-52f5-4cc8-964d-f467cb8efe76")
+		(property "Reference" "#PWR0307"
+			(at 158.75 133.35 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 158.75 132.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 158.75 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 158.75 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 158.75 127 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "2595f1dc-c65e-47ad-b6b2-d1daf090cfa7")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "#PWR0307")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Transistor_FET:BSS138")
+		(at 149.86 45.72 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b6a81a2c-69bf-4a34-ad7b-8620e2c11e51")
+		(property "Reference" "Q303"
+			(at 147.32 44.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "BSS138"
+			(at 153.67 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 151.765 50.8 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF"
+			(at 149.86 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "N-Channel Enhancement Mode Field Effect Transistor"
+			(at 149.86 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 149.86 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C400505"
+			(at 149.86 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd"
+			(at 149.86 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "BSS138"
+			(at 149.86 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 149.86 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0196"
+			(at 149.86 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 149.86 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 149.86 45.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "1f133650-d298-4a2d-a473-19c038f03041")
+		)
+		(pin "2"
+			(uuid "22086d8f-b2c6-4eaa-a769-74984f1d8002")
+		)
+		(pin "3"
+			(uuid "b5c7cc41-c156-468e-9ca1-d33b3f4d3167")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "Q303")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Transistor_FET:BSS138")
+		(at 204.47 128.27 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b70d63d5-7455-4818-9d60-b0a039eeef8b")
+		(property "Reference" "Q304"
+			(at 201.93 127 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "BSS138"
+			(at 208.28 134.62 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 206.375 133.35 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.onsemi.com/pub/Collateral/BSS138-D.PDF"
+			(at 204.47 128.27 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "N-Channel Enhancement Mode Field Effect Transistor"
+			(at 204.47 128.27 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 204.47 128.27 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C400505"
+			(at 204.47 128.27 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Yangzhou Yangjie Electronic Technology Co., Ltd"
+			(at 204.47 128.27 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "BSS138"
+			(at 204.47 128.27 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 204.47 128.27 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0196"
+			(at 204.47 128.27 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 204.47 128.27 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 204.47 128.27 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f35898d1-068f-475d-9da6-45a6ac4b8489")
+		)
+		(pin "2"
+			(uuid "da7c3c5a-81f9-4b30-891a-967b193590cc")
+		)
+		(pin "3"
+			(uuid "d288e01d-437f-4f76-882d-cdbb0c9eaf2c")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "Q304")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 62.23 95.25 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c94e4c51-69a4-4358-86be-23140a160b53")
+		(property "Reference" "TP305"
+			(at 62.23 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "SS"
+			(at 63.5 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 67.31 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 67.31 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 62.23 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 62.23 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 62.23 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 62.23 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 62.23 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 62.23 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 62.23 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 62.23 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 62.23 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "459adfd1-63a4-492d-8111-840d1521bf9a")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "TP305")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 210.82 44.45 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "caa8231d-f117-46fb-b263-12f89d97874d")
+		(property "Reference" "R321"
+			(at 208.28 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 207.01 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 209.042 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 210.82 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 210.82 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 210.82 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 210.82 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 210.82 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 210.82 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 210.82 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 210.82 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 210.82 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 210.82 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "15fb0a73-fd3a-4e33-a905-4869488c7df8")
+		)
+		(pin "2"
+			(uuid "0b63a367-299c-4e96-a3dc-f5bbb3f7a892")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R321")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 238.76 44.45 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d8791e85-46b7-4be5-b7bb-60b32684911e")
+		(property "Reference" "R324"
+			(at 236.22 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 234.95 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 236.982 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 238.76 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 238.76 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 238.76 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 238.76 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 238.76 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 238.76 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 238.76 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 238.76 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 238.76 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 238.76 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d256676a-0bfd-4199-9600-3c2443db0236")
+		)
+		(pin "2"
+			(uuid "ff42c371-2885-439c-af7c-01e58c7556fc")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R324")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 229.87 55.88 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "daa40512-8008-48fe-949a-13231cda87dc")
+		(property "Reference" "R323"
+			(at 233.68 53.34 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 229.87 58.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 229.87 54.102 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 229.87 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 229.87 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 229.87 55.88 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 229.87 55.88 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 229.87 55.88 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 229.87 55.88 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 229.87 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 229.87 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 229.87 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 229.87 55.88 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "bd6f0909-441b-474d-bb52-ccd38f510554")
+		)
+		(pin "2"
+			(uuid "35f5990e-7a06-481c-9b51-fae038181580")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R323")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 205.74 35.56 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "dc1c087d-ad7b-4812-ade8-61b9da2847ae")
+		(property "Reference" "#PWR0305"
+			(at 205.74 41.91 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 205.74 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 205.74 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 205.74 35.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 205.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "5b2f03fb-220b-4d4c-82d2-ce83013a0626")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "#PWR0305")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 161.29 44.45 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e5d5d818-5174-4a52-b94b-f13ac2536016")
+		(property "Reference" "R318"
+			(at 158.75 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 157.48 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 159.512 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 161.29 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 161.29 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 161.29 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 161.29 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 161.29 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 161.29 44.45 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 161.29 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 161.29 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 161.29 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 161.29 44.45 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "898d34e7-e395-4016-90ba-b074c8fb0e38")
+		)
+		(pin "2"
+			(uuid "875b4cd3-72e5-441d-bf75-4f3a27a689a5")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R318")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 124.46 137.16 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "ec4c867a-4ea3-4451-b568-403661971f15")
+		(property "Reference" "R314"
+			(at 128.27 134.62 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "DNI"
+			(at 124.46 139.7 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 124.46 135.382 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 124.46 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 124.46 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 124.46 137.16 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 124.46 137.16 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 124.46 137.16 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 124.46 137.16 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 124.46 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 124.46 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 124.46 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 124.46 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a3f3292d-8b81-4915-8288-703fcdc1e5b8")
+		)
+		(pin "2"
+			(uuid "abc00f6a-5bd1-4d18-bd13-25abb90348ef")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b93801"
+					(reference "R314")
+					(unit 1)
+				)
+			)
+		)
+	)
 )

--- a/PWA_REV2/USB_UART.kicad_sch
+++ b/PWA_REV2/USB_UART.kicad_sch
@@ -1,3412 +1,8390 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid 305a2529-eeaf-4b46-ae3d-4f3d499b0060)
-
-  (paper "A4")
-
-  (title_block
-    (title "KRAKE_PCB")
-    (date "2025-07-18")
-    (rev "2.0")
-    (company "PublicInvention")
-    (comment 1 "GNU Affero General Public License v3.0")
-    (comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
-    (comment 3 "https://github.com/PubInv/krake")
-    (comment 4 "Inherited from the GPAD")
-  )
-
-  (lib_symbols
-    (symbol "Connector:TestPoint" (pin_numbers hide) (pin_names (offset 0.762) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "TP" (at 0 6.858 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "TestPoint" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 5.08 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "test point tp" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "test point" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "Pin* Test*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "TestPoint_0_1"
-        (circle (center 0 3.302) (radius 0.762)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "TestPoint_1_1"
-        (pin passive line (at 0 0 90) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:C" (pin_numbers hide) (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C" (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Unpolarized capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "C_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_0_1"
-        (polyline
-          (pts
-            (xy -2.032 -0.762)
-            (xy 2.032 -0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -2.032 0.762)
-            (xy 2.032 0.762)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "C_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:C_Polarized" (pin_numbers hide) (pin_names (offset 0.254)) (in_bom yes) (on_board yes)
-      (property "Reference" "C" (at 0.635 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "C_Polarized" (at 0.635 -2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "" (at 0.9652 -3.81 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "cap capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Polarized capacitor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "CP_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "C_Polarized_0_1"
-        (rectangle (start -2.286 0.508) (end 2.286 1.016)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.778 2.286)
-            (xy -0.762 2.286)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 2.794)
-            (xy -1.27 1.778)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 2.286 -0.508) (end -2.286 -1.016)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "C_Polarized_1_1"
-        (pin passive line (at 0 3.81 270) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 2.794)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:LED" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at 0 2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "LED" (at 0 -2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "LED diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Light emitting diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "LED_0_1"
-        (polyline
-          (pts
-            (xy -1.27 -1.27)
-            (xy -1.27 1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 0)
-            (xy 1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 -1.27)
-            (xy 1.27 1.27)
-            (xy -1.27 0)
-            (xy 1.27 -1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.048 -0.762)
-            (xy -4.572 -2.286)
-            (xy -3.81 -2.286)
-            (xy -4.572 -2.286)
-            (xy -4.572 -1.524)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.778 -0.762)
-            (xy -3.302 -2.286)
-            (xy -2.54 -2.286)
-            (xy -3.302 -2.286)
-            (xy -3.302 -1.524)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "LED_1_1"
-        (pin passive line (at -3.81 0 0) (length 2.54)
-          (name "K" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 3.81 0 180) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Device:R" (pin_numbers hide) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "R" (at 2.032 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "R" (at 0 0 90)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at -1.778 0 90)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "R res resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Resistor" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "R_*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "R_0_1"
-        (rectangle (start -1.016 -2.54) (end 1.016 2.54)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "R_1_1"
-        (pin passive line (at 0 3.81 270) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -3.81 90) (length 1.27)
-          (name "~" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GND_1" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "GND_1" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"GND\" , ground" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "GND_1_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 -1.27)
-            (xy 1.27 -1.27)
-            (xy 0 -2.54)
-            (xy -1.27 -1.27)
-            (xy 0 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "GND_1_1_1"
-        (pin power_in line (at 0 0 270) (length 0) hide
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GND_2" (power) (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "#PWR" (at 0 -6.35 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "GND_2" (at 0 -3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "global power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Power symbol creates a global label with name \"GND\" , ground" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "GND_2_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 -1.27)
-            (xy 1.27 -1.27)
-            (xy 0 -2.54)
-            (xy -1.27 -1.27)
-            (xy 0 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "GND_2_1_1"
-        (pin power_in line (at 0 0 270) (length 0) hide
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:CH340B" (in_bom yes) (on_board yes)
-      (property "Reference" "U" (at -5.08 13.97 0)
-        (effects (font (size 1.27 1.27)) (justify right))
-      )
-      (property "Value" "CH340B" (at 1.27 13.97 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Footprint" "Package_SO:SOIC-16_3.9x9.9mm_P1.27mm" (at 1.27 -13.97 0)
-        (effects (font (size 1.27 1.27)) (justify left) hide)
-      )
-      (property "Datasheet" "https://datasheet.lcsc.com/szlcsc/Jiangsu-Qin-Heng-CH340C_C84681.pdf" (at -8.89 20.32 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "USB UART Serial Converter Interface" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "USB serial converter, UART, SOIC-16" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "SOIC*3.9x9.9mm*P1.27mm*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "CH340B_0_1"
-        (rectangle (start -7.62 12.7) (end 7.62 -12.7)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-      )
-      (symbol "CH340B_1_1"
-        (pin power_in line (at 0 -15.24 90) (length 2.54)
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 10.16 0 180) (length 2.54)
-          (name "~{DSR}" (effects (font (size 1.27 1.27))))
-          (number "10" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 10.16 -2.54 180) (length 2.54)
-          (name "~{RI}" (effects (font (size 1.27 1.27))))
-          (number "11" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 10.16 -5.08 180) (length 2.54)
-          (name "~{DCD}" (effects (font (size 1.27 1.27))))
-          (number "12" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at 10.16 -7.62 180) (length 2.54)
-          (name "~{DTR}" (effects (font (size 1.27 1.27))))
-          (number "13" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at 10.16 -10.16 180) (length 2.54)
-          (name "~{RTS}" (effects (font (size 1.27 1.27))))
-          (number "14" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at -10.16 7.62 0) (length 2.54)
-          (name "TNOW" (effects (font (size 1.27 1.27))))
-          (number "15" (effects (font (size 1.27 1.27))))
-        )
-        (pin power_in line (at 0 15.24 270) (length 2.54)
-          (name "VCC" (effects (font (size 1.27 1.27))))
-          (number "16" (effects (font (size 1.27 1.27))))
-        )
-        (pin output line (at 10.16 10.16 180) (length 2.54)
-          (name "TXD" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 10.16 7.62 180) (length 2.54)
-          (name "RXD" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -2.54 15.24 270) (length 2.54)
-          (name "V3" (effects (font (size 1.27 1.27))))
-          (number "4" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -10.16 2.54 0) (length 2.54)
-          (name "UD+" (effects (font (size 1.27 1.27))))
-          (number "5" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at -10.16 0 0) (length 2.54)
-          (name "UD-" (effects (font (size 1.27 1.27))))
-          (number "6" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at -10.16 -7.62 0) (length 2.54)
-          (name "RST#" (effects (font (size 1.27 1.27))))
-          (number "7" (effects (font (size 1.27 1.27))))
-        )
-        (pin no_connect line (at -10.16 -10.16 0) (length 2.54)
-          (name "NC" (effects (font (size 1.27 1.27))))
-          (number "8" (effects (font (size 1.27 1.27))))
-        )
-        (pin input line (at 10.16 2.54 180) (length 2.54)
-          (name "~{CTS}" (effects (font (size 1.27 1.27))))
-          (number "9" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:MMBT2222A-7-F" (pin_names (offset 0)) (in_bom yes) (on_board yes)
-      (property "Reference" "Q" (at -3.2004 4.2164 0)
-        (effects (font (size 1.524 1.524)) (justify left))
-      )
-      (property "Value" "MMBT2222A-7-F" (at 5.2324 0 90)
-        (effects (font (size 1.524 1.524)))
-      )
-      (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 5.08 5.08 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 5.08 7.62 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Digi-Key_PN" "MMBT2222A-FDICT-ND" (at 5.08 10.16 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "MPN" "MMBT2222A-7-F" (at 5.08 12.7 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Category" "Discrete Semiconductor Products" (at 5.08 15.24 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Family" "Transistors - Bipolar (BJT) - Single" (at 5.08 17.78 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 5.08 20.32 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723" (at 5.08 22.86 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3" (at 5.08 25.4 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Manufacturer" "Diodes Incorporated" (at 5.08 27.94 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "Status" "Active" (at 5.08 30.48 0)
-        (effects (font (size 1.524 1.524)) (justify left) hide)
-      )
-      (property "ki_keywords" "MMBT2222A-FDICT-ND Automotive, AEC-Q101" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "TRANS NPN 40V 0.6A SMD SOT23-3" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "MMBT2222A-7-F_0_1"
-        (polyline
-          (pts
-            (xy -3.81 0)
-            (xy -2.54 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -3.556 0)
-            (xy 0 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 -1.27)
-            (xy 2.54 -2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 1.27)
-            (xy 2.54 2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 2.54)
-            (xy 0 -2.54)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.524 -1.27)
-            (xy 2.032 -2.286)
-            (xy 1.016 -2.54)
-            (xy 1.524 -1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (circle (center 0 0) (radius 3.2512)
-          (stroke (width 0) (type default))
-          (fill (type background))
-        )
-      )
-      (symbol "MMBT2222A-7-F_1_1"
-        (pin input line (at -5.08 0 0) (length 2.54)
-          (name "B" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 -5.08 90) (length 2.54)
-          (name "E" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 2.54 5.08 270) (length 2.54)
-          (name "C" (effects (font (size 1.27 1.27))))
-          (number "3" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "GPAD_SCH_LIB:USB_C_Receptacle_USB2.0_GPAD" (pin_names (offset 1.016)) (in_bom yes) (on_board yes)
-      (property "Reference" "J" (at -10.16 19.05 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "USB_C_Receptacle_USB2.0" (at 19.05 19.05 0)
-        (effects (font (size 1.27 1.27)) (justify right))
-      )
-      (property "Footprint" "" (at 3.81 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip" (at 3.81 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "usb universal serial bus type-C USB2.0" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "USB 2.0-only Type-C Receptacle connector" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "USB*C*Receptacle*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "USB_C_Receptacle_USB2.0_GPAD_0_0"
-        (rectangle (start -0.254 -17.78) (end 0.254 -16.764)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 10.16 -14.986) (end 9.144 -15.494)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 10.16 -12.446) (end 9.144 -12.954)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 10.16 -6.096) (end 9.144 -6.604)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 10.16 -3.556) (end 9.144 -4.064)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 10.16 2.794) (end 9.144 2.286)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 10.16 5.334) (end 9.144 4.826)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 10.16 7.874) (end 9.144 7.366)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 10.16 10.414) (end 9.144 9.906)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (rectangle (start 10.16 15.494) (end 9.144 14.986)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "USB_C_Receptacle_USB2.0_GPAD_0_1"
-        (rectangle (start -10.16 17.78) (end 10.16 -17.78)
-          (stroke (width 0.254) (type default))
-          (fill (type background))
-        )
-        (arc (start -8.89 -3.81) (mid -6.985 -5.7067) (end -5.08 -3.81)
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (arc (start -7.62 -3.81) (mid -6.985 -4.4423) (end -6.35 -3.81)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (arc (start -7.62 -3.81) (mid -6.985 -4.4423) (end -6.35 -3.81)
-          (stroke (width 0.254) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start -7.62 -3.81) (end -6.35 3.81)
-          (stroke (width 0.254) (type default))
-          (fill (type outline))
-        )
-        (arc (start -6.35 3.81) (mid -6.985 4.4423) (end -7.62 3.81)
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (arc (start -6.35 3.81) (mid -6.985 4.4423) (end -7.62 3.81)
-          (stroke (width 0.254) (type default))
-          (fill (type outline))
-        )
-        (arc (start -5.08 3.81) (mid -6.985 5.7067) (end -8.89 3.81)
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (circle (center -2.54 1.143) (radius 0.635)
-          (stroke (width 0.254) (type default))
-          (fill (type outline))
-        )
-        (circle (center 0 -5.842) (radius 1.27)
-          (stroke (width 0) (type default))
-          (fill (type outline))
-        )
-        (polyline
-          (pts
-            (xy -8.89 -3.81)
-            (xy -8.89 3.81)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -5.08 3.81)
-            (xy -5.08 -3.81)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 -5.842)
-            (xy 0 4.318)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 -3.302)
-            (xy -2.54 -0.762)
-            (xy -2.54 0.508)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 -2.032)
-            (xy 2.54 0.508)
-            (xy 2.54 1.778)
-          )
-          (stroke (width 0.508) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy -1.27 4.318)
-            (xy 0 6.858)
-            (xy 1.27 4.318)
-            (xy -1.27 4.318)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type outline))
-        )
-        (rectangle (start 1.905 1.778) (end 3.175 3.048)
-          (stroke (width 0.254) (type default))
-          (fill (type outline))
-        )
-      )
-      (symbol "USB_C_Receptacle_USB2.0_GPAD_1_1"
-        (pin passive line (at 0 -22.86 90) (length 5.08)
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "A1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -22.86 90) (length 5.08) hide
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "A12" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 15.24 15.24 180) (length 5.08)
-          (name "VBUS" (effects (font (size 1.27 1.27))))
-          (number "A4" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 15.24 -3.81 180) (length 5.08)
-          (name "CC1" (effects (font (size 1.27 1.27))))
-          (number "A5" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 15.24 5.08 180) (length 5.08)
-          (name "D+" (effects (font (size 1.27 1.27))))
-          (number "A6" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 15.24 10.16 180) (length 5.08)
-          (name "D-" (effects (font (size 1.27 1.27))))
-          (number "A7" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 15.24 -12.7 180) (length 5.08)
-          (name "SBU1" (effects (font (size 1.27 1.27))))
-          (number "A8" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 15.24 15.24 180) (length 5.08) hide
-          (name "VBUS" (effects (font (size 1.27 1.27))))
-          (number "A9" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -22.86 90) (length 5.08) hide
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "B1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 0 -22.86 90) (length 5.08) hide
-          (name "GND" (effects (font (size 1.27 1.27))))
-          (number "B12" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 15.24 15.24 180) (length 5.08) hide
-          (name "VBUS" (effects (font (size 1.27 1.27))))
-          (number "B4" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 15.24 -6.35 180) (length 5.08)
-          (name "CC2" (effects (font (size 1.27 1.27))))
-          (number "B5" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 15.24 2.54 180) (length 5.08)
-          (name "D+" (effects (font (size 1.27 1.27))))
-          (number "B6" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 15.24 7.62 180) (length 5.08)
-          (name "D-" (effects (font (size 1.27 1.27))))
-          (number "B7" (effects (font (size 1.27 1.27))))
-        )
-        (pin bidirectional line (at 15.24 -15.24 180) (length 5.08)
-          (name "SBU2" (effects (font (size 1.27 1.27))))
-          (number "B8" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 15.24 15.24 180) (length 5.08) hide
-          (name "VBUS" (effects (font (size 1.27 1.27))))
-          (number "B9" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at -7.62 -22.86 90) (length 5.08)
-          (name "SHIELD" (effects (font (size 1.27 1.27))))
-          (number "S1" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "power:PWR_FLAG" (power) (pin_numbers hide) (pin_names (offset 0) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "#FLG" (at 0 1.905 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Value" "PWR_FLAG" (at 0 3.81 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "flag power" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Special symbol for telling ERC where power comes from" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "PWR_FLAG_0_0"
-        (pin power_out line (at 0 0 90) (length 0)
-          (name "pwr" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-      )
-      (symbol "PWR_FLAG_0_1"
-        (polyline
-          (pts
-            (xy 0 0)
-            (xy 0 1.27)
-            (xy -1.016 1.905)
-            (xy 0 2.54)
-            (xy 1.016 1.905)
-            (xy 0 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-      )
-    )
-  )
-
-  (junction (at 154.94 76.2) (diameter 0) (color 0 0 0 0)
-    (uuid 070c87a5-6471-4a1c-943e-20bae21b0944)
-  )
-  (junction (at 124.46 76.2) (diameter 0) (color 0 0 0 0)
-    (uuid 19f8e4a3-6444-4f2e-8a36-380cd2ba6b92)
-  )
-  (junction (at 86.36 100.33) (diameter 0) (color 0 0 0 0)
-    (uuid 23d77882-4ef8-47dd-8810-afda293da262)
-  )
-  (junction (at 168.91 90.17) (diameter 0) (color 0 0 0 0)
-    (uuid 2f4dcb69-1cc3-4d54-a2d5-c8da52c3e640)
-  )
-  (junction (at 193.04 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 34f7cb43-6675-4a8d-96c2-553b1efa57f4)
-  )
-  (junction (at 86.36 95.25) (diameter 0) (color 0 0 0 0)
-    (uuid 39355474-e438-4230-a30d-03138463dbd6)
-  )
-  (junction (at 161.29 76.2) (diameter 0) (color 0 0 0 0)
-    (uuid 3b2ca0e2-1e23-4c05-988e-c1f6e6cf637a)
-  )
-  (junction (at 182.88 105.41) (diameter 0) (color 0 0 0 0)
-    (uuid 5351e454-00ef-4794-a8fe-f36713490e3f)
-  )
-  (junction (at 120.65 76.2) (diameter 0) (color 0 0 0 0)
-    (uuid 8315188c-f84b-4632-b43c-c5c28567459b)
-  )
-  (junction (at 189.23 125.73) (diameter 0) (color 0 0 0 0)
-    (uuid 92f69aec-2cde-4571-aa76-ac8b628daf9f)
-  )
-  (junction (at 137.16 78.74) (diameter 0) (color 0 0 0 0)
-    (uuid a9c08cf4-2020-41cc-a221-6a63fa8bfbc3)
-  )
-  (junction (at 154.94 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid b3f0eae2-d90e-4194-a1bf-ac1969640a31)
-  )
-  (junction (at 137.16 72.39) (diameter 0) (color 0 0 0 0)
-    (uuid bdf14e23-4c25-4cce-9ec3-e39c90d1de7f)
-  )
-  (junction (at 172.72 125.73) (diameter 0) (color 0 0 0 0)
-    (uuid c4720192-394e-47aa-881c-e8cd920eacfd)
-  )
-  (junction (at 168.91 76.2) (diameter 0) (color 0 0 0 0)
-    (uuid d12eebb6-5409-4efd-863b-0b17ea8caf31)
-  )
-  (junction (at 102.87 72.39) (diameter 0) (color 0 0 0 0)
-    (uuid fe958b07-5fcc-473c-ad46-6d5eccaea944)
-  )
-
-  (no_connect (at 165.1 102.87) (uuid 04411a86-db16-4952-a604-68163e6fd7e9))
-  (no_connect (at 165.1 97.79) (uuid 07e18ba4-4b72-402f-9212-c8126ca5d493))
-  (no_connect (at 165.1 100.33) (uuid 3a8b1b72-dbfa-4e44-ba13-ed2aaff43dd1))
-  (no_connect (at 86.36 115.57) (uuid aea7c0db-db23-414c-9c77-96f9c855b49a))
-  (no_connect (at 86.36 118.11) (uuid c7fae7b0-37aa-417a-b3ef-ba5e54b00e40))
-
-  (wire (pts (xy 106.68 76.2) (xy 120.65 76.2))
-    (stroke (width 0) (type default))
-    (uuid 00de126f-497f-4d2c-a204-98243a53628e)
-  )
-  (wire (pts (xy 86.36 95.25) (xy 88.9 95.25))
-    (stroke (width 0) (type default))
-    (uuid 0abf4f1b-910d-4772-a953-f31e5a9434f4)
-  )
-  (wire (pts (xy 172.72 151.13) (xy 172.72 125.73))
-    (stroke (width 0) (type default))
-    (uuid 0b47cae6-3d2b-49c2-bb27-6b9f5cc2f693)
-  )
-  (wire (pts (xy 189.23 125.73) (xy 195.58 125.73))
-    (stroke (width 0) (type default))
-    (uuid 0bc243e5-4485-4c52-98b4-1e54db4665ff)
-  )
-  (wire (pts (xy 154.94 121.92) (xy 182.88 121.92))
-    (stroke (width 0) (type default))
-    (uuid 0ceae22f-38ef-465c-840f-47f238e844fe)
-  )
-  (wire (pts (xy 161.29 74.93) (xy 161.29 76.2))
-    (stroke (width 0) (type default))
-    (uuid 0df26040-2c90-4885-9f32-d6f95f7799cc)
-  )
-  (wire (pts (xy 165.1 87.63) (xy 168.91 87.63))
-    (stroke (width 0) (type default))
-    (uuid 1c60ad87-946b-4aed-a3d6-357e5dd9da57)
-  )
-  (wire (pts (xy 167.64 143.51) (xy 193.04 143.51))
-    (stroke (width 0) (type default))
-    (uuid 1ccfa55a-54bc-4d04-9537-36de5b00ba0c)
-  )
-  (wire (pts (xy 152.4 78.74) (xy 137.16 78.74))
-    (stroke (width 0) (type default))
-    (uuid 1d096dba-1cad-41b2-9bfb-c55a7c4717d9)
-  )
-  (wire (pts (xy 118.11 121.92) (xy 114.3 121.92))
-    (stroke (width 0) (type default))
-    (uuid 1e7f23a1-1cc1-4e7d-92dc-04ede36815a7)
-  )
-  (wire (pts (xy 140.97 90.17) (xy 144.78 90.17))
-    (stroke (width 0) (type default))
-    (uuid 1f97a489-8d71-479b-ac5f-d5f0636d6788)
-  )
-  (wire (pts (xy 86.36 87.63) (xy 87.63 87.63))
-    (stroke (width 0) (type default))
-    (uuid 1fbeeba6-a2c3-4e09-9255-b2a7f4c5d81f)
-  )
-  (wire (pts (xy 176.53 96.52) (xy 212.09 96.52))
-    (stroke (width 0) (type default))
-    (uuid 26d41837-7582-4fe0-949b-1e2ae1df0abb)
-  )
-  (wire (pts (xy 87.63 81.28) (xy 87.63 87.63))
-    (stroke (width 0) (type default))
-    (uuid 27927128-f75e-4378-9236-a36da6bcd1a2)
-  )
-  (wire (pts (xy 130.81 105.41) (xy 144.78 105.41))
-    (stroke (width 0) (type default))
-    (uuid 292c4390-b701-4fb3-9b42-2939f22c6356)
-  )
-  (wire (pts (xy 165.1 107.95) (xy 167.64 107.95))
-    (stroke (width 0) (type default))
-    (uuid 295949a2-8c7b-4c1e-8e58-a0fa5c96513c)
-  )
-  (wire (pts (xy 124.46 76.2) (xy 120.65 76.2))
-    (stroke (width 0) (type default))
-    (uuid 2e54042e-a475-4daf-908a-94160bf571a8)
-  )
-  (wire (pts (xy 88.9 97.79) (xy 144.78 97.79))
-    (stroke (width 0) (type default))
-    (uuid 2f7f10eb-a7aa-4e28-97f8-a8b203396e8a)
-  )
-  (wire (pts (xy 106.68 86.36) (xy 106.68 87.63))
-    (stroke (width 0) (type default))
-    (uuid 31130e2a-efc8-4b78-938b-57a904fd2c3e)
-  )
-  (wire (pts (xy 140.97 90.17) (xy 140.97 121.92))
-    (stroke (width 0) (type default))
-    (uuid 318cec54-9634-4ca7-a454-1439881ff2de)
-  )
-  (wire (pts (xy 212.09 66.04) (xy 109.22 66.04))
-    (stroke (width 0) (type default))
-    (uuid 34bc8dac-043a-4de8-8ab8-9ba3ae12b085)
-  )
-  (wire (pts (xy 91.44 95.25) (xy 144.78 95.25))
-    (stroke (width 0) (type default))
-    (uuid 353b9fda-953a-4889-9599-4588a423562c)
-  )
-  (wire (pts (xy 168.91 90.17) (xy 168.91 96.52))
-    (stroke (width 0) (type default))
-    (uuid 355f3b91-3732-4874-bae5-823a9ecd93fa)
-  )
-  (wire (pts (xy 172.72 125.73) (xy 189.23 125.73))
-    (stroke (width 0) (type default))
-    (uuid 35b05a53-6c56-433e-b012-87dfe99981fe)
-  )
-  (wire (pts (xy 86.36 109.22) (xy 92.71 109.22))
-    (stroke (width 0) (type default))
-    (uuid 3a04c9a4-bc09-4b52-a701-087f391e50bd)
-  )
-  (wire (pts (xy 154.94 82.55) (xy 154.94 76.2))
-    (stroke (width 0) (type default))
-    (uuid 3cd20d48-8f4f-41b8-baf3-3fdf13fcb8a8)
-  )
-  (wire (pts (xy 88.9 100.33) (xy 86.36 100.33))
-    (stroke (width 0) (type default))
-    (uuid 43b183c4-9fd9-4af7-b9d8-a0afb064264f)
-  )
-  (wire (pts (xy 154.94 127) (xy 154.94 121.92))
-    (stroke (width 0) (type default))
-    (uuid 440e1931-6dd0-4cc9-8dd1-21fc3a5cdcc3)
-  )
-  (wire (pts (xy 109.22 66.04) (xy 109.22 72.39))
-    (stroke (width 0) (type default))
-    (uuid 457cdfb2-3752-45eb-b5d6-ce0ff07e9ac0)
-  )
-  (wire (pts (xy 182.88 105.41) (xy 200.66 105.41))
-    (stroke (width 0) (type default))
-    (uuid 47be1a39-d70a-4f33-a0ab-499ba354ea6b)
-  )
-  (wire (pts (xy 102.87 83.82) (xy 102.87 72.39))
-    (stroke (width 0) (type default))
-    (uuid 48040dd8-9531-4efd-bd84-8149d36966dd)
-  )
-  (wire (pts (xy 193.04 142.24) (xy 195.58 142.24))
-    (stroke (width 0) (type default))
-    (uuid 4b68f706-c4c0-4f9c-a7c1-bf013460f703)
-  )
-  (wire (pts (xy 71.12 125.73) (xy 72.39 125.73))
-    (stroke (width 0) (type default))
-    (uuid 4c621942-d844-45ac-b71f-8da91498beb1)
-  )
-  (wire (pts (xy 210.82 118.11) (xy 210.82 120.65))
-    (stroke (width 0) (type default))
-    (uuid 4d0bb86b-e804-429f-b493-dd312f1af64d)
-  )
-  (wire (pts (xy 88.9 97.79) (xy 88.9 95.25))
-    (stroke (width 0) (type default))
-    (uuid 507f6922-8b22-40be-b478-c5e70d719de9)
-  )
-  (wire (pts (xy 140.97 121.92) (xy 137.16 121.92))
-    (stroke (width 0) (type default))
-    (uuid 50f822f4-3c82-42ef-bd94-aa376bb3f27c)
-  )
-  (wire (pts (xy 210.82 130.81) (xy 193.04 130.81))
-    (stroke (width 0) (type default))
-    (uuid 57d4cf39-3518-417c-b559-d8b60b0753f4)
-  )
-  (wire (pts (xy 86.36 106.68) (xy 100.33 106.68))
-    (stroke (width 0) (type default))
-    (uuid 5f818f40-bc5f-4799-8978-bd6206874f24)
-  )
-  (wire (pts (xy 88.9 101.6) (xy 88.9 100.33))
-    (stroke (width 0) (type default))
-    (uuid 5fe78b66-6b6c-45d9-8488-bc598d75abf6)
-  )
-  (wire (pts (xy 165.1 90.17) (xy 168.91 90.17))
-    (stroke (width 0) (type default))
-    (uuid 60221538-4531-404c-a894-257092e8bb27)
-  )
-  (wire (pts (xy 182.88 121.92) (xy 182.88 114.3))
-    (stroke (width 0) (type default))
-    (uuid 62e1ad2e-0990-4c0b-bafb-3b274b5b4944)
-  )
-  (wire (pts (xy 210.82 134.62) (xy 210.82 137.16))
-    (stroke (width 0) (type default))
-    (uuid 6506dc82-716f-4fd5-a0d4-199d69152753)
-  )
-  (wire (pts (xy 193.04 130.81) (xy 193.04 142.24))
-    (stroke (width 0) (type default))
-    (uuid 690a5a7a-57dd-4d5b-a3b3-ba1258617051)
-  )
-  (wire (pts (xy 165.1 105.41) (xy 172.72 105.41))
-    (stroke (width 0) (type default))
-    (uuid 6e2dd02a-067c-4b99-9197-e99aa22cac4a)
-  )
-  (wire (pts (xy 91.44 95.25) (xy 91.44 101.6))
-    (stroke (width 0) (type default))
-    (uuid 76122860-1c43-4964-b1e1-d4880d4636cf)
-  )
-  (wire (pts (xy 165.1 95.25) (xy 166.37 95.25))
-    (stroke (width 0) (type default))
-    (uuid 782e20c0-6291-4af1-a07f-34a2e0c467ff)
-  )
-  (wire (pts (xy 176.53 87.63) (xy 213.36 87.63))
-    (stroke (width 0) (type default))
-    (uuid 783ff210-7a12-4310-837a-499339aab7a6)
-  )
-  (wire (pts (xy 154.94 76.2) (xy 124.46 76.2))
-    (stroke (width 0) (type default))
-    (uuid 7a1a3c0c-623c-4aa0-8cfc-6b20c31299a2)
-  )
-  (wire (pts (xy 137.16 71.12) (xy 137.16 72.39))
-    (stroke (width 0) (type default))
-    (uuid 803362c2-98c3-4221-99db-f1398e5b3e68)
-  )
-  (wire (pts (xy 91.44 101.6) (xy 88.9 101.6))
-    (stroke (width 0) (type default))
-    (uuid 85cca698-de8b-4db2-b747-09ed71c2f9b5)
-  )
-  (wire (pts (xy 86.36 92.71) (xy 86.36 95.25))
-    (stroke (width 0) (type default))
-    (uuid 8b00ea2b-5db7-47ae-9572-6ce68a2d4e6c)
-  )
-  (wire (pts (xy 154.94 113.03) (xy 154.94 121.92))
-    (stroke (width 0) (type default))
-    (uuid 8cea07ce-7e86-4b2b-bd4d-ac854f717a26)
-  )
-  (wire (pts (xy 210.82 118.11) (xy 214.63 118.11))
-    (stroke (width 0) (type default))
-    (uuid 8d68be42-cfee-4cf1-a164-1231e1782a14)
-  )
-  (wire (pts (xy 124.46 72.39) (xy 124.46 76.2))
-    (stroke (width 0) (type default))
-    (uuid 8e0d11c1-07db-4b8f-89bc-8720807bf879)
-  )
-  (wire (pts (xy 133.35 72.39) (xy 137.16 72.39))
-    (stroke (width 0) (type default))
-    (uuid 8e16f852-61cc-404c-a5c8-b494b0507b47)
-  )
-  (wire (pts (xy 129.54 121.92) (xy 125.73 121.92))
-    (stroke (width 0) (type default))
-    (uuid 91f07ea3-bbe3-4a07-bfcd-819ee53aa2c0)
-  )
-  (wire (pts (xy 193.04 143.51) (xy 193.04 142.24))
-    (stroke (width 0) (type default))
-    (uuid 93d27333-2186-4ac0-94f7-c357620694d6)
-  )
-  (wire (pts (xy 152.4 82.55) (xy 152.4 78.74))
-    (stroke (width 0) (type default))
-    (uuid 94f838cb-93ee-481b-9b2b-6e211669a6dc)
-  )
-  (wire (pts (xy 210.82 149.86) (xy 219.71 149.86))
-    (stroke (width 0) (type default))
-    (uuid 954de25c-f15d-458e-8404-2b57aa4e7441)
-  )
-  (wire (pts (xy 125.73 72.39) (xy 124.46 72.39))
-    (stroke (width 0) (type default))
-    (uuid 9b9d7432-f1ab-4c6e-83da-e65281b39557)
-  )
-  (wire (pts (xy 172.72 105.41) (xy 172.72 125.73))
-    (stroke (width 0) (type default))
-    (uuid 9d3fe42c-ee57-43a9-bfba-3ced69d82758)
-  )
-  (wire (pts (xy 189.23 134.62) (xy 189.23 125.73))
-    (stroke (width 0) (type default))
-    (uuid 9d5ae90f-056d-48cd-827a-8aca4600ba0c)
-  )
-  (wire (pts (xy 210.82 149.86) (xy 210.82 147.32))
-    (stroke (width 0) (type default))
-    (uuid a316584e-3748-4384-9d2f-613b41ceb788)
-  )
-  (wire (pts (xy 161.29 76.2) (xy 168.91 76.2))
-    (stroke (width 0) (type default))
-    (uuid a35954f0-273a-4bc5-8a22-edd970d1bc77)
-  )
-  (wire (pts (xy 114.3 121.92) (xy 114.3 123.19))
-    (stroke (width 0) (type default))
-    (uuid a768b942-6431-4eec-80a6-63f071fcbea4)
-  )
-  (wire (pts (xy 154.94 76.2) (xy 161.29 76.2))
-    (stroke (width 0) (type default))
-    (uuid a82764e4-e741-4b36-9f58-1e3c3342efc0)
-  )
-  (wire (pts (xy 87.63 81.28) (xy 97.79 81.28))
-    (stroke (width 0) (type default))
-    (uuid a8b9cce2-a504-4a88-84bf-aad408727dd6)
-  )
-  (wire (pts (xy 97.79 83.82) (xy 102.87 83.82))
-    (stroke (width 0) (type default))
-    (uuid ad5c16a8-1e16-4be5-9fb3-b07cf06c6650)
-  )
-  (wire (pts (xy 120.65 87.63) (xy 120.65 86.36))
-    (stroke (width 0) (type default))
-    (uuid b171fe08-bb2d-4a26-97f9-bbbe133254ff)
-  )
-  (wire (pts (xy 205.74 76.2) (xy 213.36 76.2))
-    (stroke (width 0) (type default))
-    (uuid b6667a4c-0a26-4633-ae0c-2d275f9d28d6)
-  )
-  (wire (pts (xy 72.39 125.73) (xy 72.39 129.54))
-    (stroke (width 0) (type default))
-    (uuid b882f116-7ec8-40a2-9799-936e468ffbf6)
-  )
-  (wire (pts (xy 182.88 105.41) (xy 182.88 106.68))
-    (stroke (width 0) (type default))
-    (uuid c2c51d00-cbde-45e3-b4da-4cf590dd33d6)
-  )
-  (wire (pts (xy 229.87 86.36) (xy 229.87 90.17))
-    (stroke (width 0) (type default))
-    (uuid c30321dd-eb9e-4da9-bb0a-0cb62fc30cfc)
-  )
-  (wire (pts (xy 166.37 101.6) (xy 166.37 95.25))
-    (stroke (width 0) (type default))
-    (uuid ca1ec569-8515-4eb5-98bd-841eca3b045f)
-  )
-  (wire (pts (xy 166.37 101.6) (xy 182.88 101.6))
-    (stroke (width 0) (type default))
-    (uuid cb8e9d58-1259-448f-9f96-e9f625c8e08e)
-  )
-  (wire (pts (xy 168.91 72.39) (xy 168.91 76.2))
-    (stroke (width 0) (type default))
-    (uuid cc3a1477-4269-4c0d-8886-16b167321603)
-  )
-  (wire (pts (xy 100.33 114.3) (xy 100.33 116.84))
-    (stroke (width 0) (type default))
-    (uuid cc9c33c0-ab99-4cd5-8841-2760ae81c4d4)
-  )
-  (wire (pts (xy 137.16 86.36) (xy 137.16 87.63))
-    (stroke (width 0) (type default))
-    (uuid dde21631-e131-4d01-8656-dcbf622acde1)
-  )
-  (wire (pts (xy 120.65 76.2) (xy 120.65 78.74))
-    (stroke (width 0) (type default))
-    (uuid ddf47ef2-bf0b-4e1e-b6b7-e1ac4a0e4867)
-  )
-  (wire (pts (xy 97.79 83.82) (xy 97.79 81.28))
-    (stroke (width 0) (type default))
-    (uuid e2ab96b0-7f28-480f-a07a-807f28b4f9cb)
-  )
-  (wire (pts (xy 167.64 107.95) (xy 167.64 143.51))
-    (stroke (width 0) (type default))
-    (uuid e5589bec-599a-4e82-9311-d9d01fc86d1a)
-  )
-  (wire (pts (xy 137.16 72.39) (xy 137.16 78.74))
-    (stroke (width 0) (type default))
-    (uuid e6a50677-859c-4d5b-bc7b-f2eda18b033d)
-  )
-  (wire (pts (xy 229.87 90.17) (xy 168.91 90.17))
-    (stroke (width 0) (type default))
-    (uuid e6ee5c63-5c8f-48ac-8d3e-906db9e9eaee)
-  )
-  (wire (pts (xy 168.91 76.2) (xy 198.12 76.2))
-    (stroke (width 0) (type default))
-    (uuid e984bb22-b30f-4981-9f74-4d24d9506601)
-  )
-  (wire (pts (xy 109.22 72.39) (xy 102.87 72.39))
-    (stroke (width 0) (type default))
-    (uuid ea675666-3cf5-4c13-a9ad-d5d5c3159fcf)
-  )
-  (wire (pts (xy 86.36 97.79) (xy 86.36 100.33))
-    (stroke (width 0) (type default))
-    (uuid ec824190-0d4d-408f-b8fe-6db81e0bd7a0)
-  )
-  (wire (pts (xy 182.88 101.6) (xy 182.88 105.41))
-    (stroke (width 0) (type default))
-    (uuid f7555c16-d83e-4374-8e93-15c53a1a69e1)
-  )
-  (wire (pts (xy 92.71 116.84) (xy 92.71 118.11))
-    (stroke (width 0) (type default))
-    (uuid f900e17c-0038-42c3-901d-5dae08acd341)
-  )
-  (wire (pts (xy 210.82 134.62) (xy 189.23 134.62))
-    (stroke (width 0) (type default))
-    (uuid fbf70be2-0dc2-452d-b39e-84adb87784e5)
-  )
-  (wire (pts (xy 106.68 76.2) (xy 106.68 78.74))
-    (stroke (width 0) (type default))
-    (uuid ffed6893-60d8-4fa2-a352-5d318dbe77bd)
-  )
-
-  (image (at 251.46 173.99) (scale 0.75)
-    (uuid 1e30b73f-0a9f-493c-ad6d-e703f38be3c8)
-    (data
-      iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz
-      AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h
-      aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73
-      +/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs
-      bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA
-      xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y
-      Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h
-      xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO
-      GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful
-      fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv
-      4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ
-      EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R
-      Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM
-      vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H
-      cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0
-      6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT
-      O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA
-      4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86
-      sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+
-      oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/
-      55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0
-      qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+
-      KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn
-      Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4
-      mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii
-      P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr
-      voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6
-      bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO
-      h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da
-      4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y
-      YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC
-      0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP
-      SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb
-      WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw
-      v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay
-      PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX
-      Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh
-      oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD
-      7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da
-      43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l
-      zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl
-      pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS
-      H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV
-      ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY
-      MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2
-      NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx
-      fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl
-      tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew
-      iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj
-      jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI
-      cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo
-      XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R
-      9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv
-      8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV
-      RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY
-      l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf
-      YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN
-      EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU
-      sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z
-      7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs
-      OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs
-      qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7
-      G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6
-      wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7
-      zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln
-      Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX
-      apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk
-      lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw
-      TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb
-      54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID
-      qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd
-      P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l
-      UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD
-      zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH
-      Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1
-      QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/
-      ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX
-      08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC
-      KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ
-      SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu
-      h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp
-      VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf
-      G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK
-      dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO
-      uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2
-      DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn
-      byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc
-      dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N
-      iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP
-      NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4
-      wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8
-      K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s
-      xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS
-      Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC
-      Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5
-      m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm
-      aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj
-      gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn
-      p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL
-      ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx
-      u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+
-      FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa
-      ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h
-      1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj
-      DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy
-      +Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj
-      wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj
-      7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ
-      lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN
-      2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY
-      CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi
-      mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E
-      uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x
-      j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD
-      45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO
-      4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni
-      buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY
-      HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH
-      NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ
-      azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N
-      SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP
-      hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe
-      nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4
-      b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN
-      xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S
-      pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq
-      3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB
-      Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL
-      4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw
-      qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX
-      9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n
-      frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/
-      eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK
-      TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u
-      RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9
-      DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j
-      2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx
-      BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy
-      91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7
-      jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw
-      pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ
-      cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M
-      xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23
-      7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8
-      D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw
-      YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu
-      QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs
-      uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA
-      PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6
-      yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN
-      xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq
-      JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT
-      +HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg
-      hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K
-      hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt
-      g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z
-      5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf
-      u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO
-      Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG
-      gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK
-      hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x
-      moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56
-      KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp
-      ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz
-      eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO
-      0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA
-      BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ
-      2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB
-      4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF
-      6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI
-      gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv
-      OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt
-      8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI
-      bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM
-      500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4
-      CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V
-      aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5
-      yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF
-      zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss
-      tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q
-      r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj
-      xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h
-      6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y
-      9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE
-      XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh
-      oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk
-      Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4
-      ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW
-      zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr
-      wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV
-      BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7
-      LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr
-      owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX
-      hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j
-      1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF
-      5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw
-      a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6
-      Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN
-      +SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds
-      lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ
-      i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu
-      fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy
-      r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28
-      dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az
-      70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk
-      EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL
-      p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf
-      nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA
-      ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c
-      q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu
-      Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR
-      TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53
-      en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA
-      x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ
-      t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+
-      R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf
-      5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH
-      e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG
-      po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh
-      6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln
-      9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU
-      xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ
-      rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W
-      lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb
-      afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs
-      FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR
-      OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC
-      P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp
-      EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh
-      6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK
-      GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ
-      hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s
-      amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+
-      fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij
-      TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv
-      I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf
-      kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ
-      BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD
-      9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn
-      jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8
-      I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI
-      8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs
-      Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN
-      MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5
-      2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU
-      2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss
-      ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m
-      sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq
-      LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT
-      tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9
-      oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p
-      zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu
-      WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy
-      diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX
-      ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY
-      5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau
-      Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7
-      oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG
-      xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q
-      zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik
-      sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN
-      ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc
-      MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E
-      YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3
-      bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz
-      DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC
-      TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES
-      3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K
-      Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd
-      b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5
-      99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys
-      7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa
-      Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e
-      8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1
-      vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK
-      VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4
-      ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD
-      CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4
-      qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr
-      1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe
-      GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK
-      yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj
-      po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO
-      Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF
-      tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D
-      mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM
-      eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN
-      veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu
-      5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL
-      Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t
-      rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl
-      sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx
-      mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG
-      PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk
-      Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk
-      caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO
-      jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS
-      gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E
-      OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+
-      p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO
-      cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM
-      S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc
-      vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3
-      boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn
-      DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD
-      90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw
-      0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT
-      5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI
-      7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP
-      QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw
-      oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E
-      mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/
-      N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm
-      vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC
-      +OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp
-      gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz
-      gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni
-      R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3
-      j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo
-      BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl
-      IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4
-      jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA
-      Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS
-      AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz
-      6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H
-      qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp
-      cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa
-      M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv
-      4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M
-      IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD
-      Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r
-      un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr
-      2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/
-      kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF
-      7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8
-      YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk
-      zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp
-      8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF
-      o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt
-      Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA
-      hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx
-      LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk
-      iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2
-      HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5
-      K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo
-      XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/
-      D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j
-      MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c
-      O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB
-      fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X
-      /V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI
-      a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe
-      L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37
-      zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY
-      BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE
-      RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg==
-    )
-  )
-
-  (text "NULL MODEM" (at 165.1 81.28 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 08c8d1cd-9d4e-47e6-ac76-31d9cbf4878c)
-  )
-  (text "TX is Output\nRX is Input\n/CTS is Input\n/RTS is Output"
-    (at 234.95 95.25 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 23269888-a804-4aa1-80f3-b5a8e131503e)
-  )
-  (text "D501 indicates when data is transmitted.\nThe serial port sends ongoing status indication, \nhigh level is active.\n\n"
-    (at 100.33 137.16 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 555d1f8b-3550-4ae2-9491-ef5874efaaea)
-  )
-  (text "Place R503 near uControler TX pin." (at 177.8 93.98 0)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid b57351e4-41ae-45ff-a37e-f2035559407f)
-  )
-  (text "The DTR# pin of CH340 is used as a configuration input pin before the USB configuration is complete. An \nexternal 4.7KΩ pull-down resistor (R217) can be connected with this pin to generate default low level during USB \nenumeration, apply larger supply current to the USB bus via the configuration descriptor."
-    (at 170.18 158.75 0)
-    (effects (font (size 1.27 1.27)) (justify right bottom))
-    (uuid d9ca0c74-d524-40b1-a434-051dc2431702)
-  )
-
-  (label "3V3USB" (at 173.99 76.2 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 0cc13057-a985-41d9-954c-763c334e2e42)
-  )
-  (label "V3" (at 147.32 78.74 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left bottom))
-    (uuid 15ea67a3-fec9-41b4-8e68-df2d2e02838e)
-  )
-
-  (hierarchical_label "nRESET" (shape passive) (at 214.63 118.11 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 1c1cdf6d-f79d-4853-937d-844a81bb7912)
-  )
-  (hierarchical_label "VBus" (shape input) (at 212.09 66.04 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 1c800099-bc25-41c1-b867-0ccea2f5a251)
-  )
-  (hierarchical_label "GPIO0" (shape passive) (at 219.71 149.86 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 5f62c175-5a1c-4a13-b81f-43d0fc4ac888)
-  )
-  (hierarchical_label "ControllerRX" (shape output) (at 213.36 87.63 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 83f490d0-dd95-42b4-b7b7-782fcd3bcf15)
-  )
-  (hierarchical_label "3v3" (shape input) (at 213.36 76.2 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid dba2663a-98a6-4848-9109-561661badead)
-  )
-  (hierarchical_label "ControllerTX" (shape input) (at 212.09 96.52 0) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid ef01fced-de3a-48d0-9650-12cbfe6b1dba)
-  )
-
-  (symbol (lib_id "Device:R") (at 172.72 87.63 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062be3195)
-    (property "Reference" "R502" (at 171.45 82.55 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 172.72 85.09 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 172.72 85.852 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 172.72 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 172.72 87.63 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 172.72 87.63 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 172.72 87.63 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 172.72 87.63 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 172.72 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 172.72 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 172.72 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 172.72 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 172.72 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9352e332-f0aa-4468-932e-f7f94ca421aa))
-    (pin "2" (uuid c02d29a2-4bfd-46f9-ac78-a16d7bb40054))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R502") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 172.72 96.52 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062be31a0)
-    (property "Reference" "R503" (at 171.45 91.44 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 172.72 93.98 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 172.72 94.742 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 172.72 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 172.72 96.52 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 172.72 96.52 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 172.72 96.52 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 172.72 96.52 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 172.72 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 172.72 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 172.72 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 172.72 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 172.72 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd369641-4abd-4121-a609-72445d7a2682))
-    (pin "2" (uuid a02b5693-4db3-42d3-83d5-35dbe8bbec58))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R503") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 137.16 82.55 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062be31b2)
-    (property "Reference" "C503" (at 140.081 81.3816 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 140.081 83.693 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 138.1252 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 137.16 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 137.16 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 137.16 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 137.16 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 137.16 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 137.16 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 137.16 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 137.16 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 137.16 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 137.16 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9f5cfd73-f67a-4cf1-b146-4d071ed80c06))
-    (pin "2" (uuid 911f4b12-ce17-47db-a0c8-26b7006ca061))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "C503") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C_Polarized") (at 120.65 82.55 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062be31c2)
-    (property "Reference" "C502" (at 123.6472 81.3816 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "47uF 16V" (at 123.6472 83.693 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4" (at 121.6152 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 120.65 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 120.65 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2895272" (at 120.65 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "KNSCHA" (at 120.65 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RVT47UF16V67RV0019" (at 120.65 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 120.65 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.038" (at 120.65 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS" (at 120.65 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 120.65 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 120.65 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 138131f2-27b8-4159-a441-04ace852918c))
-    (pin "2" (uuid dd34936a-c1bb-429b-8c41-208c87de4a8e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "C502") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:C") (at 106.68 82.55 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062be31cd)
-    (property "Reference" "C501" (at 109.601 81.3816 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "100nF" (at 109.601 83.693 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder" (at 107.6452 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 106.68 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 106.68 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C14663" (at 106.68 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "YAGEO" (at 106.68 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CC0603KRX7R9BB104" (at 106.68 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS" (at 106.68 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 106.68 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0021" (at 106.68 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 106.68 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 106.68 82.55 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f4d65384-8043-4293-ac2f-ea9abe61b1be))
-    (pin "2" (uuid 0fba8e4b-ba8e-4ab9-a371-11348b3b15ec))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "C501") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 133.35 121.92 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062be31ed)
-    (property "Reference" "R501" (at 132.08 116.84 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "330R" (at 133.35 119.38 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 133.35 120.142 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 133.35 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 133.35 121.92 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269711" (at 133.35 121.92 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 133.35 121.92 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC06033301%N" (at 133.35 121.92 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS" (at 133.35 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 133.35 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 133.35 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 133.35 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 133.35 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7c46793d-ce23-4c4a-a792-d1be1ec93f74))
-    (pin "2" (uuid 3d4b5b39-d571-4e3e-a0ce-b783786c6705))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R501") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:LED") (at 121.92 121.92 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062be31fb)
-    (property "Reference" "D501" (at 123.19 119.38 0)
-      (effects (font (size 1.524 1.524)))
-    )
-    (property "Value" "RED 0603" (at 124.46 124.46 0)
-      (effects (font (size 1.524 1.524)))
-    )
-    (property "Footprint" "LED_SMD:LED_0603_1608Metric" (at 121.92 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 121.92 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 121.92 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C2286" (at 127 132.08 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "KT-0603R" (at 127 134.62 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Optoelectronics" (at 127 137.16 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "LED Indication - Discrete" (at 127 139.7 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "LED RED CLEAR SMD" (at 127 147.32 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Hubei KENTO Elec" (at 127 149.86 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 127 152.4 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "SMT" (at 121.92 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0054" (at 121.92 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 121.92 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 121.92 121.92 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 78915f80-996b-48ed-bf0a-0e4a01ea1d2c))
-    (pin "2" (uuid 246d5ebe-4911-435b-90d0-eb2af4f12ae1))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "D501") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 182.88 110.49 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00000000-0000-0000-0000-000062be320c)
-    (property "Reference" "R504" (at 186.69 109.22 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 186.69 111.76 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 184.658 110.49 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 182.88 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 182.88 110.49 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 182.88 110.49 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 182.88 110.49 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 182.88 110.49 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 182.88 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 182.88 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 182.88 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 182.88 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 182.88 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ce47349e-9b83-41ac-b2f2-0d3109eb9322))
-    (pin "2" (uuid db207fb4-184a-46ed-9c3e-520a09006685))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R504") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 201.93 76.2 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0337563e-c4c6-4c4a-bc15-49f7e2e14351)
-    (property "Reference" "R1" (at 203.2 71.12 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1R0" (at 201.93 73.66 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 201.93 74.422 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 201.93 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 201.93 76.2 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 201.93 76.2 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 201.93 76.2 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 201.93 76.2 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 201.93 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 201.93 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 201.93 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 201.93 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 201.93 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 453ce998-aab9-4630-9b00-2577498741a9))
-    (pin "2" (uuid 461f9f20-837c-4f85-905b-0a6cde030a0e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R1") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R216") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 120.65 87.63 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 17e367da-3f31-499a-bdfb-2c008e6ec973)
-    (property "Reference" "#PWR0108" (at 120.65 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 120.65 92.71 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 120.65 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 120.65 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 780cdb9d-7e88-43d0-b30b-4ea5968b1861))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "#PWR0215") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 72.39 129.54 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 195b144a-de1f-48cb-998b-9b75c0b764b0)
-    (property "Reference" "#PWR0108" (at 72.39 135.89 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 72.39 134.62 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 72.39 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 72.39 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 109b69db-810a-4c70-94cd-85fbba5a20f3))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "#PWR0209") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 172.72 154.94 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp yes)
-    (uuid 2b0ff883-c1ba-4e06-946c-4567e28994fb)
-    (property "Reference" "R217" (at 176.53 153.67 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "4K7" (at 176.53 156.21 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 174.498 154.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 172.72 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 172.72 154.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269713" (at 172.72 154.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 172.72 154.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 4K7 F N" (at 172.72 154.94 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 172.72 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 172.72 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 172.72 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 172.72 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 172.72 154.94 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9bd92741-64d1-42f5-ba26-b8dd18bcf5df))
-    (pin "2" (uuid 3c53376a-c5e9-4152-bd2c-0939470b2818))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R217") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 229.87 86.36 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 30e9c6c3-f1c0-4c64-8b14-fce9ca0c5089)
-    (property "Reference" "TP404" (at 229.87 80.01 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "U0_TX" (at 231.14 82.55 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 234.95 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 234.95 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 229.87 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 229.87 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 229.87 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 229.87 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 229.87 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 229.87 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 229.87 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 229.87 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 229.87 86.36 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6f0dffe3-7d61-4ef4-91d0-c2f8fe4632d8))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b871ee"
-          (reference "TP404") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "TP107") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "TP206") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 137.16 87.63 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3b8dc387-9564-4c9c-bb0f-81e5181224e0)
-    (property "Reference" "#PWR0108" (at 137.16 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 137.16 92.71 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 137.16 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 137.16 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 430630e9-cab2-47f9-b20f-426dd32c6290))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "#PWR0214") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "power:PWR_FLAG") (at 161.29 74.93 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 47c7159a-a915-4fec-8db7-cf2c314e8191)
-    (property "Reference" "#FLG0101" (at 161.29 73.025 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "PWR_FLAG" (at 158.75 69.85 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 161.29 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 161.29 74.93 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d9095c5d-04bc-48b0-bf6f-4581f2d814f6))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#FLG0101") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "#FLG0201") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 102.87 72.39 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 4d49e72a-82c3-4f7f-a0d6-3ebdc8952d81)
-    (property "Reference" "TP201" (at 104.14 68.58 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "VBus" (at 104.14 71.12 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 107.95 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 107.95 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 102.87 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Red" (at 102.87 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 102.87 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 102.87 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 102.87 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 102.87 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 102.87 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 102.87 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 102.87 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c2a301a8-f277-4252-8de3-21e7accd45c9))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "TP201") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 129.54 72.39 270) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 5837f945-0631-444b-943b-017afe300c6f)
-    (property "Reference" "R1" (at 128.27 67.31 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1R0" (at 129.54 69.85 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 129.54 70.612 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 129.54 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 129.54 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269434" (at 129.54 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 129.54 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC060315%N" (at 129.54 72.39 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS" (at 129.54 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 129.54 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 129.54 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 129.54 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 129.54 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 692c7983-b42a-469e-bf08-507802487ba6))
-    (pin "2" (uuid 7c6390fd-031c-4775-ab78-01d051854006))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R1") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R213") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 137.16 71.12 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 5d43196d-d659-4f19-9c48-4fbf1939a3e8)
-    (property "Reference" "TP202" (at 138.43 67.31 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "V3" (at 138.43 69.85 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 142.24 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 142.24 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 137.16 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Red" (at 137.16 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 137.16 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 137.16 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 137.16 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 137.16 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 137.16 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 137.16 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 137.16 71.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 48131a03-7f42-4499-9fcd-0560c47f68f6))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "TP202") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:CH340B") (at 154.94 97.79 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 651860ec-5ba1-44df-8ca5-5c645d270337)
-    (property "Reference" "U501" (at 156.8959 113.03 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "CH340B" (at 156.8959 115.57 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "Package_SO:SOIC-16_3.9x9.9mm_P1.27mm" (at 156.21 111.76 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-    (property "Datasheet" "https://datasheet.lcsc.com/szlcsc/Jiangsu-Qin-Heng-CH340C_C84681.pdf" (at 146.05 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "1.05" (at 154.94 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 154.94 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C81010" (at 154.94 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 154.94 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "2Mbps 3.3V Transceiver USB 2.0 SOP-16 USB Converters ROHS" (at 154.94 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "CH340B" (at 154.94 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b7869023-6eb0-4330-ac25-b03239b6bf0d))
-    (pin "10" (uuid df8615f4-3e97-4174-8f37-81a60079ae55))
-    (pin "11" (uuid b96f53e0-beb6-4490-b583-f096d90f55d9))
-    (pin "12" (uuid 0545a296-ef88-4eef-9a88-e07c2967992d))
-    (pin "13" (uuid 1e4d1d11-82f8-46c2-be32-cc89ec80c769))
-    (pin "14" (uuid a5db1bb3-74fe-4663-88e1-248809a04bfa))
-    (pin "15" (uuid 8d86b5d6-e62d-414c-a3fd-6fa1a666c169))
-    (pin "16" (uuid 3626cec7-3e18-4f6f-a036-283d15e5a6ba))
-    (pin "2" (uuid 8a0ec365-4830-4e98-b9c3-470e0e6f0666))
-    (pin "3" (uuid f1ab468e-14cd-4776-b353-5abcf71f970a))
-    (pin "4" (uuid be12b52d-8c0c-486b-a337-c8819efdb2b2))
-    (pin "5" (uuid 116507d4-9466-4c3e-a442-ac7115e1d77e))
-    (pin "6" (uuid d41b0817-49da-4025-a477-39746732769b))
-    (pin "7" (uuid b3a9cbce-4480-4b9d-bd57-e298002daebf))
-    (pin "8" (uuid 9f344d54-e6e8-414a-871e-9857deb13bef))
-    (pin "9" (uuid 5096c712-fe17-424b-b921-65e9cea78550))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "U501") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 199.39 125.73 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 763878f0-6530-40ac-839d-ef5d0582c474)
-    (property "Reference" "R505" (at 200.66 120.65 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "10K" (at 199.39 123.19 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 199.39 123.952 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 199.39 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 199.39 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269701" (at 199.39 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 199.39 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 10K F N" (at 199.39 125.73 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS" (at 199.39 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 199.39 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 199.39 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 199.39 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 199.39 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 43dfb2a0-bdc4-455d-85df-a590b428e8c4))
-    (pin "2" (uuid f4c03a40-b872-433d-a6ca-f5ed3664e9ee))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "R505") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R999") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R214") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MMBT2222A-7-F") (at 208.28 125.73 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 8d66a63c-27aa-4ae4-9d71-c16aadfac842)
-    (property "Reference" "Q205" (at 213.0552 124.3838 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "MMBT2222A-7-F" (at 213.0552 127.0762 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 213.36 120.65 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 213.36 118.11 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "MMBT2222A-FDICT-ND" (at 213.36 115.57 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "MMBT2222A-7-F" (at 213.36 113.03 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Discrete Semiconductor Products" (at 213.36 110.49 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Transistors - Bipolar (BJT) - Single" (at 213.36 107.95 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 213.36 105.41 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723" (at 213.36 102.87 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3" (at 213.36 100.33 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Diodes Incorporated" (at 213.36 97.79 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 213.36 95.25 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "SMT" (at 208.28 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 208.28 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C94515" (at 208.28 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0475" (at 208.28 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 208.28 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 208.28 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9de47db2-25f1-4dbb-a489-2724d96d2deb))
-    (pin "2" (uuid e696176b-33f2-4bd4-8009-90e683aadee0))
-    (pin "3" (uuid b0b81a3e-ed38-4a48-afa1-132ca12db330))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "Q205") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "Q206") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_2") (lib_id "power:GND") (at 172.72 158.75 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 991d9664-ba6b-47ce-85ac-b2614cfea5bc)
-    (property "Reference" "#PWR0202" (at 172.72 165.1 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 172.72 163.83 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 172.72 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 172.72 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5cea170e-2dae-436f-8aa0-89ac9a277071))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "#PWR0202") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 106.68 87.63 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9b3143cb-31dc-426d-a493-fdceb5864767)
-    (property "Reference" "#PWR0108" (at 106.68 93.98 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 106.68 92.71 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 106.68 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 106.68 87.63 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6320641e-15e0-4b74-8e82-4c8ccd60cee3))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "#PWR0216") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:MMBT2222A-7-F") (at 208.28 142.24 0) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid a7787a17-8e2a-4f13-a9fb-59b893afa936)
-    (property "Reference" "Q205" (at 213.0552 143.5862 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Value" "MMBT2222A-7-F" (at 213.0552 140.8938 0)
-      (effects (font (size 1.524 1.524)) (justify left))
-    )
-    (property "Footprint" "Package_TO_SOT_SMD:SOT-23" (at 213.36 147.32 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 213.36 149.86 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Digi-Key_PN" "MMBT2222A-FDICT-ND" (at 213.36 152.4 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "MPN" "MMBT2222A-7-F" (at 213.36 154.94 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Category" "Discrete Semiconductor Products" (at 213.36 157.48 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Family" "Transistors - Bipolar (BJT) - Single" (at 213.36 160.02 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf" (at 213.36 162.56 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723" (at 213.36 165.1 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3" (at 213.36 167.64 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Manufacturer" "Diodes Incorporated" (at 213.36 170.18 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "Status" "Active" (at 213.36 172.72 0)
-      (effects (font (size 1.524 1.524)) (justify left) hide)
-    )
-    (property "AssemblyType" "SMT" (at 208.28 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 208.28 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C94515" (at 208.28 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0475" (at 208.28 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 208.28 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 208.28 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3e8adfde-59c4-4124-bb82-f9f909a157f6))
-    (pin "2" (uuid fad493a7-65af-4e19-9418-09f9b19e8da5))
-    (pin "3" (uuid 1a11390f-a32a-4d1e-b24b-55f508774e4e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062b3ac2f"
-          (reference "Q205") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "Q207") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 200.66 105.41 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid addc1ab8-8672-45af-ab9e-760bc1b60a98)
-    (property "Reference" "TP203" (at 201.93 101.6 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "nCTS" (at 201.93 104.14 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 205.74 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 205.74 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 200.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 200.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 200.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 200.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 200.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 200.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 200.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 200.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 200.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 825c8662-d51a-436d-8d48-2ee00736ad83))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "TP203") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 100.33 110.49 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid ae29f84e-a2f6-4065-8ed8-dbc76672bccd)
-    (property "Reference" "R212" (at 104.14 109.22 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "5K1" (at 104.14 111.76 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 102.108 110.49 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 100.33 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 100.33 110.49 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C23186" (at 100.33 110.49 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "UNI-ROYAL(Uniroyal Elec)" (at 100.33 110.49 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "0603WAF5101T5E" (at 100.33 110.49 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "100mW Thick Film Resistors 75V ±100ppm/℃ ±1% 5.1kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 100.33 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 100.33 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0009" (at 100.33 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 100.33 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 100.33 110.49 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7685b497-53ad-4cf0-bbef-c6c09492c88b))
-    (pin "2" (uuid aef29479-a10f-4265-bb56-67df81dfbeee))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R212") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 92.71 118.11 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b7e3b7ea-0615-44e6-8312-7172c2961a07)
-    (property "Reference" "#PWR0108" (at 92.71 124.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 92.71 123.19 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 92.71 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 92.71 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c9763270-0c86-4a56-ac61-4c0d1f633c8d))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "#PWR0210") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 168.91 72.39 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid bcdd210b-9cb0-46a4-b4a0-7f3b3379c8b9)
-    (property "Reference" "TP205" (at 170.18 68.58 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "3V3USB" (at 170.18 71.12 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 173.99 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 173.99 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 168.91 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Red" (at 168.91 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 168.91 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5277086" (at 168.91 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5000" (at 168.91 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 168.91 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0717" (at 168.91 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 168.91 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 168.91 72.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 77386e4d-ce50-49ce-a1fe-081d2e71fe38))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "TP205") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Connector:TestPoint") (at 130.81 105.41 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid c935664c-f18e-4a0f-833e-e866d06d4718)
-    (property "Reference" "TP204" (at 132.08 101.6 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Value" "nRST" (at 132.08 104.14 0)
-      (effects (font (size 1.27 1.27)) (justify left))
-    )
-    (property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded" (at 135.89 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 135.89 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "HAND" (at 130.81 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 130.81 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "Test Points/Test Rings 1.25 mm Yellow" (at 130.81 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C5199804" (at 130.81 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RH-5004" (at 130.81 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "ronghe" (at 130.81 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0800" (at 130.81 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 130.81 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 130.81 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 58a7d20d-9d05-4d87-bc2b-4c8990620edc))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "TP204") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 63.5 125.73 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d167c2a1-a3cf-42e0-9b80-44dcd5807359)
-    (property "Reference" "#PWR0108" (at 63.5 132.08 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 63.5 130.81 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 63.5 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 63.5 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid be373e66-dd36-4df5-974e-5c024007a0df))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "#PWR0208") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "GPAD_SCH_LIB:USB_C_Receptacle_USB2.0_GPAD") (at 71.12 102.87 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d1a30577-ae94-4552-be46-71ba6e28d972)
-    (property "Reference" "J501" (at 71.12 80.01 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "USB_C_Receptacle_USB2.0" (at 71.12 82.55 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "GeneralPurposeAlarmDevicePCB:USB_C_Receptacle_HRO_TYPE-C-31-M-12" (at 74.93 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip" (at 74.93 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 71.12 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C165948" (at 71.12 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.1529" (at 71.12 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "5A 1 16P Female Type-C SMD USB Connectors ROHS" (at 71.12 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "TYPE-C-31-M-12" (at 71.12 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "Korean Hroparts Elec" (at 71.12 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 71.12 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 71.12 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 71.12 102.87 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "A1" (uuid 8d06cbf4-605b-4a2a-a44e-ab01fe86b7ac))
-    (pin "A12" (uuid 8a12e76e-0250-4f32-b93e-f7e8ec44bccb))
-    (pin "A4" (uuid de77602b-b51f-4054-807f-bbf9d1512796))
-    (pin "A5" (uuid 82bd536f-1728-41ef-a08a-cf9f25a7e9da))
-    (pin "A6" (uuid 21e0d210-403c-450b-b2fe-56b6c96bf04a))
-    (pin "A7" (uuid 7eb2515b-28ae-46e6-bfaf-30393ae9cb1a))
-    (pin "A8" (uuid 3401cf78-5558-4e23-860f-afd5300ffae4))
-    (pin "A9" (uuid 829ccaf8-b964-489a-b969-8c021fcbf879))
-    (pin "B1" (uuid c47b1ef2-3340-4167-a784-d6980e78486d))
-    (pin "B12" (uuid 04a0ea92-7284-45ed-9933-707d8d4853e7))
-    (pin "B4" (uuid d276c622-62fd-481d-8ca0-4afb2ed9c8c9))
-    (pin "B5" (uuid 4aa0b612-314c-465a-bb67-d92d21a753c8))
-    (pin "B6" (uuid 8599623b-9d94-441b-a23b-a9bfc7231e7e))
-    (pin "B7" (uuid 37a4e73e-c573-448b-bdda-673539ae0ece))
-    (pin "B8" (uuid 80dd5fd3-a8e1-4a7f-8c32-55858503a8aa))
-    (pin "B9" (uuid 331a5815-19c6-4f14-80a2-31bd1fc605b4))
-    (pin "S1" (uuid d5d8f816-9677-436c-a228-0ccfa3837ad2))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "J501") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 92.71 113.03 180) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid db500334-6099-4374-8be2-9731a1983d33)
-    (property "Reference" "R211" (at 96.52 111.76 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "5K1" (at 96.52 114.3 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 94.488 113.03 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 92.71 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 92.71 113.03 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C23186" (at 92.71 113.03 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "UNI-ROYAL(Uniroyal Elec)" (at 92.71 113.03 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "0603WAF5101T5E" (at 92.71 113.03 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "100mW Thick Film Resistors 75V ±100ppm/℃ ±1% 5.1kΩ 0603 Chip Resistor - Surface Mount ROHS" (at 92.71 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 92.71 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0009" (at 92.71 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 92.71 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 92.71 113.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 51a587e4-88bd-4250-8801-f1b53cdddb40))
-    (pin "2" (uuid a8ef87b8-d02a-4cc9-b800-ff8d0f22fb6e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R211") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 154.94 127 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid dc1bb094-cd13-4500-8e27-9b6a496ffcc6)
-    (property "Reference" "#PWR0108" (at 154.94 133.35 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 154.94 132.08 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 154.94 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 154.94 127 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bef95e75-2f34-46ee-bf3d-e835b9b63e59))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "#PWR0213") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 114.3 123.19 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid eb715f3c-fb85-4735-a99d-b966ae1bd09d)
-    (property "Reference" "#PWR0108" (at 114.3 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 114.3 128.27 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 114.3 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 114.3 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0bb27faa-87c7-4397-ace0-e7bb0cdcfe2e))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "#PWR0212") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Device:R") (at 199.39 142.24 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid f67a2cda-6f06-4c0b-a9f3-3586466c0012)
-    (property "Reference" "R505" (at 200.66 137.16 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "10K" (at 199.39 139.7 90)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder" (at 199.39 140.462 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 199.39 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1" "JLCPCB" (at 199.39 142.24 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Distributor 1 PN" "C269701" (at 199.39 142.24 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer" "TyoHM" (at 199.39 142.24 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN" "RMC 0603 10K F N" (at 199.39 142.24 90)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS" (at 199.39 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "AssemblyType" "SMT" (at 199.39 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Cost" "0.0015" (at 199.39 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "MPN 2" "" (at 199.39 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Manufacturer 2" "" (at 199.39 142.24 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cfa1a174-46a3-4327-bfef-e2a0af36ab14))
-    (pin "2" (uuid a6212afc-b28d-448a-9dd7-78f87b844083))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062dd8e5f"
-          (reference "R505") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "R998") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "R215") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_name "GND_1") (lib_id "power:GND") (at 100.33 116.84 0) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fdce78bc-1119-4c56-8b36-b640d19e7eb1)
-    (property "Reference" "#PWR0108" (at 100.33 123.19 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Value" "GND" (at 100.33 121.92 0)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Footprint" "" (at 100.33 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "" (at 100.33 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a7094b9f-c6b7-489d-a348-6ab32aad6d91))
-    (instances
-      (project "PWA_REV2"
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf"
-          (reference "#PWR0108") (unit 1)
-        )
-        (path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
-          (reference "#PWR0211") (unit 1)
-        )
-      )
-    )
-  )
+(kicad_sch
+	(version 20251012)
+	(generator "eeschema")
+	(generator_version "9.99")
+	(uuid "305a2529-eeaf-4b46-ae3d-4f3d499b0060")
+	(paper "A4")
+	(title_block
+		(title "KRAKE_PCB")
+		(date "2025-07-18")
+		(rev "2.0")
+		(company "PublicInvention")
+		(comment 1 "GNU Affero General Public License v3.0")
+		(comment 2 "DrawnBy: (Forrest) Lee Erickson, Nagham Kheir")
+		(comment 3 "https://github.com/PubInv/krake")
+		(comment 4 "Inherited from the GPAD")
+	)
+	(lib_symbols
+		(symbol "Connector:TestPoint"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.762)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "TP"
+				(at 0 6.858 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "TestPoint"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 5.08 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 5.08 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "test point"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "test point tp"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "Pin* Test*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "TestPoint_0_1"
+				(circle
+					(center 0 3.302)
+					(radius 0.762)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "TestPoint_1_1"
+				(pin passive line
+					(at 0 0 90)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C_Polarized"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C_Polarized"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Polarized capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "CP_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_Polarized_0_1"
+				(rectangle
+					(start -2.286 0.508)
+					(end 2.286 1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 2.286) (xy -0.762 2.286)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 2.794) (xy -1.27 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 2.286 -0.508)
+					(end -2.286 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(symbol "C_Polarized_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:LED"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "LED"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Light emitting diode"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "LED diode"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "LED_0_1"
+				(polyline
+					(pts
+						(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 0) (xy 1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "LED_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GND_1"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND_1"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_1_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GND_2"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND_2"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_2_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_2_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:CH340B"
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "U"
+				(at -5.08 13.97 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Value" "CH340B"
+				(at 1.27 13.97 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "Package_SO:SOIC-16_3.9x9.9mm_P1.27mm"
+				(at 1.27 -13.97 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "https://datasheet.lcsc.com/szlcsc/Jiangsu-Qin-Heng-CH340C_C84681.pdf"
+				(at -8.89 20.32 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "USB serial converter, UART, SOIC-16"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "USB UART Serial Converter Interface"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "SOIC*3.9x9.9mm*P1.27mm*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "CH340B_0_1"
+				(rectangle
+					(start -7.62 12.7)
+					(end 7.62 -12.7)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+			)
+			(symbol "CH340B_1_1"
+				(pin power_in line
+					(at 0 -15.24 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 10.16 0 180)
+					(length 2.54)
+					(name "~{DSR}"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 10.16 -2.54 180)
+					(length 2.54)
+					(name "~{RI}"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 10.16 -5.08 180)
+					(length 2.54)
+					(name "~{DCD}"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 10.16 -7.62 180)
+					(length 2.54)
+					(name "~{DTR}"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 10.16 -10.16 180)
+					(length 2.54)
+					(name "~{RTS}"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at -10.16 7.62 0)
+					(length 2.54)
+					(name "TNOW"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 15.24 270)
+					(length 2.54)
+					(name "VCC"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 10.16 10.16 180)
+					(length 2.54)
+					(name "TXD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 10.16 7.62 180)
+					(length 2.54)
+					(name "RXD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -2.54 15.24 270)
+					(length 2.54)
+					(name "V3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -10.16 2.54 0)
+					(length 2.54)
+					(name "UD+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -10.16 0 0)
+					(length 2.54)
+					(name "UD-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -10.16 -7.62 0)
+					(length 2.54)
+					(name "RST#"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin no_connect line
+					(at -10.16 -10.16 0)
+					(length 2.54)
+					(name "NC"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 10.16 2.54 180)
+					(length 2.54)
+					(name "~{CTS}"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:MMBT2222A-7-F"
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "Q"
+				(at -3.2004 4.2164 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "MMBT2222A-7-F"
+				(at 5.2324 0 90)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+				(at 5.08 5.08 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+				(at 5.08 7.62 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3"
+				(at 5.08 25.4 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Digi-Key_PN" "MMBT2222A-FDICT-ND"
+				(at 5.08 10.16 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "MPN" "MMBT2222A-7-F"
+				(at 5.08 12.7 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Category" "Discrete Semiconductor Products"
+				(at 5.08 15.24 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Family" "Transistors - Bipolar (BJT) - Single"
+				(at 5.08 17.78 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+				(at 5.08 20.32 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723"
+				(at 5.08 22.86 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Manufacturer" "Diodes Incorporated"
+				(at 5.08 27.94 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "Status" "Active"
+				(at 5.08 30.48 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+					(justify left)
+				)
+			)
+			(property "ki_keywords" "MMBT2222A-FDICT-ND Automotive, AEC-Q101"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "MMBT2222A-7-F_0_1"
+				(polyline
+					(pts
+						(xy -3.81 0) (xy -2.54 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.556 0) (xy 0 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy 0 -2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 1.27) (xy 2.54 2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 0)
+					(radius 3.2512)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -1.27) (xy 2.54 -2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.524 -1.27) (xy 2.032 -2.286) (xy 1.016 -2.54) (xy 1.524 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(symbol "MMBT2222A-7-F_1_1"
+				(pin input line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "B"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 -5.08 90)
+					(length 2.54)
+					(name "E"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 5.08 270)
+					(length 2.54)
+					(name "C"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "GPAD_SCH_LIB:USB_C_Receptacle_USB2.0_GPAD"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "J"
+				(at -10.16 19.05 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "USB_C_Receptacle_USB2.0"
+				(at 19.05 19.05 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Footprint" ""
+				(at 3.81 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip"
+				(at 3.81 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "USB 2.0-only Type-C Receptacle connector"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "usb universal serial bus type-C USB2.0"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "USB*C*Receptacle*"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "USB_C_Receptacle_USB2.0_GPAD_0_0"
+				(rectangle
+					(start -0.254 -17.78)
+					(end 0.254 -16.764)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 15.494)
+					(end 9.144 14.986)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 10.414)
+					(end 9.144 9.906)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 7.874)
+					(end 9.144 7.366)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 5.334)
+					(end 9.144 4.826)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 2.794)
+					(end 9.144 2.286)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -3.556)
+					(end 9.144 -4.064)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -6.096)
+					(end 9.144 -6.604)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -12.446)
+					(end 9.144 -12.954)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -14.986)
+					(end 9.144 -15.494)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "USB_C_Receptacle_USB2.0_GPAD_0_1"
+				(rectangle
+					(start -10.16 17.78)
+					(end 10.16 -17.78)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(polyline
+					(pts
+						(xy -8.89 -3.81) (xy -8.89 3.81)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -7.62 -3.81)
+					(end -6.35 3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(arc
+					(start -7.62 3.81)
+					(mid -6.985 4.4423)
+					(end -6.35 3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -7.62 3.81)
+					(mid -6.985 4.4423)
+					(end -6.35 3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(arc
+					(start -8.89 3.81)
+					(mid -6.985 5.7067)
+					(end -5.08 3.81)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -5.08 -3.81)
+					(mid -6.985 -5.7067)
+					(end -8.89 -3.81)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -6.35 -3.81)
+					(mid -6.985 -4.4423)
+					(end -7.62 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -6.35 -3.81)
+					(mid -6.985 -4.4423)
+					(end -7.62 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy -5.08 3.81) (xy -5.08 -3.81)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -2.54 1.143)
+					(radius 0.635)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 4.318) (xy 0 6.858) (xy 1.27 4.318) (xy -1.27 4.318)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -2.032) (xy 2.54 0.508) (xy 2.54 1.778)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -3.302) (xy -2.54 -0.762) (xy -2.54 0.508)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -5.842) (xy 0 4.318)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0 -5.842)
+					(radius 1.27)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start 1.905 1.778)
+					(end 3.175 3.048)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(symbol "USB_C_Receptacle_USB2.0_GPAD_1_1"
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08)
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -3.81 180)
+					(length 5.08)
+					(name "CC1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 5.08 180)
+					(length 5.08)
+					(name "D+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 10.16 180)
+					(length 5.08)
+					(name "D-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -12.7 180)
+					(length 5.08)
+					(name "SBU1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08)
+					(hide yes)
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08)
+					(hide yes)
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -6.35 180)
+					(length 5.08)
+					(name "CC2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 2.54 180)
+					(length 5.08)
+					(name "D+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 7.62 180)
+					(length 5.08)
+					(name "D-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -15.24 180)
+					(length 5.08)
+					(name "SBU2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08)
+					(hide yes)
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 -22.86 90)
+					(length 5.08)
+					(name "SHIELD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "S1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:PWR_FLAG"
+			(power global)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#FLG"
+				(at 0 1.905 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "PWR_FLAG"
+				(at 0 3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Special symbol for telling ERC where power comes from"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "flag power"
+				(at 0 0 0)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_0"
+				(pin power_out line
+					(at 0 0 90)
+					(length 0)
+					(name "pwr"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "PWR_FLAG_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 1.27) (xy -1.016 1.905) (xy 0 2.54) (xy 1.016 1.905) (xy 0 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(text "NULL MODEM"
+		(exclude_from_sim no)
+		(at 165.1 81.28 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "08c8d1cd-9d4e-47e6-ac76-31d9cbf4878c")
+	)
+	(text "TX is Output\nRX is Input\n/CTS is Input\n/RTS is Output"
+		(exclude_from_sim no)
+		(at 234.95 95.25 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "23269888-a804-4aa1-80f3-b5a8e131503e")
+	)
+	(text "D501 indicates when data is transmitted.\nThe serial port sends ongoing status indication, \nhigh level is active.\n\n"
+		(exclude_from_sim no)
+		(at 100.33 137.16 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "555d1f8b-3550-4ae2-9491-ef5874efaaea")
+	)
+	(text "Place R503 near uControler TX pin."
+		(exclude_from_sim no)
+		(at 177.8 93.98 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "b57351e4-41ae-45ff-a37e-f2035559407f")
+	)
+	(text "The DTR# pin of CH340 is used as a configuration input pin before the USB configuration is complete. An \nexternal 4.7KΩ pull-down resistor (R217) can be connected with this pin to generate default low level during USB \nenumeration, apply larger supply current to the USB bus via the configuration descriptor."
+		(exclude_from_sim no)
+		(at 170.18 158.75 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "d9ca0c74-d524-40b1-a434-051dc2431702")
+	)
+	(junction
+		(at 154.94 76.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "070c87a5-6471-4a1c-943e-20bae21b0944")
+	)
+	(junction
+		(at 124.46 76.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "19f8e4a3-6444-4f2e-8a36-380cd2ba6b92")
+	)
+	(junction
+		(at 86.36 100.33)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "23d77882-4ef8-47dd-8810-afda293da262")
+	)
+	(junction
+		(at 168.91 90.17)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2f4dcb69-1cc3-4d54-a2d5-c8da52c3e640")
+	)
+	(junction
+		(at 193.04 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "34f7cb43-6675-4a8d-96c2-553b1efa57f4")
+	)
+	(junction
+		(at 86.36 95.25)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "39355474-e438-4230-a30d-03138463dbd6")
+	)
+	(junction
+		(at 161.29 76.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3b2ca0e2-1e23-4c05-988e-c1f6e6cf637a")
+	)
+	(junction
+		(at 182.88 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5351e454-00ef-4794-a8fe-f36713490e3f")
+	)
+	(junction
+		(at 120.65 76.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8315188c-f84b-4632-b43c-c5c28567459b")
+	)
+	(junction
+		(at 189.23 125.73)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "92f69aec-2cde-4571-aa76-ac8b628daf9f")
+	)
+	(junction
+		(at 137.16 78.74)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a9c08cf4-2020-41cc-a221-6a63fa8bfbc3")
+	)
+	(junction
+		(at 154.94 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b3f0eae2-d90e-4194-a1bf-ac1969640a31")
+	)
+	(junction
+		(at 137.16 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bdf14e23-4c25-4cce-9ec3-e39c90d1de7f")
+	)
+	(junction
+		(at 172.72 125.73)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c4720192-394e-47aa-881c-e8cd920eacfd")
+	)
+	(junction
+		(at 168.91 76.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d12eebb6-5409-4efd-863b-0b17ea8caf31")
+	)
+	(junction
+		(at 102.87 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fe958b07-5fcc-473c-ad46-6d5eccaea944")
+	)
+	(no_connect
+		(at 165.1 102.87)
+		(uuid "04411a86-db16-4952-a604-68163e6fd7e9")
+	)
+	(no_connect
+		(at 165.1 97.79)
+		(uuid "07e18ba4-4b72-402f-9212-c8126ca5d493")
+	)
+	(no_connect
+		(at 165.1 100.33)
+		(uuid "3a8b1b72-dbfa-4e44-ba13-ed2aaff43dd1")
+	)
+	(no_connect
+		(at 86.36 115.57)
+		(uuid "aea7c0db-db23-414c-9c77-96f9c855b49a")
+	)
+	(no_connect
+		(at 86.36 118.11)
+		(uuid "c7fae7b0-37aa-417a-b3ef-ba5e54b00e40")
+	)
+	(wire
+		(pts
+			(xy 106.68 76.2) (xy 120.65 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "00de126f-497f-4d2c-a204-98243a53628e")
+	)
+	(wire
+		(pts
+			(xy 86.36 95.25) (xy 88.9 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0abf4f1b-910d-4772-a953-f31e5a9434f4")
+	)
+	(wire
+		(pts
+			(xy 172.72 151.13) (xy 172.72 125.73)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0b47cae6-3d2b-49c2-bb27-6b9f5cc2f693")
+	)
+	(wire
+		(pts
+			(xy 189.23 125.73) (xy 195.58 125.73)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0bc243e5-4485-4c52-98b4-1e54db4665ff")
+	)
+	(wire
+		(pts
+			(xy 154.94 121.92) (xy 182.88 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0ceae22f-38ef-465c-840f-47f238e844fe")
+	)
+	(wire
+		(pts
+			(xy 161.29 74.93) (xy 161.29 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0df26040-2c90-4885-9f32-d6f95f7799cc")
+	)
+	(wire
+		(pts
+			(xy 165.1 87.63) (xy 168.91 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c60ad87-946b-4aed-a3d6-357e5dd9da57")
+	)
+	(wire
+		(pts
+			(xy 167.64 143.51) (xy 193.04 143.51)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1ccfa55a-54bc-4d04-9537-36de5b00ba0c")
+	)
+	(wire
+		(pts
+			(xy 152.4 78.74) (xy 137.16 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1d096dba-1cad-41b2-9bfb-c55a7c4717d9")
+	)
+	(wire
+		(pts
+			(xy 118.11 121.92) (xy 114.3 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1e7f23a1-1cc1-4e7d-92dc-04ede36815a7")
+	)
+	(wire
+		(pts
+			(xy 140.97 90.17) (xy 144.78 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1f97a489-8d71-479b-ac5f-d5f0636d6788")
+	)
+	(wire
+		(pts
+			(xy 86.36 87.63) (xy 87.63 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1fbeeba6-a2c3-4e09-9255-b2a7f4c5d81f")
+	)
+	(wire
+		(pts
+			(xy 176.53 96.52) (xy 212.09 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "26d41837-7582-4fe0-949b-1e2ae1df0abb")
+	)
+	(wire
+		(pts
+			(xy 87.63 81.28) (xy 87.63 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "27927128-f75e-4378-9236-a36da6bcd1a2")
+	)
+	(wire
+		(pts
+			(xy 130.81 105.41) (xy 144.78 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "292c4390-b701-4fb3-9b42-2939f22c6356")
+	)
+	(wire
+		(pts
+			(xy 165.1 107.95) (xy 167.64 107.95)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "295949a2-8c7b-4c1e-8e58-a0fa5c96513c")
+	)
+	(wire
+		(pts
+			(xy 124.46 76.2) (xy 120.65 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2e54042e-a475-4daf-908a-94160bf571a8")
+	)
+	(wire
+		(pts
+			(xy 88.9 97.79) (xy 144.78 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2f7f10eb-a7aa-4e28-97f8-a8b203396e8a")
+	)
+	(wire
+		(pts
+			(xy 106.68 86.36) (xy 106.68 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "31130e2a-efc8-4b78-938b-57a904fd2c3e")
+	)
+	(wire
+		(pts
+			(xy 140.97 90.17) (xy 140.97 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "318cec54-9634-4ca7-a454-1439881ff2de")
+	)
+	(wire
+		(pts
+			(xy 212.09 66.04) (xy 109.22 66.04)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "34bc8dac-043a-4de8-8ab8-9ba3ae12b085")
+	)
+	(wire
+		(pts
+			(xy 91.44 95.25) (xy 144.78 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "353b9fda-953a-4889-9599-4588a423562c")
+	)
+	(wire
+		(pts
+			(xy 168.91 90.17) (xy 168.91 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "355f3b91-3732-4874-bae5-823a9ecd93fa")
+	)
+	(wire
+		(pts
+			(xy 172.72 125.73) (xy 189.23 125.73)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "35b05a53-6c56-433e-b012-87dfe99981fe")
+	)
+	(wire
+		(pts
+			(xy 86.36 109.22) (xy 92.71 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a04c9a4-bc09-4b52-a701-087f391e50bd")
+	)
+	(wire
+		(pts
+			(xy 154.94 82.55) (xy 154.94 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3cd20d48-8f4f-41b8-baf3-3fdf13fcb8a8")
+	)
+	(wire
+		(pts
+			(xy 88.9 100.33) (xy 86.36 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "43b183c4-9fd9-4af7-b9d8-a0afb064264f")
+	)
+	(wire
+		(pts
+			(xy 154.94 127) (xy 154.94 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "440e1931-6dd0-4cc9-8dd1-21fc3a5cdcc3")
+	)
+	(wire
+		(pts
+			(xy 109.22 66.04) (xy 109.22 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "457cdfb2-3752-45eb-b5d6-ce0ff07e9ac0")
+	)
+	(wire
+		(pts
+			(xy 182.88 105.41) (xy 200.66 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "47be1a39-d70a-4f33-a0ab-499ba354ea6b")
+	)
+	(wire
+		(pts
+			(xy 102.87 83.82) (xy 102.87 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "48040dd8-9531-4efd-bd84-8149d36966dd")
+	)
+	(wire
+		(pts
+			(xy 193.04 142.24) (xy 195.58 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4b68f706-c4c0-4f9c-a7c1-bf013460f703")
+	)
+	(wire
+		(pts
+			(xy 71.12 125.73) (xy 72.39 125.73)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4c621942-d844-45ac-b71f-8da91498beb1")
+	)
+	(wire
+		(pts
+			(xy 210.82 118.11) (xy 210.82 120.65)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4d0bb86b-e804-429f-b493-dd312f1af64d")
+	)
+	(wire
+		(pts
+			(xy 88.9 97.79) (xy 88.9 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "507f6922-8b22-40be-b478-c5e70d719de9")
+	)
+	(wire
+		(pts
+			(xy 140.97 121.92) (xy 137.16 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50f822f4-3c82-42ef-bd94-aa376bb3f27c")
+	)
+	(wire
+		(pts
+			(xy 210.82 130.81) (xy 193.04 130.81)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "57d4cf39-3518-417c-b559-d8b60b0753f4")
+	)
+	(wire
+		(pts
+			(xy 86.36 106.68) (xy 100.33 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f818f40-bc5f-4799-8978-bd6206874f24")
+	)
+	(wire
+		(pts
+			(xy 88.9 101.6) (xy 88.9 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5fe78b66-6b6c-45d9-8488-bc598d75abf6")
+	)
+	(wire
+		(pts
+			(xy 165.1 90.17) (xy 168.91 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60221538-4531-404c-a894-257092e8bb27")
+	)
+	(wire
+		(pts
+			(xy 182.88 121.92) (xy 182.88 114.3)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62e1ad2e-0990-4c0b-bafb-3b274b5b4944")
+	)
+	(wire
+		(pts
+			(xy 210.82 134.62) (xy 210.82 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6506dc82-716f-4fd5-a0d4-199d69152753")
+	)
+	(wire
+		(pts
+			(xy 193.04 130.81) (xy 193.04 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "690a5a7a-57dd-4d5b-a3b3-ba1258617051")
+	)
+	(wire
+		(pts
+			(xy 165.1 105.41) (xy 172.72 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6e2dd02a-067c-4b99-9197-e99aa22cac4a")
+	)
+	(wire
+		(pts
+			(xy 91.44 95.25) (xy 91.44 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "76122860-1c43-4964-b1e1-d4880d4636cf")
+	)
+	(wire
+		(pts
+			(xy 165.1 95.25) (xy 166.37 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "782e20c0-6291-4af1-a07f-34a2e0c467ff")
+	)
+	(wire
+		(pts
+			(xy 176.53 87.63) (xy 213.36 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "783ff210-7a12-4310-837a-499339aab7a6")
+	)
+	(wire
+		(pts
+			(xy 154.94 76.2) (xy 124.46 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a1a3c0c-623c-4aa0-8cfc-6b20c31299a2")
+	)
+	(wire
+		(pts
+			(xy 137.16 71.12) (xy 137.16 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "803362c2-98c3-4221-99db-f1398e5b3e68")
+	)
+	(wire
+		(pts
+			(xy 91.44 101.6) (xy 88.9 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "85cca698-de8b-4db2-b747-09ed71c2f9b5")
+	)
+	(wire
+		(pts
+			(xy 86.36 92.71) (xy 86.36 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8b00ea2b-5db7-47ae-9572-6ce68a2d4e6c")
+	)
+	(wire
+		(pts
+			(xy 154.94 113.03) (xy 154.94 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8cea07ce-7e86-4b2b-bd4d-ac854f717a26")
+	)
+	(wire
+		(pts
+			(xy 210.82 118.11) (xy 214.63 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d68be42-cfee-4cf1-a164-1231e1782a14")
+	)
+	(wire
+		(pts
+			(xy 124.46 72.39) (xy 124.46 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8e0d11c1-07db-4b8f-89bc-8720807bf879")
+	)
+	(wire
+		(pts
+			(xy 133.35 72.39) (xy 137.16 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8e16f852-61cc-404c-a5c8-b494b0507b47")
+	)
+	(wire
+		(pts
+			(xy 129.54 121.92) (xy 125.73 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91f07ea3-bbe3-4a07-bfcd-819ee53aa2c0")
+	)
+	(wire
+		(pts
+			(xy 193.04 143.51) (xy 193.04 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "93d27333-2186-4ac0-94f7-c357620694d6")
+	)
+	(wire
+		(pts
+			(xy 152.4 82.55) (xy 152.4 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94f838cb-93ee-481b-9b2b-6e211669a6dc")
+	)
+	(wire
+		(pts
+			(xy 210.82 149.86) (xy 219.71 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "954de25c-f15d-458e-8404-2b57aa4e7441")
+	)
+	(wire
+		(pts
+			(xy 125.73 72.39) (xy 124.46 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9b9d7432-f1ab-4c6e-83da-e65281b39557")
+	)
+	(wire
+		(pts
+			(xy 172.72 105.41) (xy 172.72 125.73)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d3fe42c-ee57-43a9-bfba-3ced69d82758")
+	)
+	(wire
+		(pts
+			(xy 189.23 134.62) (xy 189.23 125.73)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d5ae90f-056d-48cd-827a-8aca4600ba0c")
+	)
+	(wire
+		(pts
+			(xy 210.82 149.86) (xy 210.82 147.32)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a316584e-3748-4384-9d2f-613b41ceb788")
+	)
+	(wire
+		(pts
+			(xy 161.29 76.2) (xy 168.91 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a35954f0-273a-4bc5-8a22-edd970d1bc77")
+	)
+	(wire
+		(pts
+			(xy 114.3 121.92) (xy 114.3 123.19)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a768b942-6431-4eec-80a6-63f071fcbea4")
+	)
+	(wire
+		(pts
+			(xy 154.94 76.2) (xy 161.29 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a82764e4-e741-4b36-9f58-1e3c3342efc0")
+	)
+	(wire
+		(pts
+			(xy 87.63 81.28) (xy 97.79 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a8b9cce2-a504-4a88-84bf-aad408727dd6")
+	)
+	(wire
+		(pts
+			(xy 97.79 83.82) (xy 102.87 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad5c16a8-1e16-4be5-9fb3-b07cf06c6650")
+	)
+	(wire
+		(pts
+			(xy 120.65 87.63) (xy 120.65 86.36)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b171fe08-bb2d-4a26-97f9-bbbe133254ff")
+	)
+	(wire
+		(pts
+			(xy 205.74 76.2) (xy 213.36 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b6667a4c-0a26-4633-ae0c-2d275f9d28d6")
+	)
+	(wire
+		(pts
+			(xy 72.39 125.73) (xy 72.39 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b882f116-7ec8-40a2-9799-936e468ffbf6")
+	)
+	(wire
+		(pts
+			(xy 182.88 105.41) (xy 182.88 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c2c51d00-cbde-45e3-b4da-4cf590dd33d6")
+	)
+	(wire
+		(pts
+			(xy 229.87 86.36) (xy 229.87 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c30321dd-eb9e-4da9-bb0a-0cb62fc30cfc")
+	)
+	(wire
+		(pts
+			(xy 166.37 101.6) (xy 166.37 95.25)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca1ec569-8515-4eb5-98bd-841eca3b045f")
+	)
+	(wire
+		(pts
+			(xy 166.37 101.6) (xy 182.88 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb8e9d58-1259-448f-9f96-e9f625c8e08e")
+	)
+	(wire
+		(pts
+			(xy 168.91 72.39) (xy 168.91 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cc3a1477-4269-4c0d-8886-16b167321603")
+	)
+	(wire
+		(pts
+			(xy 100.33 114.3) (xy 100.33 116.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cc9c33c0-ab99-4cd5-8841-2760ae81c4d4")
+	)
+	(wire
+		(pts
+			(xy 137.16 86.36) (xy 137.16 87.63)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dde21631-e131-4d01-8656-dcbf622acde1")
+	)
+	(wire
+		(pts
+			(xy 120.65 76.2) (xy 120.65 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ddf47ef2-bf0b-4e1e-b6b7-e1ac4a0e4867")
+	)
+	(wire
+		(pts
+			(xy 97.79 83.82) (xy 97.79 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e2ab96b0-7f28-480f-a07a-807f28b4f9cb")
+	)
+	(wire
+		(pts
+			(xy 167.64 107.95) (xy 167.64 143.51)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e5589bec-599a-4e82-9311-d9d01fc86d1a")
+	)
+	(wire
+		(pts
+			(xy 137.16 72.39) (xy 137.16 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6a50677-859c-4d5b-bc7b-f2eda18b033d")
+	)
+	(wire
+		(pts
+			(xy 229.87 90.17) (xy 168.91 90.17)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6ee5c63-5c8f-48ac-8d3e-906db9e9eaee")
+	)
+	(wire
+		(pts
+			(xy 168.91 76.2) (xy 198.12 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e984bb22-b30f-4981-9f74-4d24d9506601")
+	)
+	(wire
+		(pts
+			(xy 109.22 72.39) (xy 102.87 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ea675666-3cf5-4c13-a9ad-d5d5c3159fcf")
+	)
+	(wire
+		(pts
+			(xy 86.36 97.79) (xy 86.36 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ec824190-0d4d-408f-b8fe-6db81e0bd7a0")
+	)
+	(wire
+		(pts
+			(xy 182.88 101.6) (xy 182.88 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f7555c16-d83e-4374-8e93-15c53a1a69e1")
+	)
+	(wire
+		(pts
+			(xy 92.71 116.84) (xy 92.71 118.11)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f900e17c-0038-42c3-901d-5dae08acd341")
+	)
+	(wire
+		(pts
+			(xy 210.82 134.62) (xy 189.23 134.62)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fbf70be2-0dc2-452d-b39e-84adb87784e5")
+	)
+	(wire
+		(pts
+			(xy 106.68 76.2) (xy 106.68 78.74)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ffed6893-60d8-4fa2-a352-5d318dbe77bd")
+	)
+	(image
+		(at 251.46 173.99)
+		(scale 0.2225)
+		(uuid "1e30b73f-0a9f-493c-ad6d-e703f38be3c8")
+		(data "iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz"
+			"AAANrAAADawB7wbGRwAAIABJREFUeJzsnXd81fX1/5/nc1f2ZItAQtiKAyQJIKC11tU60VY7rG0h"
+			"aLV1dQ+6ft9atbVaBZRaW2utWrW1WketokAG4GaPJCAgI3vnjs/5/XETIGbdT3JHgp/n4xEe4d73"
+			"+/05N/fe83mPc14HbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxs"
+			"bGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsjiCxNgCA"
+			"xbPzwfwGMAcRZ9ujH6A8QdXoJ3nqqUAszbOxsYkMsXVAi2YkYLjuB77SrS3CduB20H3RNA0AU/0Y"
+			"Wk/ArKPZ18yj7zdG7FqL5o7B4RsasfF7w+new32rD1vu97X8DNxmVgQs6p2P2xzrv2FAFEegBp/h"
+			"xeVqpKK6kac2eWNmzyDA2XuTCHHj+R581f8B5vfYTpkI/CsmvlIEFDAckOiCgjxAPgLdhsp2xNyO"
+			"GBuoqCvq9wfN8P0AlcVhsbsv+PwFwArL/Vzmuag8Hn6DQsDrWwIsP/J/w/89VJbExBYAA1BH8Ful"
+			"fshMhoK8OuAgaAVQDlKGUAa6juElG1mKGTN7ga2lWZPUkBlmY/w/pk2LvrOMnQPyVf+EY5zPV/Mv"
+			"4rrZFzEqbQj1LU089fZr3Pnfx/D6fTEzsWt0JDAS0QUgoApDkhspyHsDkf/iM//BypK9sbbSZsCQ"
+			"EvyRCUA+ELypIXAgr44C1gIvYRov8GDhrkgbs2Xv5Ex/s/+CVnF83jSNSYo3G6X50KGhT0b62l0R"
+			"Gwd03ZxkCNzc/t87L/smt336mg5NThk9gU9PmcVn7v0WrQPOCX0MJRG4ANULcMrdFOT9D/gz8fIM"
+			"vytqjrV5NgOWFOB84HwM8/cU5L2PshLD+VeWrakOxwVUMd4pn3ym12tc26IytbzGOfpQa+qIGq/H"
+			"cIjyqeH7Ad4966xV/nBczyqxcUBu8xwgHuD0MZO49Zyru2w2f8JpFMy7jN+/9kQ0resvBvBp4NM0"
+			"6z4K8n7GiLg/sTQ2b7DNoGI6wr2o/w4W5z6Mun7Dg2v29GWgws1TLqnHdelzGx3Tq1o9E2t87gRT"
+			"O25jZLhb2n/d0E+7+4wRk6sKY9t/nZdzKiLd7+8smHh6VEyKECcAD3Kg5QMW514Qa2NsBg3xiNyA"
+			"4d9JQd7vuTE3JZROhR+Ojn9x0/Q7n3lvxvvv1Wc8vbEm/cs761NOrfJ6OjkfgFRXcGUh6Jbwmh86"
+			"sXFAph5xvfWtTT02rW+J3MFTFJmMyAssyf0zS+amx9oYm0GDC7gJn2ymIP+inhq+vGX6/6uoHlK+"
+			"oz71trLGpJObAs5ev9vxzmB0i6oR/RPmNmLjgFQ3tv/6/AdrqW/p3gk9tu7lqJgUFVS+jAY2sSS/"
+			"55M/G5uOnAD6HIvzfsHSjt/ZraWTJhVum7pjf2Pi93c0pA7zmZ2/0k7DxCHa6fE4I7groAafMAc0"
+			"qqQQpBTgYF0VVz/8ExpbO+7Vqio/e+GPvLy5JCYmRg4dieorLM7/cqwtsRlUCMKPOJD/BAunuQE+"
+			"KJ9wYbPJ+vdq0nOqvO4uO41LrOfc4ftJdXU+YU9omwG5fByKoN09EptN6KWYLNGbUf4JyPMfrCXn"
+			"Jwu5csanmDxiLPtqDvPc+6v5YF/ETyVjhRvRR1icP44VRT+PtTE2gwm9gszkuJItE1aIyTNvV2e4"
+			"mgJdf41dhsmE5HoqWj1UeT2dnncbpgLijethCRJhYhcHtKz4OZbkfR/l/wA5UFfJva/HJBQhVgii"
+			"P2NJnp9lxf8v1sbYDCouuvuNhAsW5ruMGl/XMx+AnKQ6nGKytS6ty+cNgjvT7pa4mG20xs4BASwr"
+			"voPFeeUIvwHGdNHCC1qC6ShCTEVIRknBYBzKXAtXequPFnpAEkCTg78T0mmEJZRfsTivHuRlVGu6"
+			"bGOQAJoKMgzlPAujv9oWuV2L0vOHTPVdC+Me228LyB09tmm3X2UowbiXUPAiPI9JLWgtSGvna/NO"
+			"h/+LvIKpdd3aoJKG6FBLf0OVTcjRQ5NeEJC2b7s6ETLbYsTCzpPvxhuORBczx3f9fJzDZGxCI4da"
+			"4qnzuzo97xDFCO4LBSZM2Nn5bxslBkYy6sJpbjJSzsYw52EamYg2Ivo2uF7oMiBrSf58VFeFPP7y"
+			"YoO2+NN+ccOsTEymoo6poGeCnN0WGd1fTAw9nwdKXumx1aIZIzFc+0MeVRyTWbZ2W3+NCxvXnzEC"
+			"0/FRiK0PsLw4HH/bjhTMHgbmwZDbq05jRcnmPl/v2gVxuP3DMLw5iOSgMhPIA06in9+/BA989xIP"
+			"SZ1XV0xLqWZsYiNrDg/v0gF5HAE+NewjEBqmjNuV3B87+kNsZ0DtBPOoXmr7Gbjcv64SWN32E8yb"
+			"WpI7A5VrgauBjD6ObGDKYyyaO6OvgWc2A5RHVrUAe9p+XgMeBNoSZwOXofpFYEZfhm5qhRff9rMw"
+			"v+PXOM5hcmJCEwe7mf0AOKUtBa23mXGEic0p2PHEspK3WF58I41NY1C9Hfp8ojAEh/8xBsqs1Cay"
+			"PLhmD8uK7mF58UxMZgBP92WY9bsC1DR2nNyPTajHEKWssfuJjevosXxMU4VsBxQuHn2/kRUldxEX"
+			"Nwn4c5/GUOZSkPf18BpmM+B5sPhtlhdfgeq5wAErXQMmrNl6VC7LKcrYhEZqvG66O5oHcBhtMyCh"
+			"oU82hwnbAYWbe1bVsLz4WkSuAULdvDyWO4L7FDafOFaU/BcjMAvYYaXb22Um2jahGZPQgNMw2dXD"
+			"7AeOmQGp7YCOT5YV/Q04B+j6VKZ70sH8XgQsshkMPLD+Q/zmZ4CqULvUNil7qxQRZVxSAy0BB4da"
+			"43rs4zTaHJA9AzqOWV68FkMvwfpMqIBFM8J/AnQMO3bkeHbuHG/PtAYiK9eVofIdK112HjAZ6m4l"
+			"zgiwpykR7SL59FhcbUswUSr7bmj/sR1QpHmg5HWQGyz2ikecN/ferG9s3jn+pFaHHvA5KLed0ABl"
+			"pOfPQMjCdh9VK2MSGzCBPU29hx55jLZEVDT0sI4I8Il2QLt2ZaduLs35+tay7G9F9ELLix4GedRS"
+			"H5Fr23N+wsn7u8eki1OeM0RSgXifQWRfu03fWLrKj/B8qM0r64MzoEMt8XhNR6/t49sckKiEGpcV"
+			"ET6RDmhLWc6CjaU5/2wR47CIPqTI7zZ9OLqvMTyh4ePbWDuiH0pG8qXhNGHTpmluh+l6usHnHFlY"
+			"MVQUEOGGHTtywh/hbRMGjqpG9IbPF0BE2RvC7AcgztE2AzI0pgmXnxgHpIps3Z11xXulE7eZyv/2"
+			"NiVeXFw11NV2VCmGL25ORA34Y1EVyk8t9RGuCtflVXGQ0PL3Rr9rZlHl0Lhan5v9zQkopAYcGjsx"
+			"fJseMEKWZfX6wG8aVPSy+dxOgjMoxSG43umlaUT5RDigjTvHz95YOmFjIOB4Yl9T/MTXD40wNtWl"
+			"tcVKBOPYFc2NuCHu9D9hYV2PcC7XLgjtE9UDqhhby3L+3Oh3nV1UMSzZZxokuXyYbTGPKnyjv9ew"
+			"iQRmUqgtk+NMDrTGh1RiI84ItO8BVU4et62sz+aFgag6oJ07xw/bvCt7QjSvCWAYrD7UGjf1jUMj"
+			"jC11abQes0au9gUdkCCTI27IfS+2ovJQyO2VRDytC/pzSVVkU1nOivqA83OFFcNS/So4DZM5mYdI"
+			"cvipDs4AJ2wuzxnU2rfHJRp6ak9avHKwJbR7Varb2z5+cZ/sCiNRc0Dbd0/M9hp8KIZs3Vqa88Vo"
+			"XReguHKovFuTQXMXm3NN/rY8GtHIOyAAp/wZK4mxhpnfn8ttLht/p9d0XF1SMTQ50HY0e0JcEw5R"
+			"9jQlcrAlPthQe6nPZhMD5JRQW6bFa8jLr/Q2cTIx9Jm+2RU+ouaA/IHANSK4TcVQ0Ue2lmdf03uv"
+			"8NCVGFM7TX5nmzfQcVEx5v7C3ai+F3J7pc9Lw/svrbkS5MaiyqEJXj36Vo9JbMSrBgda4qn1BZMV"
+			"RXRKX69jExEEmB1q45R4IdBL7E87w+NaQDUgrc7n+mpcuIjiEkyvafQ7zfXVQwkgoip/2VyWE7FY"
+			"l5CtAoKKcpK4Yf+ohKhc1DBeDb2xnNTXy2Rl+H66qTbN3RI4OvPLcLWS7PSxrzGBgAr+dsekhLzf"
+			"YBMFFueeQ9caWV0yblhozifZ6SPR6QPhP5Mmba/oq3nhIioOaFtp1ikiMml3U6JR2eqhuGKo4TUN"
+			"EfS3W0uzV3744ej4aNjRHd62L2hCiydadcXXWWg7sq8b0a3qkL3NHY9lxyU2osDupmCukNsR3LZU"
+			"sbA5bhNpBDEspeMMzwwtZGxkfDD53VD9pXWzwk9UHJBpGF9UJND+Zaj1uXnz8Aip8npMFflag9/z"
+			"7tbSrOnRsKUrfG2zAFGJTjyMipU6TAYJraP7cplDrfHGsZtNqS4vI+Kb2NeUSFOb001zBvcDDFOs"
+			"OEWbSLI49ybQs0NtPiLZxOPpWvfnWByijElsCJgqL0/KLhsQ73fEHZAqoipf+Kg53vAfUzLEaxqs"
+			"qxpitIWNTzQNKdxSnt11idQIEHwzGkly+vGZbcfRDqP3dzEcmK0fWmrv1z45xgZvx5czMbmOgAo7"
+			"G44ONyq+yTRV9jZUpf6rL9ewCTOLc69H5LdWupyZ4w/pVGNSch0uMX1uJ1ZTgyJGxB3Qll3jpwl6"
+			"wr7mhE6LVFOFjbXpfFCTjqokoPLYlvLx927YMCPijuDk1GpOSqkmzhE4ImXgMLspLxBuqrOtZSA7"
+			"zD7pCvuO0TbLdLcy1NNCWWPykdnPyPgmEp1+wwG3zJz5lq8v17AJE9+YNZGCvH8jcj8WvpcOQzln"
+			"Wu/uZ1R8U1CoDL1lwpidA6bcTMS/cOKUcwOm+Cpa41zD45qZnFxHeWMiu5uO7nl+2JxIvd8lp6dX"
+			"apwjcGNiRs3pm8vHLpw6bndE8lTGJDQwKr6JXQ0pVLR6OCE+yqqUIxqcWPm6m84+1ZU32u6LIsqk"
+			"lFoa/U52NgT3fjyGybSUmmaElZOzdj7Vl/Ft+sGiGS4czumozAIuB86mD2qYC8Z7SU5w0dCD3sJw"
+			"TwunpFWpqjw8adyu5X22OQJE3AGZqudUet0OBZoDThKdPiYm17GvJYFjl2Q1PjdrK4bLqemVZLpb"
+			"54g639pUNuHSaVk7wlqZMN3tZVpqDRXeOLbXB5ci7e+63+GIjjZKoCIdek8YPIIR6JOHbL9CVkID"
+			"qS4vJZVDMVVwiDIzo6LBZegzk8fuivlJ5IDGkK+xJK//hfuUeJQxCKOBE4EslO7jQ0IyDb6R10Sd"
+			"P7PbNiPimzg1tVpNeHZa1s5FImEozhBGouCA5LQ6n8cAqPO5+KglnpFxzWQn1rO9PrVD21bTYF3l"
+			"UKal1jAmoWGkIearW8vHXzx53K7XwmGLS0ymp1bhNQ3er8k48k60lSfB9Gl9OK7TK37HWEuLXzFD"
+			"zgk6FodhkuDyMSG5jrLGZKq8HpyGSX5mRU284f3zlHG7bh5oH8gBh3JL2MYKs9r31TNamT7Sz8sH"
+			"Ou9YCDAlpYZxiQ3a6pdfnJKza2lX7/U7ZePS4sVxuolMFlOzTeFEVUYKhjjELJycteu74bW6IxF1"
+			"QBv2j0pwturwZv/Ru/2O+lRGeFrISmxgT1MyLYGO30QFNtam4TUNcpLqkhSe31yWc/bUrJ39Dhs/"
+			"ObWGBKefdZVDOlzX0ybOFKdS299rhISBlRO/Voat71PtbqeYzEyvpNLrYVt9CklOP2ekH67wuPUX"
+			"08buurcvY9oMDEakCbfOq6fZdHbK/3IZJqekVZlD3C1+Eb3u1Am7Hjv2+U27c6ZpQD8fUGOhG3OC"
+			"KoagWhdwSb3PhdMwGe5pwRQtj/TriKgD8rR4khHkWM/f4HfyYXMiYxIamJRcw3s1Xae7bK9PQYEJ"
+			"SXXxgv5z067sWdPGl+4BmDO2dfjacmtSOeMSGxgR38SOhhQqvR3DauIcfhNomDBhp1X51D6ieRZu"
+			"h2UsDSnHsBNjExvwmgbv1WQwLqGxKTupbn+8+K+YNLYs9EhsmwGHxwnXzRPiXEq1t+NSPtPdyqnp"
+			"VT6H6Ga3Uy6fMGbXLoCysnFxrSLX+AKO7xmm5vhUtNrrkSqvh2qvm3q/S9ojqScm1zHc04JhGhHf"
+			"G4yoA3IYpoEaR7RH2tlel8LIuCZOiG9id1MSNd2o9++oT8EjAcYkNg43DPmTKueIoGdP8n3KigNK"
+			"dvmYnFxLZWscO+s7n2h7DFOA3ZZeXN8RkAsstO9rVVdaTCflTfHm3MyDVS6HPt4a1/i9SaP2x6wO"
+			"uE14+MpcyB4aXE35jkmxGZfQoJNTagMIv5o6bucvRQio4thWnr2oAeOXgYAjeVdDkqvC66HB5+r2"
+			"DjjC0wRQ7wjwcqRfS0QdkNES12B6/Jrh8nZ4sV412F6fwrTUGqam1FBUMazbjYjNdemkub2kuHxn"
+			"byvPvhZK/zQy2Qy1vC8Ap6VVEVDhvdr0TteJNwIYooJIdBzQ9fn5mDoi5Paq6/txtdrJSXWvOwjc"
+			"dHL2LmuxRzYDlodXQ+lhZfLZBj4JLjBOTqtpHhnf0GoIF04Zt6sQYFvZuMmbyhxPqMi07XWpjj1N"
+			"iZi95Iulub0kufyI8EQ0SjZHNA5o8uRt9YqUp7tbO11oT1MStT43aS4v4xK7P3wyga31wXLbpsrP"
+			"NpdPGZnoCpxoxY4kp48PatM5NieqneS2zGBMfd/KmH3GpMBSe5XVfb3U8x84rzw1Z/ulJ+fYzud4"
+			"wh+AVzfB+Q9m8MImN1NTqptOSGhsdhHIb3c+W0tzFgbU8V69z33ymsMjHOWNSb06H4DshAYAE9O8"
+			"K8IvA4hCIKJDdI0hyvD4jjN/Bd6rTcdUYWJyLYmO7kNdKls9tJoORDgRvDeLxdOEPY2JHGjpOt0s"
+			"xRUMyFGhPzON0Lhh9lhQKyqHe3mwuM+KdX/ekBStZaVNDKhvFX73Pxe/+o8z4Z19jusmZZVvBdhS"
+			"Pv42E31yf0uCu6hymDT5ew75SHb6mJpSQ05SXfB7qvLs5OyybdF4DVFIxZA/AmR3Mctp8LnY0ZCC"
+			"Q5TpadWIdL0QUzgitiTKhVZt2NI2g+qKo+JMZuSlKf36A8DK7vlzWNEOsvlEsrrUzTWPpt/J9fk5"
+			"m8uyb0a5s7wpifeOCTXpCpeYTEmpYe6Qg6S4fYyOb0QAQ807omV7xB3QlKydbyi8neryMjSuc7hm"
+			"aUMy1V436e5WJiR1H4ZT06ZcqCoTrdrQnU6KAQxxtypQOjW7LLKzhetnn4Ho1yz1UeOvEbLG5vhj"
+			"gkv0rR2HXXcfao1jS133N12AE+KbmD/sICPjmnm3JpPtdSkkOAMg8vyk8aWRXw20EZVseEO4HTCn"
+			"p1QfiblpR4F3qjPxmQbjk+oY6uk6prw9lkhEw7Zxnu5pxSEqCC+Ea8wu+dL0REzzYSyFP/MBKwqL"
+			"ImWSzfGHL0DK155Mk1c/7F7JNcXlIz/zMCelVlPemMgbh0dwoCWek1OrTYFm1H9jFE2OfCQ0wORx"
+			"u17bXDr+/zyOwA+np1WxoWpIh6lhi+ngvZp0ZmZUckp6FWsOD++0YdzUxQZyfxnmDmqjiPKfsA9+"
+			"FCEx/iHAqrDYskgYY2MR4Y+Y9E+4S0gmKC42BhgNoWs9W6WiQVj+Xz83X+jmWIUOl2EyKamWExOa"
+			"ONAax7uHRhyRKM5OqifR6TdM9GdTs8rLI2VbV0Qn+xs4uPvEpSPGfTh7qKflrNPTK3mnOrNDdN2h"
+			"1nh2NqSQk1THGRkVFFUO7ZAr5guh2JoVBDghoUlV2Ts5a9d/wzr4sSzO/S3IFyz22oMr/eGI2GNj"
+			"DVN/y4qSzWEd80vTE0mIH4sYk8CcRLAgwunAVKzNkrvkcJ3yj2If15wZ9ECjE5qYnFyDXw02VGdy"
+			"+Bjt6HiHn4lJtSbC5qaKdEsyIOEgag7orLNW+bdunXSxevwvD49rzj89o4J3qzPxH7M/s70+hTgj"
+			"wOiERmamV7KuasiRo0O/CibhWzMOi2vGbZiiykMiBHrvYZGlGBzMuwfF+pRW5efc92LEYzBsYsSj"
+			"7zcCm9t+jhJ0TLPBuALRS4E+K3S+XWZyRpaXr5xSS4rLS2ljMqUNyR32Q0WU6Wk1AUMwjYBeFwtJ"
+			"lqiW5Zk8eVu90y/nAYXDPC3MGXpQk50dX/MHtekcao0jw93KqanVHRIWWsM4CxodlODwuQLyp7AN"
+			"2s6SuekcyPtHn5wPvNNWF9zmk8aj7zeyouS/rChajOk7AeQylNf7Oty/N/ip8wmrDw9nR31Kp8OY"
+			"CUn1ZLpbHCi3RHPj+ViiNgNqZ8KEnXU7duSc7XPqPYkOf8HcoYfMLbWpRnmbPpACb1dnckZ6JSPi"
+			"mzhdlHdqMjBV8AYcR2pa94dUl5dhcS0g/H7ChJ3h1EIWCnKvQv2/A0KPdj6KiWEsZumqPun/HE/E"
+			"uyTtl4XznzzygFIr0ntOnCmy/rb8VSsjalw0ePAtH/As8CyL889D9A/AeCtD7K9z8EBROvOndb5x"
+			"j4xrJiepTkEemZK98w/hMdo6UXdAAG0h3ks2l+YUgv5+ampN+oj4Zv2gNk0a/S5MFTZUZ3J6eiXD"
+			"45qZkV7JW9WZNPidpLq8BExpAfok1B6UKahVkGqnj1+E6SUJBfnngv4COKMfw9zHA4UxuRMNNJxO"
+			"4oCFRx6Q0AKiRPUbdxfOP9dM9Hz19lNeibLSXIRYUfQSX5p+CokJ9wNfsdJ19dYAZ051YBwz+Rni"
+			"buHU9EoTeMNs8liLzA8zMXFA7UzN3vnojh05L/md3JHhbr12/rCD5u7GJGNHXQpeNXi7OpNT06oY"
+			"HtdMfuZhKtvqe/mVSuCEvlwzK6medHcrhspX+5X9vhSDQ7Ono+ZFqHwVNLvPYwEIJVTUfadfYxxH"
+			"NHupARa1/19FUlHtcctA0OmIcS2qCx2NLWPuWDPnsu/OXbs/4sZGg+C+0bUsyd2PyvdD7VbdqGzZ"
+			"azLtxOCfbmRcM6ekVfkF3pRW5yXTpm3yRsrkUIipAwKYMGHnYeC6rbuyH1BDfjk2oeEzo+MbzD2N"
+			"SUZpUzJvV2eSk1xHTlIdKW15W06DnqOsPsbeqmAV9KFxLQSkUV/c537g1udS9rEkc0ZIAwgpBAwP"
+			"hjkGkxzEmMgBnQPmkGCDfgcrH8KnV/BUbD8MAwl/QFtunf2GZTmI3xYuuEfhX4rkOsX53p1FCxbe"
+			"nr9qVQRMjA3LSn5IQf4E0CtC7fJOmcn0McL4pPpATlKdATwVR+C6rMm7ehByjQ4xd0DtTB5fugE4"
+			"b3PphHkOzO9kJTWcPy6pgQPNCbKnOVHeqsrklLRqXIaJQ9SSSPs9L7RvdDuAdAFuaPsJDQVEQaVN"
+			"xies2RF1GMZFrCy063IdiyL3/ud8S5KlVWP36C3TVu28Y82cPKfheBSRiw3V/95VNP+W2/LfuC9S"
+			"pkYZxcdiXHwKSA+lw9Z9AeYNPdwa5zT9asq3p2bvHDB7ZFE9BQuFqdk73pySvesiNXUycN+IhOaq"
+			"3IzDTEut9e1tTqC6G+2gQYnQiKkX2vs+nUlOkOG+tKYWKz8ptZmH79qwYMh3566tvyX/zUtR+RnB"
+			"Ckz3/rZw/ooVUai2EhX+WFSFyj2hNm/2wcb9jmcDZmD8QHI+MAAdUDtTx5fumJq169sHy0aPUNEL"
+			"4x3+x8cmNtSkubyqx0d6ZgWmcQEPlqyJtSEDEkUBb8g/KgFFUgyvFv62cEGOCHrrnFVLEf0C0KSw"
+			"qMGb9L9PneoYEpsXFGYC5sNYmIp/+W+pz5+cXXYwghb1iQGzBOuOs85a5Qf+A/xHFWN7WdbM8hrX"
+			"9Vg8DRhQqGzC8H+O5cWlsTZloFLfogdvnf3GyFDb/9/queluh/GsIvNB191ZtOCy2/NXrbo1/80n"
+			"frd2wTZT9F/AmWdOMF7537sRNDxarCzZS0HeRuDkkNqrzgQe67VdlBmwM6CuEMGclF227qcvJYU/"
+			"eDBqyKO4zdksW287nzDy/TPXVLtqEj8D/A1IN1Rfvnvtgi8C3Dxn1bsuvzkTeFOkb6enAxMJ3ZWK"
+			"TIqgIX1mUDmgQc4BVC9hedGXua+kb8f/TsPa4jNghrkQTD/xW7GnG3GoHrjpghdbb8l/44ttez9u"
+			"RP9y99oFSwFumrf6sKsm4dxWH3+zOu7AxbSSo5bae5PoM+CXYIMeoRHlfnxyB38srurXWA6jyVJ9"
+			"DKf0KVgzYjjdiZih+hXtUxBhsPbVqqV3FS3YK6rLEP3pXUXzxyS7GhYvnvliKwWzbwau7svYAw+j"
+			"2sI2kKXQlWhhz4AiRwOq9+DT8Swv/i5/LOqf8wHIjLdW0cIfSOq9URQxSQ65rWq/qtTelr9qpahx"
+			"BdAkylcbWpNeuLc4t3NJlEGNpb/RgHzt9gwo/KwDVuJ1/J2H14a30urSVX4K8pqBrgWuP0ZqgnPy"
+			"91bP3fTxxyU+zvzezFejU4Sxw4UZG/INW4x+/+1umfP6v35beOZZivFvhE/7zLg1l+T6vvzPsBb7"
+			"jilWwgoGZH6h7YD6zwFgFcgqAoHXeWjd9sheTvdAaBuKsyfLQ26H46FOT3h93F04v6euJtCtg1Iw"
+			"pYfnu+v/4jv+Ea9+EGIysWpYJHJvmb163Z0l8/IkIC8KnHzqWNeL/yw5TpRORNIIPSYlSkU3rfFJ"
+			"cUB9Lu4HgFIH0oRoE6r7ENmOynYc/u08sD66JW/U2IloSA6o7LDpA0dX03SDnjclDXqIsm3bSc4M"
+			"xYZj+ajGwr6yaNgc+e25b5b9tjB/tuL+p8CZ4Ro35qhOCL1xlMqOW+ST4YCWF5/B8VJdQnRXqE23"
+			"7jPrb317S/mEAAAgAElEQVRFhluV91iqGJ41c7t1UMluj+Hztnb7vDqchmlIh+er69W1Za/5CoS8"
+			"D7QjxHYhccvsoqr7X19wQbWpzwLnhHPsGDIz9Kahf26iySfDAR1XaBHITSE2zuBQ89nAK1ausFQw"
+			"YU11L80qrYzJkvxLUAub0H7CHiF+w1mrGoZ8Z85XgH3hHjvqLJoxBAgtmRpAtdNe4EDAPgUbbJiu"
+			"QmvtLetRRwbVr1povZuVJRFJzq2o0wG5GWsZcV6DFf1oMT6InDF9x3ZAg40H1+wBsRJF/fm2u2Xs"
+			"uOGMacBnLfToswzpJ4JFM1yIfNNCj1YaGwdkzqHtgAYjaj5toXUchuvHEbMlFEzHXUDoUdCqlnWA"
+			"PlEYriVAjoUeq9sEzQYctgMalOiTvbfpwBIK8k+LiCm9Xjn/apTzLPQ4jPojVyZpsLNo9njgV9Y6"
+			"yb8iYksYsB3QYGTFug3ARgs9XCiPsmhGQqRM6pKC2SehusJSH9XH2gTZbT7ODbMyMcx/A6FHuAuN"
+			"xHkGbIlv2wENWuR31prrNAzXX1gapfd8yRnZYL6MlS8LeHGYUS+ONygomD2MgPE/YIqlfsrj3LOq"
+			"JjJG9R/bAQ1WXGmPEYzCtsLlHMh/hKULIht+sSj/ZNTxJjDKWkf9a9QDOwcDBfmngVkInGKxpxfT"
+			"+HUkTAoXtgMarAQrp/7Eekf9EgdaXuTGM/tcdbNHluR9HUPXYrVqidCI6fpZRGwarCyc5qYg98eg"
+			"hVisCdbGch4sHJABiO3YDmgwU3niw6j2Rd/vHHy+9ynIuwYrp1M98Y1ZEynIewXlIUKPdj6KKb8K"
+			"hhjYsHCamyW5XyUzZQvIz+lbDbyDmL5w1b2LGAMnEnrx7HzE/BIwE6Q9z+gDlCeoGv0kTz0V/vrt"
+			"g52nngqwJHcJymqsv5cjgL+yOPc2hDtwZTxruR79UgwO5M0Drgcu7YMN7WzEndbz3s/SBU4OtH4Z"
+			"5Sqk/QhaW4FVGMaDPFA4uIVWl2JwIH8mYl6CynUow/uRPaSoXseDb1WE08RIEHvFvEUzEjBc7RUf"
+			"u7PnPSRw2REZ08X5n0L01ZCvUVnvOa5rbhXk/rjtTtl3VGsQeQHVQsTYQGPjpk6xIzfmptAqUxBO"
+			"Q/QMkPOwvM/TiQZMOYMHi7Z22yJ4mvZ3RKd1Zz2wHNP3rV5P0AryTwANPcpadSEGZSG3DxWTDETG"
+			"gWSjnI7oTCAjLGML97GsONR0nZgSWwd04/kefNUvAz1qQwAgmCj1BLVw+lKbpwno/g5v6ucGbYWK"
+			"hQsdZO59BfTsMI7alaRGSHWoLKCoXMOKose7bbEkdzoqqwlFUEt1OyI97W3FEaKW0qBF5QVGei6x"
+			"moAcK2K7BPNV/4RjnM9X8y/iutkXMSptCPUtTTz19mvc+d/H8Pp9oL1KSPRGQttP1zgtiTsNLJ56"
+			"KsCSuVeg/kJgcphG7VGSIzzoD1hR3L3zWTjNjfIkbc4nPSGZH55/LZ+ZmkeC20NZxUfc9epjvLSp"
+			"ONheZGJk7R3gCFswPJ8fLM4HYjkDum5OMu7AQdruSHde9k1u+/Q1nZq9seMdPnPvt2j1Rzg2zdCz"
+			"eaBkcOcgLTkjG3WuAQ25nE0M+R3Li2/pscWS3C+i8ihAWnwSq29bwUmjsjs0UVVuffpefve/v0fO"
+			"0sFDEyIXsKzojVgbEiqxOwVzm+fQ5nxOHzOJW8/pWid8/oTTKJh3WTQtG7wsW1+KPzAH2BlrU3rA"
+			"BP1+r84HALmo/bfvn/eVTs4HQES449IbGJ0+LKxGDlISQF+gIG9BrA0Jldg5IGFs+6/zck5FpPvJ"
+			"2IKJp0fFpOOClevK8OtcoDjWpnRBHcpClpeEGhw3rv2X+RO6T2VzOZzMHW81Ru94oAs9ViUR4fnB"
+			"4oRi54BMbWn/tb6152IP9S0DMpF34LKy5CCV9fMR7ou1KUcQSjCN01lR/EzIfZSQPyN1n7TPiLAF"
+			"6eacXklE9VkK8mdF2SrLxM4BqR5Jpnz+g7XUt3T/AXts3ctRMem44qlNXpYV34RwsUX9oHDTBPyI"
+			"gO9My1G5x3xGHl/fvajjvprDrNr+dp8NHGTsQ/Q6lhVPQ7kS6HpzVCQN0dcG+kwodg5oVEkhEoyv"
+			"OFhXxdUP/4TG1uYOTVSVn73wR17efPzUUYk6y4qfo8UzDZUfoBrNpEQTeBLTOYXlxb/qW4a740gt"
+			"8z8VvcCK1f/s1KKqsY4rH/ohTd6WTs8dZ+wFuZGWuByWlfwJUJaXPA36BbpzQu3Lsetzz4qqpRaI"
+			"bRxQQd6VwBPt/x2Rksm1+ReSNWQk1U31/G3dK7y/L0r7qYP0FGzD/lEJbp/TM33snt40nGHRjFQM"
+			"500g36IPVS1CpBnhz/jN34WlRFFB3jMEo6wByMs6iYWnn01SXDybPyrnL8X/obqpvYSYKvSwmTj4"
+			"CKDyEgYrGe55vtvj9SWzLkSNpwFPN+M0YehFA/HzHfs3a0neD1B+GXNbBqED2lKac64pPGWgNY2V"
+			"aTkzZ4Y4y1g4zU1myrmoXoVwAf2PwK0CXkLkn4jnRR5Y1a+qph0Ihmu8CMzppaUfYTXKgL3bh0g5"
+			"yGqUF3EGXuH+daGJ/w9SJxR7BwSwOO8qhN8AY7p4NgAcRDnQ7aYbMDRFclwO4ivqdafXT3N37bpF"
+			"zYI2oa9BwfbdE7P9AfNd0GQRENGvTR5X+nAfhhJuOGMqfseZCN8Aejty3I9QCloKxjuIrGJY4fss"
+			"tVS13hrXLogjrvXXoAV0/QXbiso3EfMMkCsiZkcHZBJoV1pHO+m5aCMIzW0b7Ifa6sztRWU76t3Q"
+			"r/ytxbkXIPIMg8gJDQwHBMG7ckbK2RjmPEwjE9FGRN8G1wss67VEDHcXzl8PzFRl1m1z3lgfBYtj"
+			"xo4dOSleJ+80+R1jt9SlOc7IqAA46DZ10vjxpX0vQLck/9uodiV0tpKWuBt5ZFVsN1oKZg9DzM9h"
+			"6jQwEjDMA6i+QeXYN6KerFyQ9wjB/MWPITeyvOgPUbXlWJbknY/yDN1n0A8oJzRwsuGDyaIvtf3Y"
+			"9ECrwUpRHfd2TabR4HNR5XWT4fYO9zrkR8DtfR/ZrOjyniQkx9z5ACwvPASs7PzEuqibgkop0sWE"
+			"XM2+6PaEj2XFL7Ik77IenFACpjxPwazPsnzda9E27+PYekCDjC1l4xc5DF24qTbdaPAF09c216Wh"
+			"oCg3bynPye/z4KbR9fRfe0zw/GTSXYVaQ2LrgCDohFQuBbq7aSSA8W8KZoUzeblP2A5oELGtbNxk"
+			"Re6raPWwtzmROEdw1VHnc1PWkCyAA9VHNuwf1Ufx+UA3+w8a27piA5HuHJD2Sbkw/KwoegnkEga4"
+			"ExoYS7Als87ENL6KcCbB4+FGkLdiIEYmLM49H5EvAXkEs+9rgWKQx1he9AK9qUQtXOggc8/CoHCW"
+			"zCAoyl4ZFA0zHmFF4Zt9Nc6nrocM1L2pLo1T0ysZGdfM2oph1Prc7GhIYUR8syY4/BMTvfG/Bqzr"
+			"wTidhwl0uZdsO6BOGCd2+VFQcgje2CO3KR8qy4te5vrcizHlX3S3HFPjVQry6oDdqL6MYS4/orsV"
+			"BWK7Cb1kbjqm72FELum+kW7D4Edoz6JQ3/yM+y8uB1Pf3h348hubAputGyPD2sIBejgFktX4zau7"
+			"LRu8KH8yhj4JnNztEKr/xHBdF8rG+rFsKc05F9GXP2pO4J2aDE5Nq2JUfBPv1WSwrzk44cn0tDAr"
+			"owIB0zB1/qTxpdb0jb40PZHEhM5H6IoiVAMHUH0d9CFWrHvP0tjHCwWzh4H5V+DTPbR6B795OSvX"
+			"hV/IrC9cn3supvyT0LSQfIj+HxVjfh6NG3/sHNCXpieSmLgKdGZI7ZVYu8sgQhk+zWdlycEOj39j"
+			"1kQcxlpCmy1sQczFID0nOB3Dw1fV3Zseb87e2ZSB4XGTk1THxOQ6djYks73+qEzS9NRqRic0orDF"
+			"5ZfTJkzYaU1mtSCvid4/qIrqs+C4CyMQWaVJw2zh/vWbQm5/4/ke/FUnRcQWIQXTWAnaOS2/M/vw"
+			"a56lGvdL5qaDL5Sx+4BxJuidaIirHmE5y4qXRMaWo8RuCZaUuBQNOh8R4av5F3LD/CvIGjKK6qY6"
+			"Hlv3Mne88tej6RlRcj5Ow8GNZy3k63M+x8jUIRysq+Lhwn9zz2tP4Av4QcnCKfcBVx7TTXAYf6LN"
+			"+SS44/jOuV/ki7POIyMxhd1VB3jgjadZufY5NJjAPAU1LC3Frvt7u5NR0hNbueR0F7fnQ4qrY3Ds"
+			"lvpUhnpa8DgCU/xOfgD81NpfQOpBe3NAgshlYF6GRviNCTi2YqUWVqDmRFQiE8+lR/7BYRgsmXcZ"
+			"i+Zewuj0YVQ01PBI0Qvc/erf2rWrTsApK4ALQx/f/2mQJ3pv2Bc6LhfHZozgxxdcx4Unz8bjdLOu"
+			"fDO/fvkvR3PqlAIK8l9gedHzkbEnSGzmFB8TI1txzXdZNLfzKuytPVuZd/eSqOX5iAjPLP41l5wy"
+			"r9NzL20q5sL7b8VUE0AJmJOPpBoEE/5eB4h3eXjj1mWcMbbzd+aPa//N1//6/8Jm70VTW/jFBU28"
+			"dqij/tgJ8U2cklYF4HUYjikTx24PbU1/7YI44lpqaZO8HZKUxg/Pv5YrTjuLRE88mz8q4+5X/8az"
+			"70ZV72ory4tDd0DX5+dg6o4I2gPAY9f9jKvPOLfT42/seIdP//6m4M0KADmd5UXvhDTox1KTIsXk"
+			"EWNZc9sKMhM7CoyaanLtn3/JoyUvtj2iRSwvmR1JW2JzCnaMGNnMsVO6dD4AM8ZMZvGZPWwPhZmL"
+			"p5/ZpfMBOG9aHpeftqD9v4JhHBHLQuTIXe4bcy/u0vkAfG3OZ8nN6k5X3TrPb47jsbc8R07D2tnf"
+			"nEB98IjeHTAD3wl5wPjmL9DmfDITUyn+zkq+ffZVjE4fRnpCMnPGT+eZxb/uUrnyk8Snp8zq0vlA"
+			"ULeo43PmRV02jCH/d8n1nZwPgCEG9yz8NnGudsl1yWPRjIgeQMTGAR0jRnZmTs9CUj0JUYWbeb1c"
+			"q8PzQtaR3/WocNa8Caf2PEZOz89b5Q+rE/C1dNzmUWBL3ZEP2Fd27MjpXdAdOFaB8EcXfJXxQ7uu"
+			"Lfirzy3mhLRPbmhQb+/x/InHfE5UsrpvGRt6+s5lJKZw0qgjkQSCOMZF0pbYOCA9mqtV29xz3uLR"
+			"TOfI07stdcf+99gN5GNeT8/CWOF+PS1+4a9rOz9e4Y2jyucBiAs4+FxIg2loCoRup4v87O4P+o53"
+			"en2PG499jzXkg4ZoUdfrZ/SYz7lTredVWiBGDkjeb//1X++t7lHN7tGS6GVmPL7+v/jNrk8e/WaA"
+			"x9f/9+gDoh8c/Y955Ej66Pq5M/UtTfzrvT6HAXXLhj0O3invbPeB5uBesimEuo4P+cbQ24f4eObJ"
+			"t16lxdf14Z+pJo+tP0ZAT4wPumwYQ3r6ThWVbmTX4X3B/wiNuJ0RjQmKjQMaWVjSLkZW2VjLZSu+"
+			"R1Vjh9kFAdPktqfv47Vt0UtQ335oD9c8/NNOm94tPi/X/vkXbDlQ3v5QHZ74o6cDfn2GNlGoVdvf"
+			"5ttP3dPJkdU0N3D5g9/ncENkNMGeW++n+WNiHLVtqRqi2pXKAB+UZg1/r3Ti1zfsmPTyxtKcA/PH"
+			"e4+s23pypOWVH7FqxydGgbATe6oOctXKH3VS8fT6fSx67Ne8vWdb+0NN+M3OKmox5lcvPdLxZtrG"
+			"po9K+cIff3z0AZVn+F1RRGdAsYusWZL3OZR/ttswJCmNq884l1FpQ6hrbuTZd9849gsfVcZkDGfh"
+			"6Z9iaHIaFQ21PPXW/9hddeBoA+UmVhR31FtenPdrhO+2/3fyiLFcduoCUuIT2V9TwePrX4mY82ln"
+			"9iQHl+cejaxIdXmZM+QQir4yNav0MwA7duR4ajCuN9X4SkvAOeqj5viMRJfPkZNUz5PveFb89JWU"
+			"xRA8Ebzzsm9yy6e+0KFgwN7qQ3z2gdt4d2/ED5raGZCnYACjUodw1cxzGJ6SQVVjHU+/8/rR2QMQ"
+			"rP4RsgB/1E7B2jlr4gzOnjwDl8PJB/t28dTbrwVr8AWpxXRO58E1eyJpQ6wVEb8D/DrmdlhB9X5W"
+			"lHyz0+MLFzrI/PAJ4PLoGxVEBL55nptxQ4N/znYHZKo8MS175+c3luZ81m8aD5c3JaXtaUp0Zrpb"
+			"afQ7GZvQwJjERkTlysm/GXIFx8Q4nTF2CueflE+CO45dh/fx+PpXaGiN6E3x4wxYB9QLj7C8+Dqs"
+			"FHiPsgPqgXpULmVF0f8ifaHY5oItL/4Ni3M3InInMLWLFocRfRlT9nXxHEFBKMOFaBY9h8Z/nGdR"
+			"OTz1RMkdkiwT9lToq+WHzC3AVIR5dF2BdQ+iP2R5yV+7HDEYtr6Qxbk3IfIDoKtCVXWEUmK4j6jC"
+			"P4p93HyhG4cBCW3H84aYW7aWZ18XMPXBt2syHNVeDyelVjMmoZHVFcOJd7YtFw2txIj7GmbLCbQp"
+			"EK7fvYX1u7dEyuTjkf2o/IQVRX+MtSHd00NagfASOL7N8rXbum4QXmKfjLqi5D8s5SX2552BQ+Zh"
+			"6lExsjjHa/yuuPfb7eJZpyDGuyFfU5xfY/ma6usKFzwi6CmIPHtr/qpHAFi6wMmh5jNHpTovnzyK"
+			"GxDZ/9oHgS+j3jdDEFZXVpT8nmsXrCC+5azcCY6fJ7qYeaiBpzeW6904zGwCH8sTEwSVNFAXQhKQ"
+			"hGo+Imkhv55j+KhaeXNzgLNOcpDsCpprmhw0DB4sbUx2VHs9xBsBRsc3cbA1jnqfC5dhthlPCw+s"
+			"amDhtLPJTPkR6LeB5C7+gPtRXgX96MhDhjgwSUGIB10AnBiiycUIm1C8KHUAY4cak8YPl0vqW9i+"
+			"fpe/C/2fHpBANWrc0flxTQNJByYBoRcRU7aD/hek4668GoJhnpCcIKdkJMhJiXF8uPnDwNeoanij"
+			"TdvKOqJbMaWz7cdi4MLU7J7zJz8+LmUobwPVqFaDmMH3iWwgPdHD3s+c6rwqZ6Sx/zfnvXl+n2zv"
+			"I7F3QEBQzrO4BIh9+Yug8PfrtxSfeVBM4wag9rVvrrE2FQ2Kd714ZdH8S1FmKrxy2/ffKAKKQupf"
+			"kPcEHVM9LPHK+35OGWeQnuFFFQxDLgEc7UmrWcn1GKLsrA9OxtodkIkEnX3wC/QTrptzJy7/ZxCZ"
+			"BhKHcBCRVTxQ2LOzL8h7HPh8aNbq71lW0qGu8k1rz7ocMS8R2Lj+9rV3h/7KoU1D+XvdPr9ohgvD"
+			"9RGhivIL8SwvuZFullJL1yzIw9Ai4MCtsws77+xaYVnJ+8D7vbYLbl2E6oAUCcxn2foPu2vws7Vn"
+			"jxUJXEV31TUiyMBwQAMQFWlum6SGkkEcXgS1sHPQCa8fnij084XxrZjIQQd6Tr3fRaPfhdsIcGJ8"
+			"I5XeOGp9wYhXt7QpRwTMjgLoD6+tB/7R9nN88OBbPhbnP43oohB7nEhB3myWF3cRbQWGgwOmAsqI"
+			"8BnZC6pfsFD8o5AHunc+AA7DFDP4eevHp65v2IJk3aBitC/9utPWHdDsPGDyny0exNC9gKOqNehs"
+			"Rsc34RBlb1NwNmRwdAaUYJiHYmRudHGYf++90TGofqG7p2pbCB6PCsNVo3CYsjh3KiIWwunF2muN"
+			"MrYD6gZX4xEluejPgMLEHa8nUt1keAGaA8HJ7gnxTfhVONASfFnuo3lklVlZ5bHXfY4Gw0reALo5"
+			"2OgCkStZuqDL1cLSs1a1ADWA+/51n+pveaPeMbjKQms/Lmevp2p+w2x3nPYMaKDgaI5vnwENWgdU"
+			"2Wjwq1eSsgFMhGSnj2SXj4Mt8QTaZDSSne3Lfi2MlZ1RZykmqk9Z6DGUQ809SZceAPD6zMgvw1Ss"
+			"ZAK/zn2rD0fMljBgO6BuuOmCF1sJymq6n3xyoSPW9vSVl7Z5hr+114VTTEbGByN3P2o+Khmd7g4m"
+			"sooMiPiTfrHpw9EZm3bnTNuwYYar18ZiPG5pcFO6XYZJmwNSI8L7QEtyZ4AFzWnRkF6j02vPgAYq"
+			"LQC7J9UOyn0gCMYGLX05GcFkiKcVVaHaG9wPEmBUfFNAlQ8CjfFWZgQDjrKycXHi8+w2TN2YkFHT"
+			"tLk054PNZTl/3Fqac2WXagDLi9YRLCIYKpdxc36Xs2FT2hyQBCLrgLR7J9gFrXjin42YLWHCdkA9"
+			"oG3JmfEtgUHrgAB2Vjh4/j0HqS4vjX4nPg2+7eMSG3AbZp1hOC+eNq2PsSsDhHHjyltFguvKHQ2p"
+			"zj1NCSc1m46vqOgTPicVm0uzX9lall3wTtm4Y+OrnrRwiRSaOa+rJ0T1AIBhRnAGtBQDsOCA5CXu"
+			"WRVS7o/PcMdsBmQfw/eAtM2AGjUwaPeB2nl0vZurpjsQ95HNaM1OrP/IUDN/8ridEc33iQYi6NYy"
+			"diicWutzcbg1GepwJLl8jPC0uEbGNZ2V7PJ9Ok6Mu7aUj3/YacjvJ/w/43EwfxD6VfTzQOdZhYoX"
+			"ARU++9vC+RG5qa/dZmY/fcA3KuQOGtryK9bYDqhnmgEEc9A7oGYv/OTFZH58kY9T06ubh7hbdiSY"
+			"5pkTckrreu89SBDZgHJqstPH4dbgpLXB56LOCDAkznDubEgh0emLHxnXfIM/oDds/e7B5079beau"
+			"Fp8R6r7KRVy/IIkHVnWIilZDHKIKyHyF+WF+VQB8VGOpyk8D6vt3qI2dYrbXeLVnQAOMNgfUq0j7"
+			"oGBtuYtt+5r1Uzmtm1rim+dPGLV/wIll9QdV1gJfHxLXSmnj0QwSATJcraQ4vaw9PNzYUpvGuKQG"
+			"xiU2fHZRXrNx7+rEUC+RgNlyMfBYh+s6/G+I37FAYb+gYc+h8gXU2LDLXELoJ7LP8eBbg+K9tR1Q"
+			"zzQDOMzBGYzYFT9/OYm6xrgv//iyXYPiA2oFk8BLBg4z09ViuA0TrxlcDR1sjaO0IZnspHpOz6ik"
+			"sGIYW+tSKW9McuSOr1NZE9ysD4ngRnAHB3T7rDX/BkKecVhmcf55iN4ScnvFUvCh3zDFYQpin4IN"
+			"ONoC85wDeQbUTTnlrqlsMuTH/3VHvN5TLJiWVX5AYK0IjIjrmMO8rSGFilYPyU4fJ6cGa0K2BBwc"
+			"MNMly4rsuui53DArtDyycGGYVk6/KlFf9GRE+4ntgHqkXQ93AC/BVH+KRSeEcgPX50e03ErMEH0E"
+			"YGRcxwmeqvBuTSYtpoNR8U1kJR7dxjl5rKWFgAtToqf5dHN+PCqXWujxbAiqDR1wSDAOSPuVgdg3"
+			"bAfUIzLwHRBSiUr32d9dY2DqChaFELA3yGhwt/xdlZoMT+sROZJ2vKbB21WZmMDklBoyXMEgzFOz"
+			"DAwrWVzW4nH6R7N5AV1KonSDDuzcr49jO6CeaQYwB3pC6oqih9FgYUQLnITDFfq+wiBhZnBj/bcC"
+			"TEjqfMBX43OzpTYNAU5Lr8JjBEiJF7KGW/oqzKMgv+uaRWHHkrPbz8giq58DHD5XcAYk9gxoQKES"
+			"3AMaBKdgiuFYAlirA6/8lCVnRKgWeexwBeT3AodGxDWT4e78J9ndlMS+5gQ8jgCnpVciwOlZlr4K"
+			"Bmif9ZpCZtGMVKyUdoZ/BLW1Bg+2A+qZwZOQumztNpQ7LfaKB8f9EbEnhkyYsLMOlVsBTkqtxiGd"
+			"b+wba9Op97nIcHuZnFLDKWMdOKxl/IUouNYPxH0xVmbfavRp+eU3ghHksTgFs4/he0DUGAomqFx5"
+			"99r51mcKSh6AoUcrwUYUd/ov8VUtBJkUch/lPAryrmR5sZW0hAHPpKydj20tG//5JKf/wikptWys"
+			"7ahwG1DhrZohzB5ykKzEBhr9LiaOcLNlX8gTiFkszp3AipLICeAb+oWQXYJQxvLC4ojZEiEGhQPa"
+			"Wpo1ycRxlxha3qKBH5+WVR7Z+jZtqJhDJajfPQ/oumh8KOMYhB5C3x/ue7GVgrwC4DWsVRr5Pd9e"
+			"8EqouUODARF0y17XV/D53huT0HBCg99JeWNShzZNfgdvVWWSm3mYaanVzJs4lC2hqwQFdYLgV2E1"
+			"vJ2C2cNQ85yQ26s8QR9nMA4xxQxOguwZUFcoxpdF9CIU4sRx6ZZd2QVTxpc+33vP/iE4/ib4GwXK"
+			"VYOFFC0OMBEYaar+K/zWdcPy4lUU5P0NsKIbM4Lm5l8CncsNDWKmjN5auXnn+PPEIWumJNek+tU4"
+			"ogTZTrXXwwc1GZySVsW106t4+M0MfF0Xx+2Ka4iUA8K8HCvfTw0MqtOvdgaFA0LkDFB2NqRwYkLD"
+			"CI9h/ntL2fhVCD+cMm5XxIS0bs1/7SHgoUiNHzH8eitOuQBID7mPyBIWz36MFYWhCecPEqbm7Nq4"
+			"qWzCZwx4+eTUqtQ4I8DOho6n2vuaE0hy+hmfVMe88T7+tz3k6IQpLMo/mQeLIlB+WT8f8iRWZRMr"
+			"1r3Xe8OuCYi2CwnYp2Afp01nd4aqsLMhmVWHRjp2NiQTUJmPsnZL2fjHz53i7aoG1yeXlSUHEbUe"
+			"GyTmcRkbNC1rR4npYA7KnonJtczMqCTe6DjN2V6fwkfNCVw81WLRRYelKOXQ+HruaJC5IbcXc9CK"
+			"yQ14B7S5NPtE0AwVZd7QA0xNqWF7fSpvHhohe5sTUfh8QX5T9JY4g4VlJQ8hrLHY62TE+a2I2BNj"
+			"po3ducmjOj0Ajw/zNOv8YQd0YnLdsTXReLcmg6knGCR7LEwEVK4m3JV9nVxF6N9NxXT8rT+XM/xO"
+			"Ww+oO5wwxgS8AQMDODGhkVqfmz1Nibxfk86B5njizL4pFgp6EoCqeftdhfO73TMR0VpUej4eUTFF"
+			"tLa3ayrqRYzGntrc+x/v9N2H+x3OoRiBAgKOd4DQZzUiP+Prs55m5Trre14DnPHjS2uBq7eUj/+D"
+			"mvqbnKS6OVlJ9XqoOV4OtcZR73eypTGdueMbeXGzO9Rhx7IkN5dlJWE8gbISfChv8WDhrvBdO7oM"
+			"eAfkd+IxTFAM3qnOIDfzMFNTaqj1uaj1uTnUGkdFrVMg9J3DIwhOFASZSteloYNoCDc4CTWRRnpN"
+			"veCJ6pMAAA9rSURBVE5Pgt3hkBK/f/0mluTehcr3LfRKwGncD1wQBgsGJG37hnO3l0+Ygga+NDSu"
+			"5dKR8U2TaJvJeKa5rTig9tSM8Digb8yaCMwIvYPFEkNdEBCVtumWPQP6OM6AVpgixDn81PtdbKpL"
+			"Z3pqFTPSKymsHEZLwNEmu2DdAZmmfNEZgpC4aUoqYvY8JRY1VKWrmvIdMBC3qtmjAE1FrV4NTO9t"
+			"rJCIM35Bs16JFTFzOJ+C3MtZXvJ0WGwYoEwct2ML8APgBxv2j0pI8CZMJmBmnDLK53A59O++QMjl"
+			"sa9k4cJbeOqpPtwFP4bh+LwFP2DidA4K5cPuGPAOaGJW2cat5eM/Ehg5Iq6ZvU0JJDj85CTVkZtx"
+			"mHWVQ+nrEvz2Oas2AhvDanA4WJJ3GuFyQL8raub63Osx5WVrHY37+PaC/x1PsUE90ZZD9vaRBwqG"
+			"PA6EKlsygoy9CwBrJby7QrovgtgZXcMf1u7v7yUdYkpbTUX7FOzjiBAQ9A6AnKQ6XGKyvT6F0oZk"
+			"Ep1+Zg05jMeI+t9tcPFAyStgTaQKdCStLT+PiD2DAatpDaL9T824fvapwGQLFx2UsT/HMuAdEMCk"
+			"caX3Ac8kOv2cml6FU5St9amUNSSR6PBzUmpVrE0c+Pj120C1pT7KDSzJzYuMQQOckYVrgL0WelzO"
+			"jed7+nVN09KRvg/TF5ZSSoEY5oINCgckgtlYmfZ5hIeGelqYO/SgmeluZUt9Glvq0jrFdNh0wcqS"
+			"gygWKkAAYKByXMYG9Uowq9xKfE063upz+3FFwUrZHeF/PPiWNSG6AcigcEAAM2e+5ZsybtcihS/E"
+			"OwNVuZmHyc08bFZ73WysCz3g9xPNyOIHAauR49MxXMdVikbIqMUTJkv7Nx+jIG82cKKFHmFbfhk+"
+			"p60HFCpTs3b93WhxZIP8IN3Vunf2kEOMT6qzJEH5iWUpJhiLAat/r19SkDcuAhYNbFas24CyPfQO"
+			"cjHXL0jqvV2XWNlDasapYat6arQtwWxJ1hCZPHnb/2/v7oPjqs47jn+fs7vCsmxcAyngljB204SM"
+			"S0OA2CtwQEwgJWlLalI1caFTSgmScRNKkrbMNDQmNONJDCGF1DIeAu20eFw7EGCGZtqm5cUvsnDc"
+			"vJEOmcTuFNLaoQEXLNvSavee/rErIVtr6R7ty92X32dGzOrq3nPPCu+jc+455zmH37n4x+uWLtl3"
+			"boTLHj5aaNqp6PXwhR2Xzl+3fcXCddtXLPzijR0/W9BpDwcWMRdoubxBsZiF/NuaS3TsN4LvsbYn"
+			"DXwkfp34BvcPtcR+bg0/DD+TpYt/NETfshGM65OuS6NYv+O9f+ycu7fsD/Oe21d2cPeTOV4dDvqD"
+			"90FWd/8WA4OPV6WSzSJiM4474l9gqwjtHh04dgVmb4lfp+ruehpZZKBteaRKnHMn7qIwTHEE7BDw"
+			"0440+6+5OH0wuGDv7+PGS+MnSG8FmwZfBEJWml/NH3afFnaToLzPbzDaWfNUNPXS9C0gmcogX/xT"
+			"5q781CVPn3xyXH92K9AbUPQ5ZPKfA26rqIJNx28Be1fMkztIsxL4aqyzb+iZg43E3+bH8yR/88xI"
+			"7PNjcOYTS0imFlA7c4VP4H3YTGezj7N6ecBapRYQZTYT8uEMmZTYOXo1cGr8ylS3+5U0BaB2tmHP"
+			"QRyfCbwqhbcH6O0NS+HezDbteAl8yGLTK7jlPTOuMQTABw3dv4rP/0vA+bEULLl0HApA7e7MoQHw"
+			"oVkQL+K0l9psblDQsocUhdTMXdvikH38UTNvj4buetroFIDa3VoiolnMDTK7q5i5r024wlZCUi7E"
+			"mZQYjXyI4hSHuGXWpPvl8l4tIEnQpsHvY/ZXgVfNJ2331aQ+jWjDnoPAM/EvsCw3LVs87SlhWzz/"
+			"N2ftfi7g/KagACRFhdxnseCdP1bSt/xDNalPI7Kg+T1G2k4+uXDNstMxH7J2bGutdj2NTC0gSdqm"
+			"vUeBNcHXmd1fwfKDJpN+lKDtr6dp4UT2YUJS5bZA6o1yFIDkTQO7vwGEZkE8Bz9yZy2q03AGdhzC"
+			"+OeAK36VNe9ZWvYnkYWs/foRGwefDzg/iLNILSBpENHYx4EZk+sfx3MrN2cvrE2FGkxkYQ+C86mp"
+			"gaa/+xcwLg8opaW2zZ5MAUiOt2nvAeAvAq9K4dpkbpDPPYEx7a4mxzFWcWLOYKOXoM9eYHbGQOPz"
+			"gGym3RJqoC2XYvRd6c4/7/qehl1NfMejoz83fDTBNLNn7f4KB7OrgIBsiP5iTv/JauArld7eHKni"
+			"R8EW3Luz54JKy6u2Ox4d3TF81P9azNN/ib5lF/HA89+aOBI2+fAFNu5qvLzlVdKWAeic0+3ZyBo3"
+			"j/TbzjS+858J1m8tEat9H972EvRvxH+e/u6vV/oooeBJO8Dj3+eNb1dUWA30Lk/x8NP5+Bc4twoo"
+			"BqC+5b8MLIt9rVHzpReu4A0H3ur/oWjLAFTwvIDNZiOx+siNcS4Qd0uY2hgY+h792fsJW3h6KvBl"
+			"IODTOVU6n386yrhZ73Vea+ctcjYnY0tHxny8Lqfno/T2/inbthUw+52AW3kotOTo17i2DECf3Vq4"
+			"jIEdYQna62l1dgshCapqJRq7E5f5CLAo/kX+t4GXK7ntbZdtPwA0XNfrOH3ZhzD+IObZizjjJyuA"
+			"Z4GT7sBbxh4G9uwPr1wYZ8Vtf5URURrLpr2v4/0ts7gyJLdxkwpcFuGjVdzcfT7wztjXWOCIWxNS"
+			"AJLpPTD0BPCPSVej4bz21n8Dfhr/AuvF+d8PuEOBQq4uqYbHZ0IrI2Ibufe595597/YVS760q7sz"
+			"6brMyBX6gcNJV6OhFLdhfizgitMImmnud5amRLS0tnwGNNk9z192Dnl7qfRtRQ9PQ3hIeTDvUu8H"
+			"qp7jpao27HmZ1d134f0Xk65KQ/FuCxbF3b4ZYE78U+u39MJZyiJfegpUZ23fAvJ51zXp23S9vnxp"
+			"cpovuI6avsFq+dkvfgnYm3Q1Gkr47qlx5clkvlaDchtO27eAcNZF5DH8v3d1HKnbNsTDo11fw+wa"
+			"M98cu45u21Zg9fI+vA0BrT/jOY61RPTzD8Cnqlqu8U3u3/6/VS1zGgUrzQDymgdUf4VCF2Z4bLjv"
+			"4vplm7t71+UjBjiLmqMFBDAwtJf+7F8Dn0i6Ko3DHgFf3QCEf6S65TWutu+C4awLwAhY31MF5m0M"
+			"IApKydAAcqnPUJtuR3PaOPht4D+qWOJRRtNPVLG8GU1kRNTWzAmIbPwZUF0DkHc+B+Aia54WEMBD"
+			"Ow/juTXpajSYaq5Wf4qHdrbNiGPbd8Gci7q8NyKsrgHIecZK3e7mCkAAD+x+jP7sk8A1lRa1YJ7r"
+			"un37ioWTj42edujI2qU/yFVadiV8wIDQC/+z/87z77pubXVuHLirahVE5s1IZl+wtg9ARNaFAebr"
+			"2wLC54rb4brm6oKNs8Jt+NSVhCRVL+M3L0w92JFKPTj5WMfrZ3DPrrLpcgpA2SwGBkc8TAlaBgV/"
+			"kmvAD3tsynO/zvT8uU+8+OcXpFxmynvrSM3F2dRn8O846+f54cFXyt8mvtcZndNWkz5bIwA5SwfF"
+			"7rS9+b6NYhfM1/kZENa8LSCAgT376V9+F9i6SoqJIjvC1MDRBZT7vaSAhWWO409+fBp2QqKeopH8"
+			"YfYd2jntlSda9rZF/DB8s+sTPV7tXU/jcJYyTzLzgBo/APVl/w7j16c5Yy6eU4LKHBt7hf7sMWDk"
+			"zx4Z7UynIB/xR/Rnb5o4x6LfY+D5p2ZX6Zl5sxzeQ1R2GD5+q8gS/H8Y5e/BZa4DfmW2RWzekbtp"
+			"8/VDsbodW7f2pvadfaDsLqIdp7h5bjSa8nuLOkh7nym7n72LmHfiNIgrl3z6m/M63kKucLRsHXKF"
+			"o0R+aiKF7KKM//udnwvquk3hk8n7XDBvzoNR/2H4cn8AGkt/9jFgZf1vbNeycfDrVS3yY8veTsrt"
+			"Bsik6EynmJMvcGysQPGvnveG2WzScIwBw+PfnJJhvjPSo2Mcjjx54CE27v50Nd7CFP3ZS4HnmPWA"
+			"hl/FxngBqB4qCSCXrP+YH9w/u9xhXR2dI0dG3jg1iY0H1w/29DjvnzZ45pOXPHtFPe+tUbB6yrjx"
+			"LsTCsQJzjuVgrEDn+LFZBh8otpgWjn+NjpE+loPIM790rKLnNNPauHsn3h6c+cTGV1HrBbhuWdwk"
+			"iVNdvTR7IKldT12hOAzvNQwvTcmlbidoZXhjMqusQ3DtBT2WcrP7SF377p4XK7p5k2r8Z0DS+AZ2"
+			"HGJ19yfx7TODt5yzF5xBz9sv5F9f/NbMJ0+yYK7jlWj9pffsunwfAJ48Vsw+YPh8hJVek+fNrAR5"
+			"K72OjLyVziEiD9HE+ZHZRDlMKsdKx/OQ9/AO8x7D6p6ZQQFIqmNgcDP92RuAq5KuSpI+evFVwQHo"
+			"XecaUTR2KsWUtsc9mfUnGakr/qyo+Oi49J1N/Ad/XFF23HXj3c3J7bXIR28NqngVKABJ9Ti7hch/"
+			"D2j8HEcnYWYVPQv68LuvsDVb7va5fPzHOYsXdN8Y+V1PpSM3r1iHTCafpvg67zMuVXxdwGfMl47j"
+			"MxE28ZqJ4y7jXfE1kc+YFV9HxsS1QMbzZjmUysFsaNZvfJYUgKR6Ngz+mP7s54G/TLoqlagkCC2c"
+			"O58PLu3m8e8+F+v8lKX2/e0Ndz9c+rbimYzNRg+hpbpePbye6i7OTISZzeah9BJgycuvvRI7W0CB"
+			"fFs/N1MAkura9oMczl0HlJ/J12TGA1HMr/1mtn/vf33/q0yalzWtgmv5xPPTafwumNk+vK9/Jj4X"
+			"/V/d79kqNuz6Dv3d15Z2jii7RKKlbdp7tLRY93dnOPO7bBpsy+H3cY0fgAYG/yTpKlRNLhoh7RJI"
+			"a+pfmvmcKts4+E/cfNFiUpk1RHYJxpngp/ZpHK/VvW714NmC8QFgAeV7GsOYtXX3C5phKYZIA/Pe"
+			"L6LYyiubcP799936hdeOvPG+Ew5H61b2f+Cq85a/epJi3wAOjs/VaWUKQCKzUOmyjRCVztBuZK37"
+			"zkRqpJ7BZ1yrBqHWfFciNZJE8BnXikFIw/AikhgFIJGYkmz9tCoFIBFJjAKQSEyt+AwmaQpAIpIY"
+			"BSCRJtCqrS8FIJEArRoIkqLfpsgs1GtETAFPRERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERERE"
+			"RERERERERERERERERERERERERKT2/h8g+1rQ77W2SwAAAABJRU5ErkJggg=="
+		)
+	)
+	(label "3V3USB"
+		(at 173.99 76.2 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "0cc13057-a985-41d9-954c-763c334e2e42")
+	)
+	(label "V3"
+		(at 147.32 78.74 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "15ea67a3-fec9-41b4-8e68-df2d2e02838e")
+	)
+	(hierarchical_label "nRESET"
+		(shape passive)
+		(at 214.63 118.11 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1c1cdf6d-f79d-4853-937d-844a81bb7912")
+	)
+	(hierarchical_label "VBus"
+		(shape input)
+		(at 212.09 66.04 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1c800099-bc25-41c1-b867-0ccea2f5a251")
+	)
+	(hierarchical_label "GPIO0"
+		(shape passive)
+		(at 219.71 149.86 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5f62c175-5a1c-4a13-b81f-43d0fc4ac888")
+	)
+	(hierarchical_label "ControllerRX"
+		(shape output)
+		(at 213.36 87.63 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "83f490d0-dd95-42b4-b7b7-782fcd3bcf15")
+	)
+	(hierarchical_label "3v3"
+		(shape input)
+		(at 213.36 76.2 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "dba2663a-98a6-4848-9109-561661badead")
+	)
+	(hierarchical_label "ControllerTX"
+		(shape input)
+		(at 212.09 96.52 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "ef01fced-de3a-48d0-9650-12cbfe6b1dba")
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 172.72 87.63 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062be3195")
+		(property "Reference" "R502"
+			(at 171.45 82.55 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 172.72 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 172.72 85.852 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 172.72 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 172.72 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 172.72 87.63 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 172.72 87.63 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 172.72 87.63 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 172.72 87.63 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 172.72 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 172.72 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 172.72 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 172.72 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "9352e332-f0aa-4468-932e-f7f94ca421aa")
+		)
+		(pin "2"
+			(uuid "c02d29a2-4bfd-46f9-ac78-a16d7bb40054")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "R502")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 172.72 96.52 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062be31a0")
+		(property "Reference" "R503"
+			(at 171.45 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 172.72 93.98 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 172.72 94.742 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 172.72 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 172.72 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 172.72 96.52 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 172.72 96.52 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 172.72 96.52 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 172.72 96.52 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 172.72 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 172.72 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 172.72 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 172.72 96.52 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "fd369641-4abd-4121-a609-72445d7a2682")
+		)
+		(pin "2"
+			(uuid "a02b5693-4db3-42d3-83d5-35dbe8bbec58")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "R503")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 137.16 82.55 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062be31b2")
+		(property "Reference" "C503"
+			(at 140.081 81.3816 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 140.081 83.693 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 138.1252 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 137.16 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 137.16 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 137.16 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 137.16 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 137.16 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 137.16 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 137.16 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 137.16 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 137.16 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 137.16 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "9f5cfd73-f67a-4cf1-b146-4d071ed80c06")
+		)
+		(pin "2"
+			(uuid "911f4b12-ce17-47db-a0c8-26b7006ca061")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "C503")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Polarized")
+		(at 120.65 82.55 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062be31c2")
+		(property "Reference" "C502"
+			(at 123.6472 81.3816 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "47uF 16V"
+			(at 123.6472 83.693 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:CP_Elec_5x5.4"
+			(at 121.6152 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 120.65 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "47uF 16V 33mA@120Hz ±20% SMD,D5xL5.4mm Aluminum Electrolytic Capacitors - SMD ROHS"
+			(at 120.65 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 120.65 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2895272"
+			(at 120.65 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "KNSCHA"
+			(at 120.65 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RVT47UF16V67RV0019"
+			(at 120.65 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 120.65 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.038"
+			(at 120.65 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 120.65 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 120.65 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "138131f2-27b8-4159-a441-04ace852918c")
+		)
+		(pin "2"
+			(uuid "dd34936a-c1bb-429b-8c41-208c87de4a8e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "C502")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 106.68 82.55 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062be31cd")
+		(property "Reference" "C501"
+			(at 109.601 81.3816 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100nF"
+			(at 109.601 83.693 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 107.6452 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 106.68 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "50V 100nF X7R ±10% 0603 Multilayer Ceramic Capacitors MLCC - SMD/SMT ROHS"
+			(at 106.68 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 106.68 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C14663"
+			(at 106.68 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "YAGEO"
+			(at 106.68 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CC0603KRX7R9BB104"
+			(at 106.68 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 106.68 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0021"
+			(at 106.68 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 106.68 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 106.68 82.55 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "f4d65384-8043-4293-ac2f-ea9abe61b1be")
+		)
+		(pin "2"
+			(uuid "0fba8e4b-ba8e-4ab9-a371-11348b3b15ec")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "C501")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 133.35 121.92 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062be31ed")
+		(property "Reference" "R501"
+			(at 132.08 116.84 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "330R"
+			(at 133.35 119.38 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 133.35 120.142 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 133.35 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 330Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 133.35 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 133.35 121.92 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269711"
+			(at 133.35 121.92 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 133.35 121.92 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC06033301%N"
+			(at 133.35 121.92 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 133.35 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 133.35 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 133.35 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 133.35 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7c46793d-ce23-4c4a-a792-d1be1ec93f74")
+		)
+		(pin "2"
+			(uuid "3d4b5b39-d571-4e3e-a0ce-b783786c6705")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "R501")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 121.92 121.92 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062be31fb")
+		(property "Reference" "D501"
+			(at 123.19 119.38 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Value" "RED 0603"
+			(at 124.46 124.46 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0603_1608Metric"
+			(at 121.92 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 121.92 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "LED RED CLEAR SMD"
+			(at 127 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 121.92 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C2286"
+			(at 127 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "KT-0603R"
+			(at 127 134.62 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Optoelectronics"
+			(at 127 137.16 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "LED Indication - Discrete"
+			(at 127 139.7 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Hubei KENTO Elec"
+			(at 127 149.86 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 127 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 121.92 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0054"
+			(at 121.92 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 121.92 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 121.92 121.92 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "78915f80-996b-48ed-bf0a-0e4a01ea1d2c")
+		)
+		(pin "2"
+			(uuid "246d5ebe-4911-435b-90d0-eb2af4f12ae1")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "D501")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 182.88 110.49 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00000000-0000-0000-0000-000062be320c")
+		(property "Reference" "R504"
+			(at 186.69 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 186.69 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 184.658 110.49 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 182.88 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 182.88 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 182.88 110.49 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 182.88 110.49 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 182.88 110.49 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 182.88 110.49 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 182.88 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 182.88 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 182.88 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 182.88 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "ce47349e-9b83-41ac-b2f2-0d3109eb9322")
+		)
+		(pin "2"
+			(uuid "db207fb4-184a-46ed-9c3e-520a09006685")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "R504")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 201.93 76.2 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0337563e-c4c6-4c4a-bc15-49f7e2e14351")
+		(property "Reference" "R216"
+			(at 203.2 71.12 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1R0"
+			(at 201.93 73.66 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 201.93 74.422 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 201.93 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 201.93 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 201.93 76.2 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 201.93 76.2 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 201.93 76.2 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 201.93 76.2 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 201.93 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 201.93 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 201.93 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 201.93 76.2 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "453ce998-aab9-4630-9b00-2577498741a9")
+		)
+		(pin "2"
+			(uuid "461f9f20-837c-4f85-905b-0a6cde030a0e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "R216")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 120.65 87.63 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "17e367da-3f31-499a-bdfb-2c008e6ec973")
+		(property "Reference" "#PWR0215"
+			(at 120.65 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 120.65 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 120.65 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 120.65 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 120.65 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "780cdb9d-7e88-43d0-b30b-4ea5968b1861")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "#PWR0215")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 72.39 129.54 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "195b144a-de1f-48cb-998b-9b75c0b764b0")
+		(property "Reference" "#PWR0209"
+			(at 72.39 135.89 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 72.39 134.62 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 72.39 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 72.39 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 72.39 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "109b69db-810a-4c70-94cd-85fbba5a20f3")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "#PWR0209")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 172.72 154.94 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2b0ff883-c1ba-4e06-946c-4567e28994fb")
+		(property "Reference" "R217"
+			(at 176.53 153.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "4K7"
+			(at 176.53 156.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 174.498 154.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 172.72 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "1W ±1% 4.7kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 172.72 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 172.72 154.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269713"
+			(at 172.72 154.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 172.72 154.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 4K7 F N"
+			(at 172.72 154.94 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 172.72 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 172.72 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 172.72 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 172.72 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "9bd92741-64d1-42f5-ba26-b8dd18bcf5df")
+		)
+		(pin "2"
+			(uuid "3c53376a-c5e9-4152-bd2c-0939470b2818")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "R217")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 229.87 86.36 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "30e9c6c3-f1c0-4c64-8b14-fce9ca0c5089")
+		(property "Reference" "TP206"
+			(at 229.87 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "U0_TX"
+			(at 231.14 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 234.95 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 234.95 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 229.87 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 229.87 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 229.87 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 229.87 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 229.87 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 229.87 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 229.87 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 229.87 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 229.87 86.36 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6f0dffe3-7d61-4ef4-91d0-c2f8fe4632d8")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "TP206")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 137.16 87.63 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3b8dc387-9564-4c9c-bb0f-81e5181224e0")
+		(property "Reference" "#PWR0214"
+			(at 137.16 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 137.16 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 137.16 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 137.16 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 137.16 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "430630e9-cab2-47f9-b20f-426dd32c6290")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "#PWR0214")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:PWR_FLAG")
+		(at 161.29 74.93 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "47c7159a-a915-4fec-8db7-cf2c314e8191")
+		(property "Reference" "#FLG0201"
+			(at 161.29 73.025 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "PWR_FLAG"
+			(at 158.75 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 161.29 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 161.29 74.93 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 161.29 74.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "d9095c5d-04bc-48b0-bf6f-4581f2d814f6")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "#FLG0201")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 102.87 72.39 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "4d49e72a-82c3-4f7f-a0d6-3ebdc8952d81")
+		(property "Reference" "TP201"
+			(at 104.14 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "VBus"
+			(at 104.14 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 107.95 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 107.95 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Red"
+			(at 102.87 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 102.87 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 102.87 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 102.87 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 102.87 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 102.87 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 102.87 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 102.87 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 102.87 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c2a301a8-f277-4252-8de3-21e7accd45c9")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "TP201")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 129.54 72.39 270)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5837f945-0631-444b-943b-017afe300c6f")
+		(property "Reference" "R213"
+			(at 128.27 67.31 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1R0"
+			(at 129.54 69.85 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 129.54 70.612 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 129.54 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±5% 1Ω 0603 Chip Resistor - Surface Mount ROHS"
+			(at 129.54 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 129.54 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269434"
+			(at 129.54 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 129.54 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC060315%N"
+			(at 129.54 72.39 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 129.54 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 129.54 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 129.54 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 129.54 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "692c7983-b42a-469e-bf08-507802487ba6")
+		)
+		(pin "2"
+			(uuid "7c6390fd-031c-4775-ab78-01d051854006")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "R213")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 137.16 71.12 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5d43196d-d659-4f19-9c48-4fbf1939a3e8")
+		(property "Reference" "TP202"
+			(at 138.43 67.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "V3"
+			(at 138.43 69.85 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 142.24 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 142.24 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Red"
+			(at 137.16 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 137.16 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 137.16 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 137.16 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 137.16 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 137.16 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 137.16 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 137.16 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 137.16 71.12 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "48131a03-7f42-4499-9fcd-0560c47f68f6")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "TP202")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:CH340B")
+		(at 154.94 97.79 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "651860ec-5ba1-44df-8ca5-5c645d270337")
+		(property "Reference" "U501"
+			(at 156.8959 113.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "CH340B"
+			(at 156.8959 115.57 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_SO:SOIC-16_3.9x9.9mm_P1.27mm"
+			(at 156.21 111.76 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://datasheet.lcsc.com/szlcsc/Jiangsu-Qin-Heng-CH340C_C84681.pdf"
+			(at 146.05 77.47 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "2Mbps 3.3V Transceiver USB 2.0 SOP-16 USB Converters ROHS"
+			(at 154.94 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "1.05"
+			(at 154.94 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 154.94 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C81010"
+			(at 154.94 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 154.94 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "CH340B"
+			(at 154.94 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "b7869023-6eb0-4330-ac25-b03239b6bf0d")
+		)
+		(pin "10"
+			(uuid "df8615f4-3e97-4174-8f37-81a60079ae55")
+		)
+		(pin "11"
+			(uuid "b96f53e0-beb6-4490-b583-f096d90f55d9")
+		)
+		(pin "12"
+			(uuid "0545a296-ef88-4eef-9a88-e07c2967992d")
+		)
+		(pin "13"
+			(uuid "1e4d1d11-82f8-46c2-be32-cc89ec80c769")
+		)
+		(pin "14"
+			(uuid "a5db1bb3-74fe-4663-88e1-248809a04bfa")
+		)
+		(pin "15"
+			(uuid "8d86b5d6-e62d-414c-a3fd-6fa1a666c169")
+		)
+		(pin "16"
+			(uuid "3626cec7-3e18-4f6f-a036-283d15e5a6ba")
+		)
+		(pin "2"
+			(uuid "8a0ec365-4830-4e98-b9c3-470e0e6f0666")
+		)
+		(pin "3"
+			(uuid "f1ab468e-14cd-4776-b353-5abcf71f970a")
+		)
+		(pin "4"
+			(uuid "be12b52d-8c0c-486b-a337-c8819efdb2b2")
+		)
+		(pin "5"
+			(uuid "116507d4-9466-4c3e-a442-ac7115e1d77e")
+		)
+		(pin "6"
+			(uuid "d41b0817-49da-4025-a477-39746732769b")
+		)
+		(pin "7"
+			(uuid "b3a9cbce-4480-4b9d-bd57-e298002daebf")
+		)
+		(pin "8"
+			(uuid "9f344d54-e6e8-414a-871e-9857deb13bef")
+		)
+		(pin "9"
+			(uuid "5096c712-fe17-424b-b921-65e9cea78550")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "U501")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 199.39 125.73 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "763878f0-6530-40ac-839d-ef5d0582c474")
+		(property "Reference" "R214"
+			(at 200.66 120.65 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10K"
+			(at 199.39 123.19 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 199.39 123.952 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 199.39 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS"
+			(at 199.39 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 199.39 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269701"
+			(at 199.39 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 199.39 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 10K F N"
+			(at 199.39 125.73 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 199.39 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 199.39 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 199.39 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 199.39 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "43dfb2a0-bdc4-455d-85df-a590b428e8c4")
+		)
+		(pin "2"
+			(uuid "f4c03a40-b872-433d-a6ca-f5ed3664e9ee")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "R214")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MMBT2222A-7-F")
+		(at 208.28 125.73 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8d66a63c-27aa-4ae4-9d71-c16aadfac842")
+		(property "Reference" "Q206"
+			(at 213.0552 124.3838 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MMBT2222A-7-F"
+			(at 213.0552 127.0762 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 213.36 120.65 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 213.36 118.11 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3"
+			(at 213.36 100.33 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "MMBT2222A-FDICT-ND"
+			(at 213.36 115.57 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "MMBT2222A-7-F"
+			(at 213.36 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Discrete Semiconductor Products"
+			(at 213.36 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Transistors - Bipolar (BJT) - Single"
+			(at 213.36 107.95 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 213.36 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723"
+			(at 213.36 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Diodes Incorporated"
+			(at 213.36 97.79 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 213.36 95.25 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 208.28 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 208.28 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C94515"
+			(at 208.28 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0475"
+			(at 208.28 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 208.28 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 208.28 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "9de47db2-25f1-4dbb-a489-2724d96d2deb")
+		)
+		(pin "2"
+			(uuid "e696176b-33f2-4bd4-8009-90e683aadee0")
+		)
+		(pin "3"
+			(uuid "b0b81a3e-ed38-4a48-afa1-132ca12db330")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "Q206")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_2")
+		(lib_id "power:GND")
+		(at 172.72 158.75 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "991d9664-ba6b-47ce-85ac-b2614cfea5bc")
+		(property "Reference" "#PWR0202"
+			(at 172.72 165.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 172.72 163.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 172.72 158.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 172.72 158.75 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 172.72 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "5cea170e-2dae-436f-8aa0-89ac9a277071")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "#PWR0202")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 106.68 87.63 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9b3143cb-31dc-426d-a493-fdceb5864767")
+		(property "Reference" "#PWR0216"
+			(at 106.68 93.98 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 106.68 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 106.68 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 106.68 87.63 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 106.68 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "6320641e-15e0-4b74-8e82-4c8ccd60cee3")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "#PWR0216")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:MMBT2222A-7-F")
+		(at 208.28 142.24 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a7787a17-8e2a-4f13-a9fb-59b893afa936")
+		(property "Reference" "Q207"
+			(at 213.0552 143.5862 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MMBT2222A-7-F"
+			(at 213.0552 140.8938 0)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 213.36 147.32 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Datasheet" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 213.36 149.86 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Description" "TRANS NPN 40V 0.6A SMD SOT23-3"
+			(at 213.36 167.64 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Digi-Key_PN" "MMBT2222A-FDICT-ND"
+			(at 213.36 152.4 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "MPN" "MMBT2222A-7-F"
+			(at 213.36 154.94 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Category" "Discrete Semiconductor Products"
+			(at 213.36 157.48 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Family" "Transistors - Bipolar (BJT) - Single"
+			(at 213.36 160.02 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Datasheet_Link" "https://www.diodes.com/assets/Datasheets/ds30041.pdf"
+			(at 213.36 162.56 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "DK_Detail_Page" "/product-detail/en/diodes-incorporated/MMBT2222A-7-F/MMBT2222A-FDICT-ND/815723"
+			(at 213.36 165.1 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Manufacturer" "Diodes Incorporated"
+			(at 213.36 170.18 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "Status" "Active"
+			(at 213.36 172.72 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.524 1.524)
+				)
+				(justify left)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 208.28 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 208.28 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C94515"
+			(at 208.28 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0475"
+			(at 208.28 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 208.28 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 208.28 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "3e8adfde-59c4-4124-bb82-f9f909a157f6")
+		)
+		(pin "2"
+			(uuid "fad493a7-65af-4e19-9418-09f9b19e8da5")
+		)
+		(pin "3"
+			(uuid "1a11390f-a32a-4d1e-b24b-55f508774e4e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "Q207")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 200.66 105.41 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "addc1ab8-8672-45af-ab9e-760bc1b60a98")
+		(property "Reference" "TP203"
+			(at 201.93 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "nCTS"
+			(at 201.93 104.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 205.74 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 205.74 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 200.66 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 200.66 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 200.66 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 200.66 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 200.66 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 200.66 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 200.66 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 200.66 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 200.66 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "825c8662-d51a-436d-8d48-2ee00736ad83")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "TP203")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 100.33 110.49 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ae29f84e-a2f6-4065-8ed8-dbc76672bccd")
+		(property "Reference" "R212"
+			(at 104.14 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "5K1"
+			(at 104.14 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 102.108 110.49 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 100.33 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "100mW Thick Film Resistors 75V ±100ppm/℃ ±1% 5.1kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 100.33 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 100.33 110.49 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C23186"
+			(at 100.33 110.49 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "UNI-ROYAL(Uniroyal Elec)"
+			(at 100.33 110.49 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "0603WAF5101T5E"
+			(at 100.33 110.49 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 100.33 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0009"
+			(at 100.33 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 100.33 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 100.33 110.49 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "7685b497-53ad-4cf0-bbef-c6c09492c88b")
+		)
+		(pin "2"
+			(uuid "aef29479-a10f-4265-bb56-67df81dfbeee")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "R212")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 92.71 118.11 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b7e3b7ea-0615-44e6-8312-7172c2961a07")
+		(property "Reference" "#PWR0210"
+			(at 92.71 124.46 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 92.71 123.19 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 92.71 118.11 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 92.71 118.11 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 92.71 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "c9763270-0c86-4a56-ac61-4c0d1f633c8d")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "#PWR0210")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 168.91 72.39 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "bcdd210b-9cb0-46a4-b4a0-7f3b3379c8b9")
+		(property "Reference" "TP205"
+			(at 170.18 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "3V3USB"
+			(at 170.18 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 173.99 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 173.99 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Red"
+			(at 168.91 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 168.91 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 168.91 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5277086"
+			(at 168.91 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5000"
+			(at 168.91 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 168.91 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0717"
+			(at 168.91 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 168.91 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 168.91 72.39 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "77386e4d-ce50-49ce-a1fe-081d2e71fe38")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "TP205")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 130.81 105.41 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c935664c-f18e-4a0f-833e-e866d06d4718")
+		(property "Reference" "TP204"
+			(at 132.08 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "nRST"
+			(at 132.08 104.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Loop_D1.80mm_Drill1.0mm_Beaded"
+			(at 135.89 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 135.89 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "Test Points/Test Rings 1.25 mm Yellow"
+			(at 130.81 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "HAND"
+			(at 130.81 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 130.81 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C5199804"
+			(at 130.81 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RH-5004"
+			(at 130.81 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "ronghe"
+			(at 130.81 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0800"
+			(at 130.81 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 130.81 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 130.81 105.41 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "58a7d20d-9d05-4d87-bc2b-4c8990620edc")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "TP204")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 63.5 125.73 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d167c2a1-a3cf-42e0-9b80-44dcd5807359")
+		(property "Reference" "#PWR0208"
+			(at 63.5 132.08 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 63.5 130.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 63.5 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 63.5 125.73 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 63.5 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "be373e66-dd36-4df5-974e-5c024007a0df")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "#PWR0208")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "GPAD_SCH_LIB:USB_C_Receptacle_USB2.0_GPAD")
+		(at 71.12 102.87 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d1a30577-ae94-4552-be46-71ba6e28d972")
+		(property "Reference" "J501"
+			(at 71.12 80.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "USB_C_Receptacle_USB2.0"
+			(at 71.12 82.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "GeneralPurposeAlarmDevicePCB:USB_C_Receptacle_HRO_TYPE-C-31-M-12"
+			(at 74.93 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip"
+			(at 74.93 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "5A 1 16P Female Type-C SMD USB Connectors ROHS"
+			(at 71.12 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 71.12 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C165948"
+			(at 71.12 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.1529"
+			(at 71.12 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "TYPE-C-31-M-12"
+			(at 71.12 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "Korean Hroparts Elec"
+			(at 71.12 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 71.12 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 71.12 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 71.12 102.87 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "A1"
+			(uuid "8d06cbf4-605b-4a2a-a44e-ab01fe86b7ac")
+		)
+		(pin "A12"
+			(uuid "8a12e76e-0250-4f32-b93e-f7e8ec44bccb")
+		)
+		(pin "A4"
+			(uuid "de77602b-b51f-4054-807f-bbf9d1512796")
+		)
+		(pin "A5"
+			(uuid "82bd536f-1728-41ef-a08a-cf9f25a7e9da")
+		)
+		(pin "A6"
+			(uuid "21e0d210-403c-450b-b2fe-56b6c96bf04a")
+		)
+		(pin "A7"
+			(uuid "7eb2515b-28ae-46e6-bfaf-30393ae9cb1a")
+		)
+		(pin "A8"
+			(uuid "3401cf78-5558-4e23-860f-afd5300ffae4")
+		)
+		(pin "A9"
+			(uuid "829ccaf8-b964-489a-b969-8c021fcbf879")
+		)
+		(pin "B1"
+			(uuid "c47b1ef2-3340-4167-a784-d6980e78486d")
+		)
+		(pin "B12"
+			(uuid "04a0ea92-7284-45ed-9933-707d8d4853e7")
+		)
+		(pin "B4"
+			(uuid "d276c622-62fd-481d-8ca0-4afb2ed9c8c9")
+		)
+		(pin "B5"
+			(uuid "4aa0b612-314c-465a-bb67-d92d21a753c8")
+		)
+		(pin "B6"
+			(uuid "8599623b-9d94-441b-a23b-a9bfc7231e7e")
+		)
+		(pin "B7"
+			(uuid "37a4e73e-c573-448b-bdda-673539ae0ece")
+		)
+		(pin "B8"
+			(uuid "80dd5fd3-a8e1-4a7f-8c32-55858503a8aa")
+		)
+		(pin "B9"
+			(uuid "331a5815-19c6-4f14-80a2-31bd1fc605b4")
+		)
+		(pin "S1"
+			(uuid "d5d8f816-9677-436c-a228-0ccfa3837ad2")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "J501")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 92.71 113.03 180)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "db500334-6099-4374-8be2-9731a1983d33")
+		(property "Reference" "R211"
+			(at 96.52 111.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "5K1"
+			(at 96.52 114.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 94.488 113.03 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 92.71 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "100mW Thick Film Resistors 75V ±100ppm/℃ ±1% 5.1kΩ 0603 Chip Resistor - Surface Mount ROHS"
+			(at 92.71 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 92.71 113.03 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C23186"
+			(at 92.71 113.03 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "UNI-ROYAL(Uniroyal Elec)"
+			(at 92.71 113.03 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "0603WAF5101T5E"
+			(at 92.71 113.03 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 92.71 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0009"
+			(at 92.71 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 92.71 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 92.71 113.03 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "51a587e4-88bd-4250-8801-f1b53cdddb40")
+		)
+		(pin "2"
+			(uuid "a8ef87b8-d02a-4cc9-b800-ff8d0f22fb6e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "R211")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 154.94 127 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "dc1bb094-cd13-4500-8e27-9b6a496ffcc6")
+		(property "Reference" "#PWR0213"
+			(at 154.94 133.35 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 154.94 132.08 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 154.94 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 154.94 127 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 127 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "bef95e75-2f34-46ee-bf3d-e835b9b63e59")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "#PWR0213")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 114.3 123.19 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eb715f3c-fb85-4735-a99d-b966ae1bd09d")
+		(property "Reference" "#PWR0212"
+			(at 114.3 129.54 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 114.3 128.27 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 114.3 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 114.3 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 123.19 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "0bb27faa-87c7-4397-ace0-e7bb0cdcfe2e")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "#PWR0212")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 199.39 142.24 90)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f67a2cda-6f06-4c0b-a9f3-3586466c0012")
+		(property "Reference" "R215"
+			(at 200.66 137.16 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10K"
+			(at 199.39 139.7 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 199.39 140.462 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 199.39 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" "0.1W ±1% 10kΩ 0603  Chip Resistor - Surface Mount ROHS"
+			(at 199.39 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1" "JLCPCB"
+			(at 199.39 142.24 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Distributor 1 PN" "C269701"
+			(at 199.39 142.24 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer" "TyoHM"
+			(at 199.39 142.24 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN" "RMC 0603 10K F N"
+			(at 199.39 142.24 90)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "AssemblyType" "SMT"
+			(at 199.39 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Cost" "0.0015"
+			(at 199.39 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "MPN 2" ""
+			(at 199.39 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Manufacturer 2" ""
+			(at 199.39 142.24 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "cfa1a174-46a3-4327-bfef-e2a0af36ab14")
+		)
+		(pin "2"
+			(uuid "a6212afc-b28d-448a-9dd7-78f87b844083")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "R215")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_name "GND_1")
+		(lib_id "power:GND")
+		(at 100.33 116.84 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fdce78bc-1119-4c56-8b36-b640d19e7eb1")
+		(property "Reference" "#PWR0211"
+			(at 100.33 123.19 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 100.33 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 100.33 116.84 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 100.33 116.84 0)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 100.33 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "a7094b9f-c6b7-489d-a348-6ab32aad6d91")
+		)
+		(instances
+			(project "PWA_REV2"
+				(path "/412a327d-1ee3-473e-bc00-1545004b7edf/00000000-0000-0000-0000-000062bc4e7e"
+					(reference "#PWR0211")
+					(unit 1)
+				)
+			)
+		)
+	)
 )


### PR DESCRIPTION

## Links
- [ ] Closes #312 

## What & Why
- Adding to the Schematic / BOM as of 20251213 does not have a jumper for J102.

## Validation / How to Verify
1.
<img width="1728" height="1117" alt="Screenshot 2026-04-04 at 22 24 10" src="https://github.com/user-attachments/assets/94575735-3478-4349-8fb4-60aa6be46af0" />

 
## Artifacts (attach if relevant)
- [ ] Screenshots / PDFs / STLs
- [ ] Logs

## Checklist
- [ ] Only related changes 
- [ ] Folder structure respected, work directory: /Repos/krake/PWA_REV2
- [ ] Validation steps written