### PR TITLE
add mute timeout menu field with rotary encoder UI and auto-unmute on expiry

### DIFF
--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -48,6 +48,7 @@ extern const char *AlarmNames[];
 extern AlarmLevel currentLevel;
 extern bool currentlyMuted;
 extern char AlarmMessageBuffer[81];
+extern unsigned long muteTimeoutEndMillis;
 
 extern char macAddressString[13];
 
@@ -290,6 +291,7 @@ void muteButtonCallback(byte buttonEvent)
     // Do something...
     local_ptr_to_serial->println(F("SWITCH_MUTE onPress"));
     toggleMuted();
+    muteTimeoutEndMillis = 0;
     start_of_song = millis();
     annunciateAlarmLevel(local_ptr_to_serial);
     printAlarmState(local_ptr_to_serial);
@@ -595,6 +597,13 @@ void GPAD_HAL_loop()
 #if defined(GPAD) // FLE??? Why is this conditional compile?
   muteButton.poll();
 #endif
+
+  if (muteTimeoutEndMillis > 0 && millis() >= muteTimeoutEndMillis)
+  {
+    muteTimeoutEndMillis = 0;
+    currentlyMuted = false;
+    annunciateAlarmLevel(local_ptr_to_serial);
+  }
 }
 
 /* Assumes LCD has been initilized

--- a/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
@@ -12,6 +12,7 @@ using namespace Menu;
 
 extern bool running_menu;
 extern bool menu_just_exited;
+extern unsigned long muteTimeoutEndMillis;
 
 #define LEDPIN 12
 #define MAX_DEPTH 2
@@ -88,8 +89,6 @@ result action5(eventMask e)
   return proceed;
 }
 
-
-
 result actionResetConfirm(eventMask e)
 {
   if (e == eventMask::enterEvent)
@@ -101,18 +100,41 @@ result actionResetConfirm(eventMask e)
   return proceed;
 }
 
+int muteTimeoutMinutes = 5;
+
+result actionMuteTimeout(eventMask e)
+{
+  if (e == eventMask::enterEvent)
+  {
+    Serial.print(F("Mute timeout set: "));
+    Serial.print(muteTimeoutMinutes);
+    Serial.println(F(" min"));
+    setMuted(true);
+    muteTimeoutEndMillis = millis() + ((unsigned long)muteTimeoutMinutes * 60000UL);
+    annunciateAlarmLevel(&Serial);
+    lcd.clear();
+    lcd.setCursor(0, 0);
+    lcd.print("Muted for:");
+    lcd.setCursor(0, 1);
+    lcd.print(muteTimeoutMinutes);
+    lcd.print(" minute(s)");
+  }
+  return proceed;
+}
+
 MENU(resetConfirmMenu, "Reset", Menu::doNothing, Menu::noEvent, Menu::noStyle,
   OP("Yes - Reset", actionResetConfirm, enterEvent),
   OP("No  - Cancel", Menu::doNothing, Menu::noEvent)
 );
+
 
 MENU(mainMenu, "Krake Menu", Menu::doNothing, Menu::noEvent, Menu::wrapStyle,
   OP("Acknowledge", action1, enterEvent),
   OP("Dismiss", action2, enterEvent),
   OP("Shelve", action3, enterEvent),
   FIELD(volumeDFPlayer, "Volume", "%", 0, 30, 10, 1, action4, anyEvent, wrapStyle),
-     
-     SUBMENU(resetConfirmMenu),
+  FIELD(muteTimeoutMinutes, "Mute Time", "min", 1, 60, 5, 1, actionMuteTimeout, enterEvent, wrapStyle),
+  SUBMENU(resetConfirmMenu),
   OP("Exit Menu", action5, enterEvent)
 );
 

--- a/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
+++ b/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
@@ -30,6 +30,7 @@
 AlarmLevel currentLevel = silent;
 bool currentlyMuted = false;
 char AlarmMessageBuffer[MAX_BUFFER_SIZE];
+unsigned long muteTimeoutEndMillis = 0;
 const char *AlarmNames[] = {"OK   ", "INFO.", "PROB.", "WARN ", "CRIT.", "PANIC"};
 
 // This is the abstract alarm function. It CANNOT


### PR DESCRIPTION
### Links

- [ ]  Closes #51

### What & Why

- Added Mute Time field to the Krake Menu, navigable via rotary encoder on the LCD display
- User dials in a duration (1–60 min, default 5) and confirms with a button press to mute the alarm for that period
- Alarm automatically unmutes when the timer expires via a check in GPAD_HAL_loop on every cycle
- Pressing the physical mute button while a timeout is active cancels the timeout immediately
- Switched to setMuted(true) / toggleMuted() from the new alarm API introduced in main

### Validation / How to Verify

- Flash firmware, trigger an alarm, open Krake Menu via rotary encoder, navigate to Mute Time, set a short duration, press button — LCD should show "Muted for: X minute(s)" and audio/LEDs should go silent
- Wait for the timeout to expire — alarm should automatically resume without any user input

### Artifacts (attach if relevant)

- [ ]  Screenshots / PDFs / STLs
- [ ]  Logs

### Checklist

- [ ]  Only related changes: GPAD_HAL.cpp and GPAD_menu.cpp and alarm_api.cpp
- [ ]  Folder structure respected, work directory : Firmware/GPAD_API/GPAD_API
- [ ]  Validation steps written