### PR TITLE
Fix alarm mute duration issue

### DIFF
--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -1856,6 +1856,13 @@ void loop()
     poll_GPAD_menu();
   }
 
+  // Run one final timeout service after command/network processing so
+  // timed unmute wins even if other paths re-assert mute during this loop.
+  if (serviceMuteTimeout())
+  {
+    annunciateAlarmLevel(&debugSerial);
+  }
+
   // if ((millis() / 10000) > cnt_actions) {
   //   cnt_actions++;
   //   navigate_to_n_and_execute(cnt_actions % 3);

--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -1856,13 +1856,6 @@ void loop()
     poll_GPAD_menu();
   }
 
-  // Run one final timeout service after command/network processing so
-  // timed unmute wins even if other paths re-assert mute during this loop.
-  if (serviceMuteTimeout())
-  {
-    annunciateAlarmLevel(&debugSerial);
-  }
-
   // if ((millis() / 10000) > cnt_actions) {
   //   cnt_actions++;
   //   navigate_to_n_and_execute(cnt_actions % 3);

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -291,7 +291,7 @@ void muteButtonCallback(byte buttonEvent)
     // Do something...
     local_ptr_to_serial->println(F("SWITCH_MUTE onPress"));
     toggleMuted();
-    muteTimeoutEndMillis = 0;
+    clearMuteTimeout();
     start_of_song = millis();
     annunciateAlarmLevel(local_ptr_to_serial);
     printAlarmState(local_ptr_to_serial);
@@ -598,10 +598,10 @@ void GPAD_HAL_loop()
   muteButton.poll();
 #endif
 
-  if (muteTimeoutEndMillis > 0 && millis() >= muteTimeoutEndMillis)
+  const bool wasMuted = currentlyMuted;
+  serviceMuteTimeout();
+  if (wasMuted && !currentlyMuted)
   {
-    muteTimeoutEndMillis = 0;
-    currentlyMuted = false;
     annunciateAlarmLevel(local_ptr_to_serial);
   }
 }

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -51,6 +51,7 @@ extern char AlarmMessageBuffer[81];
 extern unsigned long muteTimeoutEndMillis;
 
 extern char macAddressString[13];
+extern int muteTimeoutMinutes;
 
 // TODO: Remove this; for explanation only
 extern char publish_Ack_Topic[];
@@ -290,8 +291,19 @@ void muteButtonCallback(byte buttonEvent)
   case onPress:
     // Do something...
     local_ptr_to_serial->println(F("SWITCH_MUTE onPress"));
-    toggleMuted();
-    clearMuteTimeout();
+    if (isMuted())
+    {
+      setMuted(false);
+      clearMuteTimeout();
+      local_ptr_to_serial->println(F("Manual unmute."));
+    }
+    else
+    {
+      setMuteTimeoutMinutes((unsigned long)muteTimeoutMinutes);
+      local_ptr_to_serial->print(F("Muted for "));
+      local_ptr_to_serial->print(muteTimeoutMinutes);
+      local_ptr_to_serial->println(F(" minute(s)."));
+    }
     start_of_song = millis();
     annunciateAlarmLevel(local_ptr_to_serial);
     printAlarmState(local_ptr_to_serial);

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -590,6 +590,16 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
 } // end interpretBuffer()
 
 // This has to be called periodically, at a minimum to handle the mute_button
