### PR TITLE
Added Reset Option to GPAD API

### DIFF
--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -128,8 +128,8 @@ byte received_signal_raw_bytes[MAX_BUFFER_SIZE];
 Serial.println("Debug defined >0")
 #endif
 
-    const int NUM_PREFICES = 5;
-char legal_prefices[NUM_PREFICES] = {'h', 's', 'a', 'u', 'i'};
+    const int NUM_PREFICES = 6;
+char legal_prefices[NUM_PREFICES] = {'h', 's', 'a', 'u', 'i', 'r'};
 
 void setup_spi()
 {
@@ -429,6 +429,14 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
   if (!found)
   {
     printError(serialport);
+    return;
+  }
+
+  if (buf[0] == 'r')
+  {
+    serialport->println(F("Reset command received. Restarting device..."));
+    delay(100);
+    ESP.restart();
     return;
   }
 

--- a/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
@@ -79,7 +79,7 @@ result actionResetConfirm(eventMask e)
   return proceed;
 }
 
-MENU(resetConfirmMenu, "Confirm Reset?", Menu::doNothing, Menu::noEvent, Menu::noStyle,
+MENU(resetConfirmMenu, "Reset", Menu::doNothing, Menu::noEvent, Menu::noStyle,
   OP("Yes - Reset", actionResetConfirm, enterEvent),
   OP("No  - Cancel", Menu::doNothing, Menu::noEvent)
 );

--- a/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
@@ -13,7 +13,7 @@ extern bool running_menu;
 extern bool menu_just_exited;
 
 #define LEDPIN 12
-#define MAX_DEPTH 1
+#define MAX_DEPTH 2
 
 // This needs to be cleaned up; the PubSublcient and WiFi stuff needs to put into a
 // a module that is not in GPAD_API.ino
@@ -68,7 +68,30 @@ result action5(eventMask e)
   return proceed;
 }
 
-MENU(mainMenu, "Krake Menu", Menu::doNothing, Menu::noEvent, Menu::wrapStyle, OP("Acknowledge", action1, anyEvent), OP("Dismiss", action2, anyEvent), OP("Shelve", action3, anyEvent), FIELD(volumeDFPlayer, "Volume", "%", 0, 30, 10, 1, action4, anyEvent, wrapStyle), OP("Exit Menu", action5, enterEvent));
+result actionResetConfirm(eventMask e)
+{
+  if (e == eventMask::enterEvent)
+  {
+    Serial.println(F("Reset confirmed. Restarting device..."));
+    delay(100);
+    ESP.restart();
+  }
+  return proceed;
+}
+
+MENU(resetConfirmMenu, "Confirm Reset?", Menu::doNothing, Menu::noEvent, Menu::noStyle,
+  OP("Yes - Reset", actionResetConfirm, enterEvent),
+  OP("No  - Cancel", Menu::doNothing, Menu::noEvent)
+);
+
+MENU(mainMenu, "Krake Menu", Menu::doNothing, Menu::noEvent, Menu::wrapStyle,
+  OP("Acknowledge", action1, anyEvent),
+  OP("Dismiss", action2, anyEvent),
+  OP("Shelve", action3, anyEvent),
+  FIELD(volumeDFPlayer, "Volume", "%", 0, 30, 10, 1, action4, anyEvent, wrapStyle),
+  SUBMENU(resetConfirmMenu),
+  OP("Exit Menu", action5, enterEvent)
+);
 
 RotaryEventIn reIn(
     RotaryEventIn::EventType::BUTTON_CLICKED |        // select


### PR DESCRIPTION
### Links

- [ ]  Closes #230

### What & Why

- Having to pull the power cord to reset the device is poor design and risks hardware damage.
- Added a Reset entry to the LCD menu. Selecting it opens a "Confirm Reset?" submenu with "Yes - Reset" / "No - Cancel" to prevent accidental resets.
- MAX_DEPTH increased from 1 → 2 in GPAD_menu.cpp to allow the confirmation submenu to render.
- Added 'r' command to interpretBuffer in GPAD_HAL.cpp so a reset can also be triggered over UART or MQTT by sending r\n — extending the API as suggested in the issue.

### Validation / How to Verify

- Flash firmware to a Krake device.
- Open the LCD menu and scroll to Confirm Reset? (appears before "Exit Menu").
- Select Yes - Reset — device should restart (WiFi reconnect, boot messages).
- Repeat and select No - Cancel — device should remain running; use back gesture (double-click or long-press encoder) to return to main menu.
- Connect a serial terminal over UART, send r\n — device should print "Reset command received. Restarting device..." and restart.

### Artifacts (attach if relevant)
 

- [ ] Screenshots / PDFs / STLs
- [ ]  Logs

### Checklist

- [ ]  Only related changes : GPAD_HAL.cpp and GPAD_menu.cpp
- [ ]  Folder structure respected, work directory : Firmware\GPAD_API\GPAD_API
- [ ]  Validation steps written