### PR TITLE
bugfix: return early from setupDFPlayer when no module detected

### DIFF
--- a/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
+++ b/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
@@ -151,6 +151,7 @@ void setupDFPlayer()
     Serial.println("DFPlayer Mini not detected or not working.");
     Serial.println("Check for missing SD Card.");
     isDFPlayerDetected = false;
+    return; // No module present -- skip all play/query commands that would block the main loop.
   }
   else
   {

--- a/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
+++ b/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
@@ -156,7 +156,7 @@ void setupDFPlayer()
   else
   {
     isDFPlayerDetected = true;
-    Serial.println("DFPlayer Mini detected!");
+     // Serial.println("DFPlayer Mini detected!");
   }
 
   dfPlayer.setTimeOut(500);  // Set serial communication time out 500ms
@@ -173,6 +173,7 @@ void setupDFPlayer()
     return;
   }
   if (moduleState > 0) {
+    Serial.println("DFPlayer Mini detected!");
     Serial.println("*** DFPlayer: TD5580 clone detected (readState non-zero at idle). ***");
     Serial.println("*** Incompatible module -- audio disabled. Replace with genuine DFPlayer Mini or MP3-TF-16P. ***");
     isDFPlayerDetected = false;
@@ -180,7 +181,8 @@ void setupDFPlayer()
   }
 
   dfPlayer.volume(volumeDFPlayer); // Set initial volume
-
+  
+  Serial.println("DFPlayer Mini detected!");
   dfPlayer.start(); // Todo, ?? necessary for DFPlayer processing
   delay(1000);
   //  dfPlayer.play(11);  //DFPlayer Splash

--- a/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
+++ b/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
@@ -161,11 +161,17 @@ void setupDFPlayer()
 
   dfPlayer.setTimeOut(500);  // Set serial communication time out 500ms
 
-  // Detect TD5580 clone: readState() returns non-zero at idle on TD5580,
-  // whereas genuine DFRobot DFPlayerMini returns 0 when stopped.
-  // TD5580 blocks firmware execution if play commands are sent -- bail out early.
+  // Validate module with readState():
+  //   < 0 : timeout -- begin() false-positive (floating UART), treat as absent.
+  //   = 0 : genuine DFPlayer Mini stopped, proceed normally.
+  //   > 0 : TD5580 clone -- blocks on play commands, bail out early.
   delay(100);  // allow module to settle before querying state
   int moduleState = dfPlayer.readState();
+  if (moduleState < 0) {
+    Serial.println("DFPlayer: no response to readState() -- module absent or UART noise. Disabling audio.");
+    isDFPlayerDetected = false;
+    return;
+  }
   if (moduleState > 0) {
     Serial.println("*** DFPlayer: TD5580 clone detected (readState non-zero at idle). ***");
     Serial.println("*** Incompatible module -- audio disabled. Replace with genuine DFPlayer Mini or MP3-TF-16P. ***");
@@ -281,6 +287,7 @@ void printDetail(uint8_t type, int value)
 
 void dfPlayerUpdate(void)
 {
+  if (!isDFPlayerDetected) return;
   unsigned long timePlay = 3000; // Plays 3 seconds of all files.
   static unsigned long timer = millis();
   if (millis() - timer > timePlay)
@@ -298,6 +305,7 @@ void dfPlayerUpdate(void)
 // Functions to learn DFPlayer behavior
 void playNotBusy()
 {
+  if (!isDFPlayerDetected) return;
   // Plays all files succsivly.
   Serial.println("PlayNotBusy");
   if (HIGH == digitalRead(nDFPlayer_BUSY))
@@ -315,6 +323,7 @@ void playNotBusy()
 
 void playNotBusyLevel(int level)
 {
+  if (!isDFPlayerDetected) return;
   // Plays all files succsivly.
   Serial.println("PlayNotBusyLevel");
   if (HIGH == digitalRead(nDFPlayer_BUSY))
@@ -337,6 +346,7 @@ void playNotBusyLevel(int level)
 // Play a track but not if the DFPlayer is busy
 bool playAlarmLevel(int alarmNumberToPlay)
 {
+  if (!isDFPlayerDetected) return false;
   static unsigned long timer = millis();
 
   const unsigned long delayPlayLevel = 20;


### PR DESCRIPTION
##Links
 - Closes #460
  
## What & Why

- Added return early exit in setupDFPlayer() when dfPlayer.begin() fails (no module connected)
- Without this, the firmware fell through into dfPlayer.play(), dfPlayer.stop(), dfPlayer.previous() and multiple delay() calls — each blocking the main loop waiting for ACK from a module that isn't there
- This caused WiFi, MQTT, and the rotary encoder to become completely unresponsive on an ESP32 Dev Kit 1 loaded with GPAD_API without a DFPlayer attached

## Validation / How to Verify

- Flash GPAD_API v0.48 or v0.49 to an ESP32 Dev Kit 1 with no DFPlayer connected (only the two 10K resistors on GPIO34/35)
- Open Serial Monitor — confirm the device does NOT hang at DFPlayer about to play.
- Confirm WiFi SoftAP appears and credentials can be set
- Confirm device connects to WiFi and MQTT broker
- Confirm rotary encoder navigation still works
- Repeat with a genuine DFPlayer Mini connected — confirm audio splash still plays normally on boot (existing behavior unchanged)

## Artifacts (attach if relevant)
 Screenshots / PDFs / STLs
 Logs
## Checklist
 Only related changes : DFPlayer.cpp
 Folder structure respected, work directory : Firmware\GPAD_API\GPAD_API\DFPlayer.cpp
 Validation steps written