+void muteTimeoutWatchdog(Stream *serialport)
+{
+  // Watchdog for timed mute: when duration expires, force unmute and re-annunciate.
+  if (isMuted() && serviceMuteTimeout())
+  {
+    serialport->println(F("Mute timeout expired. Auto-unmuting."));
+    annunciateAlarmLevel(serialport);
+  }
+}
+
 void GPAD_HAL_loop()
 {
   muteButton.poll();
@@ -598,10 +608,7 @@ void GPAD_HAL_loop()
   muteButton.poll();
 #endif
 
-  if (serviceMuteTimeout())
-  {
-    annunciateAlarmLevel(local_ptr_to_serial);
-  }
+  muteTimeoutWatchdog(local_ptr_to_serial);
 }
 
 /* Assumes LCD has been initilized

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -598,9 +598,7 @@ void GPAD_HAL_loop()
   muteButton.poll();
 #endif
 
-  const bool wasMuted = currentlyMuted;
-  serviceMuteTimeout();
-  if (wasMuted && !currentlyMuted)
+  if (serviceMuteTimeout())
   {
     annunciateAlarmLevel(local_ptr_to_serial);
   }

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
@@ -294,6 +294,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
 
 // This module has to be initialized and called each time through the superloop
 void GPAD_HAL_setup(Stream *serialport, wifi_mode_t wifiMode, IPAddress &deviceIp);
+void muteTimeoutWatchdog(Stream *serialport);
 void GPAD_HAL_loop();
 
 extern LiquidCrystal_I2C Real_lcd;

--- a/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
@@ -109,8 +109,7 @@ result actionMuteTimeout(eventMask e)
     Serial.print(F("Mute timeout set: "));
     Serial.print(muteTimeoutMinutes);
     Serial.println(F(" min"));
-    setMuted(true);
-    muteTimeoutEndMillis = millis() + ((unsigned long)muteTimeoutMinutes * 60000UL);
+    setMuteTimeoutMinutes((unsigned long)muteTimeoutMinutes);
     annunciateAlarmLevel(&Serial);
     lcd.clear();
     lcd.setCursor(0, 0);

--- a/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
+++ b/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
@@ -32,6 +32,8 @@ AlarmLevel currentLevel = silent;
 bool currentlyMuted = false;
 char AlarmMessageBuffer[MAX_BUFFER_SIZE];
 unsigned long muteTimeoutEndMillis = 0;
+unsigned long muteTimeoutStartMillis = 0;
+unsigned long muteTimeoutDurationMillis = 0;
 const char *AlarmNames[] = {"OK   ", "INFO.", "PROB.", "WARN ", "CRIT.", "PANIC"};
 
 // This is the abstract alarm function. It CANNOT
@@ -76,12 +78,16 @@ void toggleMuted()
 void setMuteTimeoutMinutes(unsigned long minutes)
 {
   setMuted(true);
-  muteTimeoutEndMillis = millis() + (minutes * 60000UL);
+  muteTimeoutStartMillis = millis();
+  muteTimeoutDurationMillis = minutes * 60000UL;
+  muteTimeoutEndMillis = muteTimeoutStartMillis + muteTimeoutDurationMillis;
 }
 
 void clearMuteTimeout()
 {
   muteTimeoutEndMillis = 0;
+  muteTimeoutStartMillis = 0;
+  muteTimeoutDurationMillis = 0;
 }
 
 bool serviceMuteTimeout()
@@ -91,8 +97,7 @@ bool serviceMuteTimeout()
     return false;
   }
 
-  // Use signed subtraction so timeout logic remains correct across millis() rollover.
-  if ((long)(millis() - muteTimeoutEndMillis) >= 0)
+  if ((millis() - muteTimeoutStartMillis) >= muteTimeoutDurationMillis)
   {
     clearMuteTimeout();
     setMuted(false);

--- a/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
+++ b/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
@@ -72,6 +72,32 @@ void toggleMuted()
   currentlyMuted = !currentlyMuted;
 }
 
+void setMuteTimeoutMinutes(unsigned long minutes)
+{
+  setMuted(true);
+  muteTimeoutEndMillis = millis() + (minutes * 60000UL);
+}
+
+void clearMuteTimeout()
+{
+  muteTimeoutEndMillis = 0;
+}
+
+void serviceMuteTimeout()
+{
+  if (muteTimeoutEndMillis == 0)
+  {
+    return;
+  }
+
+  // Use signed subtraction so timeout logic remains correct across millis() rollover.
+  if ((long)(millis() - muteTimeoutEndMillis) >= 0)
+  {
+    clearMuteTimeout();
+    setMuted(false);
+  }
+}
+
 AlarmLevel getCurrentAlarmLevel()
 {
   return currentLevel;

--- a/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
+++ b/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
@@ -84,11 +84,11 @@ void clearMuteTimeout()
   muteTimeoutEndMillis = 0;
 }
 
-void serviceMuteTimeout()
+bool serviceMuteTimeout()
 {
   if (muteTimeoutEndMillis == 0)
   {
-    return;
+    return false;
   }
 
   // Use signed subtraction so timeout logic remains correct across millis() rollover.
@@ -96,7 +96,10 @@ void serviceMuteTimeout()
   {
     clearMuteTimeout();
     setMuted(false);
+    return true;
   }
+
+  return false;
 }
 
 AlarmLevel getCurrentAlarmLevel()

--- a/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
+++ b/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
@@ -19,6 +19,7 @@
 */
 #include "alarm_api.h"
 #include "gpad_utility.h"
+#include <Arduino.h>
 
 // here is the abstract "state" of the machine,
 // completely independent of hardware.

--- a/Firmware/GPAD_API/GPAD_API/alarm_api.h
+++ b/Firmware/GPAD_API/GPAD_API/alarm_api.h
@@ -50,7 +50,7 @@ bool isMuted();
 void toggleMuted();
 void setMuteTimeoutMinutes(unsigned long minutes);
 void clearMuteTimeout();
-void serviceMuteTimeout();
+bool serviceMuteTimeout();
 
 AlarmLevel getCurrentAlarmLevel();
 char *getCurrentMessage();

--- a/Firmware/GPAD_API/GPAD_API/alarm_api.h
+++ b/Firmware/GPAD_API/GPAD_API/alarm_api.h
@@ -48,6 +48,9 @@ int alarm(AlarmLevel level, char *str, Stream *serialport);
 void setMuted(bool muted);
 bool isMuted();
 void toggleMuted();
+void setMuteTimeoutMinutes(unsigned long minutes);
+void clearMuteTimeout();
+void serviceMuteTimeout();
 
 AlarmLevel getCurrentAlarmLevel();
 char *getCurrentMessage();


### PR DESCRIPTION
- Fixed mute-button behavior so pressing the hardware mute button now uses the configured mute duration (muteTimeoutMinutes) instead of a plain indefinite toggle.
  -   If currently unmuted: it starts a timed mute via setMuteTimeoutMinutes(...).
  -   If currently muted: it performs a manual unmute and clears the timeout.
 This makes mute-button muting follow the configured duration as requested. 
- Added extern int muteTimeoutMinutes; in HAL so mute button logic can use the same configured duration from menu settings. 
 
- Added a dedicated watchdog-style function, muteTimeoutWatchdog(Stream *serialport), to continuously monitor mute timeout and automatically unmute once the configured duration expires. This directly addresses your requirement for a “watch dog waiting the counter to finish.” 
- The watchdog now runs from GPAD_HAL_loop() every superloop cycle, ensuring timeout checks happen continuously without waiting for button interaction. 
- Declared the new watchdog function in GPAD_HAL.h so it is part of the HAL API and explicit in structure. 
- Removed duplicate timeout servicing from GPAD_API.ino so timeout behavior is centralized in HAL watchdog logic (cleaner and less conflicting paths)