### PR TITLE
Set the Serial Monitor for local echo in GPAD_API and in FactoryTest_…

### DIFF
--- a/Firmware/GPAD_API/platformio.ini
+++ b/Firmware/GPAD_API/platformio.ini
@@ -21,6 +21,7 @@ board = esp32dev
 board_build.filesystem = littlefs
 # upload_port = COM22 One of Lee's Ports.
 monitor_speed = 115200
+monitor_echo = yes
 framework = arduino
 lib_deps = 
 	mathertel/RotaryEncoder@^1.5.3

--- a/Firmware/factoryTest/FactoryTest_wMenu/platformio.ini
+++ b/Firmware/factoryTest/FactoryTest_wMenu/platformio.ini
@@ -17,6 +17,7 @@ board = esp32dev
 board_build.filesystem = littlefs
 framework = arduino
 monitor_speed = 115200
+monitor_echo = yes
 build_flags =
 	-DELEGANTOTA_USE_ASYNC_WEBSERVER=1
 lib_deps =


### PR DESCRIPTION

## Links
- [x] Closes #456 

## What & Why
- Serial monitor echoing commands locally

## Validation / How to Verify
1. open serial monitor and type a command 

## Artifacts (attach if relevant)
- [ ] Screenshots / PDFs / STLs <img width="804" height="207" alt="Screenshot 2026-04-06 at 16 05 39" src="https://github.com/user-attachments/assets/9168743e-5713-4148-8651-9da354429049" />
- [ ] Logs

## Checklist
- [ ] Only related changes: GPAD_API and  FactoryTest_wMenu
- [ ] Folder structure respected, work directory:
Firmware/GPAD_API/platformio.ini
Firmware/factoryTest/FactoryTest_wMenu/platformio.ini

 