### PR TITLE
Bugfix/444 firmware factorytest wmenu the delimiters in the mac are unfriendly

### DIFF
--- a/Firmware/factoryTest/FactoryTest_wMenu/FactoryTest_wMenu/FactoryTest_wMenu.ino
+++ b/Firmware/factoryTest/FactoryTest_wMenu/FactoryTest_wMenu/FactoryTest_wMenu.ino
@@ -1,12 +1,12 @@
 #define PROG_NAME "FactoryTest_wMenu"
-#define FIRMWARE_VERSION "v0.4.6.2"
+#define FIRMWARE_VERSION "v0.4.6.3"
  /*
 ------------------------------------------------------------------------------
 File:            FactoryTest_wMenu.ino
 Project:         Krake / GPAD v2 – Factory Test Firmware
 Document Type:   Source Code (Factory Test)
 Document ID:     KRAKE-FT-ESP32-FT01
-Version:         v0.4.6.1
+Version:         v0.4.6.3
 Date:            2026-03-31
 Author(s):       Nagham Kheir, Public Invention
 Status:          Draft
@@ -61,8 +61,9 @@ Revision History:
 |v0.4.6.0 | 2026-3-31 | Yukti         | Migrate to PlatformIO (#352)                    |
 |v0.4.6.1 | 2026-4-01 | Yukti         | Ignore CR characters in serial input            |
 |v0.4.6.2 | 2026-4-06 | Yukti         | Remove hardcoded DEVICE_UNDER_TEST; prompt      |
-|         |           |               | tester to enter SN at startup; print MAC        |
-|         |           |               | without delimiters and drop misleading (STA)    |
+|         |           |               | tester to enter SN at startup;                  |
+|v0.4.6.3 | 2026-4-07 | Yukti         | print MAC address without delimiters and drop   |
+|         |           |               | misleading (STA)                                |
 ----------------------------------------------------------------------------------------|
 Overview:
 - Repeatable factory test sequence for ESP32-WROOM-32D Krake/GPAD v2 boards.


### PR DESCRIPTION
## Links
- [ ] Closes #444

## What & Why
- WiFi.macAddress() returns a colon-delimited string (e.g. F4:65:0B:C2:95:E8), inconsistent with the format used in PMD_Processing_MQTT and GPAD_API (e.g. F4650BC295E8)
- The (STA) label incorrectly implied the MAC is a property of the WiFi STA mode — it is a unique chip identifier independent of WiFi mode
- Both printBanner() and splashserial() now strip colons and use the label MAC:
- Built on top of #445 (stale code / SN prompt fix)

## Validation / How to Verify
1. Flash FactoryTest_wMenu v0.4.6.3 to a Krake / GPAD v2 board
2. Open serial monitor at 115200 baud and reset the board
3. Confirm the banner and splash both print MAC in no-delimiter format, e.g. MAC: F4650BC0B524
4. Cross-check the printed MAC against PMD_Processing_MQTT mac_to_NameDict entries — format should match exactly

## Artifacts (attach if relevant)
- [ ] Screenshots / PDFs / STLs
- [ ] Logs

## Checklist
- [x] Only related changes : FactoryTest_wMenu.ino
- [x] Folder structure respected, work directory : E:\Dev\Repos\krake\Firmware\factoryTest\FactoryTest_wMenu\FactoryTest_wMenu
- [x] Validation steps written
