### PR TITLE
Alert user on LCD and DFPlayer when MQTT connection is lost

### DIFF
--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -1800,12 +1800,24 @@ void loop()
 {
 #if defined HMWK || defined KRAKE
 
-  if (!client.loop())
   {
-    debugSerial.print(mqtt_broker_name);
-    debugSerial.print(" lost MQTT at: ");
-    debugSerial.println(millis());
-    reconnect();
+    const bool wasConnected = client.connected();
+    if (!client.loop())
+    {
+      debugSerial.print(mqtt_broker_name);
+      debugSerial.print(" lost MQTT at: ");
+      debugSerial.println(millis());
+      if (wasConnected && !running_menu)
+      {
+        showMqttStatusLCD(false);
+        playNotBusyLevel(problem);
+      }
+      reconnect();
+      if (client.connected() && !wasConnected && !running_menu)
+      {
+        restoreAlarmLevel(&debugSerial);
+      }
+    }
   }
 
   if (wifiResetRequestedAtMs != 0 && (millis() - wifiResetRequestedAtMs) > 750)

--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -1813,7 +1813,7 @@ void loop()
         playAlarmLevel(problem);
       }
       reconnect();
-      if (client.connected() && !wasConnected && !running_menu)
+      if (client.connected() && !running_menu)
       {
         annunciateAlarmLevel(&debugSerial);
       }

--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -1810,12 +1810,12 @@ void loop()
       if (wasConnected && !running_menu)
       {
         showMqttStatusLCD(false);
-        playNotBusyLevel(problem);
+        playAlarmLevel(problem);
       }
       reconnect();
       if (client.connected() && !wasConnected && !running_menu)
       {
-        restoreAlarmLevel(&debugSerial);
+        annunciateAlarmLevel(&debugSerial);
       }
     }
   }

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -608,6 +608,26 @@ void clearLCD(void)
   lcd.clear();
 }
 
+void showMqttStatusLCD(bool connected)
+{
+  lcd.init();
+  lcd.clear();
+  if (connected)
+  {
+    lcd.noBacklight();
+    return;
+  }
+  lcd.backlight();
+  lcd.setCursor(0, 0);
+  lcd.print("MQTT DISCONNECTED   ");
+  lcd.setCursor(0, 1);
+  lcd.print("Alarm status stale  ");
+  lcd.setCursor(0, 2);
+  lcd.print("Reconnecting...     ");
+  lcd.setCursor(0, 3);
+  lcd.print("                    ");
+}
+
 // Splash a message so we can tell the LCD is working
 void splashLCD(wifi_mode_t wifiMode, IPAddress &deviceIp)
 {

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
@@ -288,6 +288,7 @@ void restoreAlarmLevel(Stream *serialport);
 void unchanged_anunicateAlarmLevel(Stream *serialport);
 void annunciateAlarmLevel(Stream *serialport);
 void clearLCD(void);
+void showMqttStatusLCD(bool connected);
 void splashLCD(wifi_mode_t wifiMode, IPAddress &deviceIp);
 
 void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *client);


### PR DESCRIPTION
### Links

- [ ]  Closes #86

### What & Why

- When the Krake loses its MQTT connection, the user previously had no indication — the LCD stayed on the last known alarm state with no warning that the data was stale.
- On disconnect, the LCD now immediately shows "MQTT DISCONNECTED / Alarm status stale / Reconnecting..." with backlight on, and the DFPlayer plays a problem-level alert sound.
- On reconnect, the LCD automatically restores the alarm status display.
- Implemented by detecting the MQTT connection state transition in the main loop using client.connected() before and after client.loop(), so the alert fires once on drop and the restore fires once on recovery.

### Validation / How to Verify

- Flash the firmware and confirm normal operation — LCD shows alarm status as usual.
- Disconnect the Krake from WiFi (or take the broker offline) and confirm the LCD switches to the "MQTT DISCONNECTED" screen and the DFPlayer plays a sound.
- Restore WiFi/broker and confirm the LCD returns to the alarm status display.
- Open the menu while MQTT is connected, then drop the connection — confirm the menu is not interrupted by the LCD override.

### Artifacts (attach if relevant)

- [ ]  Screenshots / PDFs / STLs
- [ ]  Logs

### Checklist

- [ ]  Only related changes GPAD_API.ino , GPAD_HAL.cpp and GPAD_HAL.h
- [ ]  Folder structure respected, work directory : Firmware/GPAD_API/GPAD_API
- [ ]  Validation steps written