### PR TITLE
Fix DFPlayer alarm playback track validation

### DIFF
--- a/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
+++ b/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
@@ -401,8 +401,14 @@ bool playAlarmLevel(int alarmNumberToPlay)
     timer = millis();
 
     // If not busy play the alarm message
-    if ((0 > tracNumber < 0) || (numberFilesDF < tracNumber))
+    if (numberFilesDF <= 0)
     {
+      numberFilesDF = dfPlayer.readFileCounts();
+    }
+
+    if ((tracNumber <= 0) || (numberFilesDF <= 0) || (numberFilesDF < tracNumber))
+    {
+      Serial.printf("DFPlayer: invalid track request %d (available files: %d)\n", tracNumber, numberFilesDF);
       return false;
     }
     else // Valid track number


### PR DESCRIPTION
### Motivation
- Address a bug that could cause the DFPlayer to silently skip playback (no sound) by incorrectly rejecting valid track numbers during alarm playback.

### Description
- Corrected the invalid chained comparison and now reject only non-positive or out-of-range track numbers in `playAlarmLevel()` in `Firmware/GPAD_API/GPAD_API/DFPlayer.cpp`.
- Refresh the cached `numberFilesDF` using `dfPlayer.readFileCounts()` when the cached count is unknown or zero before validating a requested track.
- Emit a diagnostic message via `Serial.printf()` when an invalid track request is rejected to make runtime failures easier to debug.

### Testing
- Ran repository inspection and review commands including `git status --short`, `git diff -- Firmware/GPAD_API/GPAD_API/DFPlayer.cpp`, and `nl -ba Firmware/GPAD_API/GPAD_API/DFPlayer.cpp | sed -n '388,430p'`, and they completed successfully.
- Verified the modified logic by examining the updated file snippet and committing the change; no unit or firmware build tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23bc8ac54832ab09beeb8a4a5129a)