### PR TITLE
Harden alarm handling, Remove unsafe string copying, remove risky restart, fix UART extern, and decouple MQTT publish from HAL

### DIFF
--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -25,7 +25,6 @@
 #include <SPI.h>
 #include "WiFiManagerOTA.h"
 #include "GPAD_menu.h"
-#include "GPAPMessage.h"
 #include "mqtt_handler.h"
 
 using namespace gpad_hal;
@@ -123,9 +122,6 @@ byte received_signal_raw_bytes[MAX_BUFFER_SIZE];
 #if (DEBUG > 0)
 Serial.println("Debug defined >0")
 #endif
-
-    const int NUM_PREFICES = 5;
-char legal_prefices[NUM_PREFICES] = {'h', 's', 'a', 'u', 'i'};
 
 void setup_spi()
 {
@@ -428,43 +424,30 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     return; // no action
   }
 
-  bool found = false;
-  for (int i = 0; i < NUM_PREFICES; i++)
-  {
-    if (buf[0] == legal_prefices[i])
-      found = true;
-  }
-  if (!found)
-  {
-    printError(serialport);
-    return;
-  }
-
-  const auto protocolMessage = gpap_message::GPAPMessage::deserialize(buf, rlen);
-
+  const char command = buf[0];
   serialport->print(F("Command: "));
-  serialport->printf("%c\n", protocolMessage.getMessageType());
+  serialport->printf("%c\n", command);
 
-  switch (protocolMessage.getMessageType())
+  switch (command)
   {
-  case gpap_message::MessageType::MUTE:
+  case 's':
   {
     serialport->println(F("Muting Case!"));
     setMuted(true);
     break;
   }
-  case gpap_message::MessageType::UNMUTE:
+  case 'u':
   {
     serialport->println(F("UnMuting Case!"));
     setMuted(false);
     break;
   }
-  case gpap_message::MessageType::HELP:
+  case 'h':
   {
     printInstructions(serialport);
     break;
   }
-  case gpap_message::MessageType::ALARM:
+  case 'a':
   {
     if (rlen < 2)
     {
@@ -492,7 +475,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
 
     break;
   }
-  case gpap_message::MessageType::INFO:
+  case 'i':
   {
     // Firmware Version
     //  81+23 = Maximum string length
@@ -584,7 +567,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
   }
   default:
   {
-    serialport->println(F("Unknown Command"));
+    printError(serialport);
     break;
   }
   }

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -26,6 +26,7 @@
 #include "WiFiManagerOTA.h"
 #include "GPAD_menu.h"
 #include "GPAPMessage.h"
+#include "mqtt_handler.h"
 
 using namespace gpad_hal;
 
@@ -52,13 +53,6 @@ extern unsigned long muteTimeoutEndMillis;
 
 extern char macAddressString[13];
 extern int muteTimeoutMinutes;
-
-// TODO: Remove this; for explanation only
-extern char publish_Ack_Topic[];
-
-#include <PubSubClient.h> // From library https://github.com/knolleary/pubsubclient
-
-extern PubSubClient client;
 
 // For LCD
 //  #include <LiquidCrystal_I2C.h>
@@ -130,8 +124,8 @@ byte received_signal_raw_bytes[MAX_BUFFER_SIZE];
 Serial.println("Debug defined >0")
 #endif
 
-    const int NUM_PREFICES = 6;
-char legal_prefices[NUM_PREFICES] = {'h', 's', 'a', 'u', 'i', 'r'};
+    const int NUM_PREFICES = 5;
+char legal_prefices[NUM_PREFICES] = {'h', 's', 'a', 'u', 'i'};
 
 void setup_spi()
 {
@@ -446,14 +440,6 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     return;
   }
 
-  if (buf[0] == 'r')
-  {
-    serialport->println(F("Reset command received. Restarting device..."));
-    delay(100);
-    ESP.restart();
-    return;
-  }
-
   const auto protocolMessage = gpap_message::GPAPMessage::deserialize(buf, rlen);
 
   serialport->print(F("Command: "));
@@ -480,16 +466,23 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
   }
   case gpap_message::MessageType::ALARM:
   {
-    // In the case of an alarm state, the rest of the buffer is a message.
-    // we will read up to 60 characters from this buffer for display on our
-    // Arguably when we support mulitple states this will become more complicated.
-    char D = buf[1];
-    int N = D - '0';
-    serialport->println(N);
-    // WARNING: Shouldn't this be MAX_BUFFER_SIZE?
-    char msg[61];
-    msg[0] = '\0';
-    strncat(msg, buf, 60);
+    if (rlen < 2)
+    {
+      printError(serialport);
+      return;
+    }
+
+    int N = buf[1] - '0';
+    if (N < 0 || N >= NUM_LEVELS)
+    {
+      printError(serialport);
+      return;
+    }
+
+    char msg[MAX_BUFFER_SIZE];
+    size_t copyLen = min((size_t)rlen, sizeof(msg) - 1);
+    memcpy(msg, buf, copyLen);
+    msg[copyLen] = '\0';
     // This copy loooks uncessary, but is not...we want "alarm"
     // to be a completely independent and abstract function.
     // it should copy the msg buffer
@@ -509,14 +502,14 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     char str[20];
 
     strcat(onInfoMsg, FIRMWARE_VERSION);
-    client->publish(publish_Ack_Topic, onInfoMsg);
+    publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
     onInfoMsg[0] = '\0';
 
     // Report API version
     strcat(onInfoMsg, "GPAD API Version: ");
     strcat(onInfoMsg, gpadApi.getVersion().toString().c_str());
-    client->publish(publish_Ack_Topic, onInfoMsg);
+    publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
     onInfoMsg[0] = '\0';
 
@@ -527,7 +520,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     strcat(onInfoMsg, "System up time (mills): ");
     sprintf(str, "%d", millis());
     strcat(onInfoMsg, str);
-    client->publish(publish_Ack_Topic, onInfoMsg);
+    publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
 
     // Mute status
@@ -542,7 +535,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     {
       strcat(onInfoMsg, "NOT MUTED");
     }
-    client->publish(publish_Ack_Topic, onInfoMsg);
+    publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
 
     // Alarm level
@@ -551,7 +544,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     strcat(onInfoMsg, "Current alarm Level: ");
     sprintf(str, "%d", getCurrentAlarmLevel());
     strcat(onInfoMsg, str);
-    client->publish(publish_Ack_Topic, onInfoMsg);
+    publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
 
     // Alarm message
@@ -559,7 +552,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     strcat(onInfoMsg, "Current alarm message: ");
     //        strcat(onInfoMsg, *getCurrentMessage());  Produced error error: invalid conversion from 'char' to 'const char*' [-fpermissive]
     strcat(onInfoMsg, getCurrentMessage());
-    client->publish(publish_Ack_Topic, onInfoMsg);
+    publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
 
     // IP Address
@@ -581,7 +574,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
 
     strcat(onInfoMsg, ipString);
 
-    client->publish(publish_Ack_Topic, onInfoMsg);
+    publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
 
     // serialport->print("myIP =");

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -809,6 +809,22 @@ void restoreAlarmLevel(Stream *serialport)
 
 void annunciateAlarmLevel(Stream *serialport)
 {
+  static unsigned long lastAnnunciateMs = 0;
+  const unsigned long now = millis();
+
+  if (serialport == nullptr)
+  {
+    return;
+  }
+
+  // Avoid long back-to-back UI/audio work under message bursts.
+  if ((now - lastAnnunciateMs) < 50)
+  {
+    unchanged_anunicateAlarmLevel(serialport);
+    return;
+  }
+  lastAnnunciateMs = now;
+
   start_of_song = millis();
   unchanged_anunicateAlarmLevel(serialport);
   showStatusLCD(currentLevel, currentlyMuted, AlarmMessageBuffer);
@@ -819,6 +835,8 @@ void annunciateAlarmLevel(Stream *serialport)
   {
     playNotBusyLevel(currentLevel);
   }
+
+  yield();
 }
 
 GPAD_API::GPAD_API(SemanticVersion version)

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -26,8 +26,11 @@
 #include "WiFiManagerOTA.h"
 #include "GPAD_menu.h"
 #include "mqtt_handler.h"
+#include <esp_system.h>
 
 using namespace gpad_hal;
+
+const char *resetReasonToString(esp_reset_reason_t reason);
 
 // Use Serial1 for UART communication
 HardwareSerial uartSerial1(1); // For user Serial Port
@@ -568,6 +571,14 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     if (client != nullptr) publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
 
+    // Reset reason
+    onInfoMsg[0] = '\0';
+    strcat(onInfoMsg, "Reset reason: ");
+    const esp_reset_reason_t resetReason = esp_reset_reason();
+    strcat(onInfoMsg, resetReasonToString(resetReason));
+    if (client != nullptr) publishAck(client, onInfoMsg);
+    serialport->println(onInfoMsg);
+
     // serialport->print("myIP =");
     // serialport->println(myIP);   // Caused Error Multiple libraries were found for "WiFiManager.h"
 
@@ -865,4 +876,22 @@ std::string SemanticVersion::toString() const
   versionString.append(std::to_string(this->patch));
 
   return versionString;
+}
+const char *resetReasonToString(esp_reset_reason_t reason)
+{
+  switch (reason)
+  {
+  case ESP_RST_UNKNOWN: return "UNKNOWN";
+  case ESP_RST_POWERON: return "POWERON";
+  case ESP_RST_EXT: return "EXTERNAL";
+  case ESP_RST_SW: return "SOFTWARE";
+  case ESP_RST_PANIC: return "PANIC";
+  case ESP_RST_INT_WDT: return "INT_WDT";
+  case ESP_RST_TASK_WDT: return "TASK_WDT";
+  case ESP_RST_WDT: return "OTHER_WDT";
+  case ESP_RST_DEEPSLEEP: return "DEEPSLEEP";
+  case ESP_RST_BROWNOUT: return "BROWNOUT";
+  case ESP_RST_SDIO: return "SDIO";
+  default: return "UNMAPPED";
+  }
 }

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -418,13 +418,21 @@ void GPAD_HAL_setup(Stream *serialport, wifi_mode_t wifiMode, IPAddress &deviceI
 // the Hardware Abstraction Layer.
 void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *client)
 {
-  if (rlen < 1)
+  if (buf == nullptr || serialport == nullptr || rlen < 1)
   {
-    printError(serialport);
+    if (serialport != nullptr)
+    {
+      printError(serialport);
+    }
     return; // no action
   }
 
   const char command = buf[0];
+  if (command == '\0')
+  {
+    printError(serialport);
+    return;
+  }
   serialport->print(F("Command: "));
   serialport->printf("%c\n", command);
 
@@ -485,14 +493,14 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     char str[20];
 
     strcat(onInfoMsg, FIRMWARE_VERSION);
-    publishAck(client, onInfoMsg);
+    if (client != nullptr) publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
     onInfoMsg[0] = '\0';
 
     // Report API version
     strcat(onInfoMsg, "GPAD API Version: ");
     strcat(onInfoMsg, gpadApi.getVersion().toString().c_str());
-    publishAck(client, onInfoMsg);
+    if (client != nullptr) publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
     onInfoMsg[0] = '\0';
 
@@ -503,7 +511,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     strcat(onInfoMsg, "System up time (mills): ");
     sprintf(str, "%d", millis());
     strcat(onInfoMsg, str);
-    publishAck(client, onInfoMsg);
+    if (client != nullptr) publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
 
     // Mute status
@@ -518,7 +526,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     {
       strcat(onInfoMsg, "NOT MUTED");
     }
-    publishAck(client, onInfoMsg);
+    if (client != nullptr) publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
 
     // Alarm level
@@ -527,7 +535,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     strcat(onInfoMsg, "Current alarm Level: ");
     sprintf(str, "%d", getCurrentAlarmLevel());
     strcat(onInfoMsg, str);
-    publishAck(client, onInfoMsg);
+    if (client != nullptr) publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
 
     // Alarm message
@@ -535,7 +543,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     strcat(onInfoMsg, "Current alarm message: ");
     //        strcat(onInfoMsg, *getCurrentMessage());  Produced error error: invalid conversion from 'char' to 'const char*' [-fpermissive]
     strcat(onInfoMsg, getCurrentMessage());
-    publishAck(client, onInfoMsg);
+    if (client != nullptr) publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
 
     // IP Address
@@ -557,7 +565,7 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
 
     strcat(onInfoMsg, ipString);
 
-    publishAck(client, onInfoMsg);
+    if (client != nullptr) publishAck(client, onInfoMsg);
     serialport->println(onInfoMsg);
 
     // serialport->print("myIP =");
@@ -661,9 +669,21 @@ bool printable(char c)
 // Remove unwanted characters....
 void filter_control_chars(char *msg)
 {
+  if (msg == nullptr)
+  {
+    return;
+  }
+
   size_t len = strlen(msg);
+  if (len >= MAX_BUFFER_SIZE)
+  {
+    len = MAX_BUFFER_SIZE - 1;
+    msg[len] = '\0';
+  }
+
   char buff[MAX_BUFFER_SIZE];
-  strcpy(buff, msg);
+  memcpy(buff, msg, len);
+  buff[len] = '\0';
   int k = 0;
   for (int i = 0; i < len; i++)
   {

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
@@ -121,7 +121,7 @@ extern HardwareSerial uartSerial1;
 #define TXD2 17
 #define RXD2 16
 #define UART2_BAUD_RATE 9600
-extern HardwareSerial uartSerial1;
+extern HardwareSerial uartSerial2;
 
 namespace gpad_hal
 {

--- a/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
@@ -7,8 +7,12 @@
 #include "RickmanLiquidCrystal_I2C.h"
 #include "DFPlayer.h"
 #include "alarm_api.h"
+#include "mqtt_handler.h"
 
 using namespace Menu;
+
+
+extern PubSubClient client;
 
 extern bool running_menu;
 extern bool menu_just_exited;
@@ -17,11 +21,6 @@ extern unsigned long muteTimeoutEndMillis;
 #define LEDPIN 12
 #define MAX_DEPTH 2
 
-// This needs to be cleaned up; the PubSublcient and WiFi stuff needs to put into a
-// a module that is not in GPAD_API.ino
-extern PubSubClient client;
-extern char publish_Ack_Topic[];
-
 result action1(eventMask e)
 {
   if (e == eventMask::enterEvent)
@@ -29,9 +28,7 @@ result action1(eventMask e)
     Serial.println(F("Yes, I will take that action #1 !"));
   }
   char onLineMsg[32] = "Acknowledging!";
-  client.publish(publish_Ack_Topic, onLineMsg);
-  Serial.print("Message sent to topic: ");
-  Serial.println(publish_Ack_Topic);
+  publishAck(&client, onLineMsg);
   lcd.clear();
   lcd.setCursor(0, 0);
   lcd.print("Acknowledged!");
@@ -49,9 +46,7 @@ result action2(eventMask e)
   alarm(silent, emptyMsg, &Serial);      // sets currentLevel=0, clears AlarmMessageBuffer
   annunciateAlarmLevel(&Serial);          // turns off LEDs, updates LCD, stops DFPlayer buzzer
   char onLineMsg[32] = "Dismissed!";
-  client.publish(publish_Ack_Topic, onLineMsg);
-  Serial.print("Message sent to topic: ");
-  Serial.println(publish_Ack_Topic);
+  publishAck(&client, onLineMsg);
   return proceed;
 }
 result action3(eventMask e)
@@ -64,9 +59,7 @@ result action3(eventMask e)
   alarm(silent, emptyMsg, &Serial);
   annunciateAlarmLevel(&Serial);
   char onLineMsg[32] = "Shelved!";
-  client.publish(publish_Ack_Topic, onLineMsg);
-  Serial.print("Message sent to topic: ");
-  Serial.println(publish_Ack_Topic);
+  publishAck(&client, onLineMsg);
   return proceed;
 }
 result action4(eventMask e)

--- a/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
+++ b/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
@@ -48,8 +48,11 @@ int alarm(AlarmLevel level, char *str, Stream *serialport)
 {
   if (!(level >= 0 && level < NUM_LEVELS))
   {
-    serialport->println(F("Bad Level!"));
-    printError(serialport);
+    if (serialport != nullptr)
+    {
+      serialport->println(F("Bad Level!"));
+      printError(serialport);
+    }
     return -1;
   }
   int previousLevel = currentLevel;

--- a/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
+++ b/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
@@ -56,7 +56,11 @@ int alarm(AlarmLevel level, char *str, Stream *serialport)
   currentLevel = level;
   // This makes sure we erase the buffer even if msg is an empty string
   AlarmMessageBuffer[0] = '\0';
-  strcpy(AlarmMessageBuffer, str);
+  if (str != nullptr)
+  {
+    strncpy(AlarmMessageBuffer, str, MAX_BUFFER_SIZE - 1);
+    AlarmMessageBuffer[MAX_BUFFER_SIZE - 1] = '\0';
+  }
   return previousLevel;
 }
 

--- a/Firmware/GPAD_API/GPAD_API/gpad_serial.cpp
+++ b/Firmware/GPAD_API/GPAD_API/gpad_serial.cpp
@@ -49,8 +49,9 @@ void processSerial(Stream *debugPort, Stream *inputPort, PubSubClient *client)
   }
 
   static size_t writeIndex = 0;
+  bool processedCommand = false;
 
-  while (inputPort->available() > 0)
+  while (inputPort->available() > 0 && !processedCommand)
   {
     const int raw = inputPort->read();
     if (raw < 0)
@@ -82,6 +83,7 @@ void processSerial(Stream *debugPort, Stream *inputPort, PubSubClient *client)
         interpretBuffer(buf, rlen, debugPort, client);
         annunciateAlarmLevel(debugPort);
         printAlarmState(debugPort);
+        processedCommand = true;
       }
       writeIndex = 0;
       continue;
@@ -96,6 +98,13 @@ void processSerial(Stream *debugPort, Stream *inputPort, PubSubClient *client)
       // Overflow guard: reset buffer if a line grows too long.
       writeIndex = 0;
       printError(debugPort);
+      processedCommand = true;
     }
+  }
+
+  // Keep the scheduler/WDT serviced during burst traffic.
+  if (processedCommand)
+  {
+    yield();
   }
 }

--- a/Firmware/GPAD_API/GPAD_API/gpad_serial.cpp
+++ b/Firmware/GPAD_API/GPAD_API/gpad_serial.cpp
@@ -44,14 +44,13 @@ where C is an character, and D is a single digit.
 void processSerial(Stream *debugPort, Stream *inputPort, PubSubClient *client)
 {
   // Now see if we have a serial command
-  int rlen;
   // TODO: This code can probably hang; it needs to have
   // timeouts added!
   if (inputPort->available() > 0)
   {
     // TODO: MAKE NON-BLOCKING
     // read the incoming bytes:
-    int rlen = inputPort->readBytesUntil('\n', buf, COMMAND_BUFFER_SIZE);
+    const int rlen = inputPort->readBytesUntil('\n', buf, COMMAND_BUFFER_SIZE - 1);
     // readBytesUntil does not terminate the string!
     buf[rlen] = '\0';
     // prints the received data

--- a/Firmware/GPAD_API/GPAD_API/gpad_serial.cpp
+++ b/Firmware/GPAD_API/GPAD_API/gpad_serial.cpp
@@ -43,28 +43,59 @@ where C is an character, and D is a single digit.
 // a parameter passed in from the caller.
 void processSerial(Stream *debugPort, Stream *inputPort, PubSubClient *client)
 {
-  // Now see if we have a serial command
-  // TODO: This code can probably hang; it needs to have
-  // timeouts added!
-  if (inputPort->available() > 0)
+  if (debugPort == nullptr || inputPort == nullptr)
   {
-    // TODO: MAKE NON-BLOCKING
-    // read the incoming bytes:
-    const int rlen = inputPort->readBytesUntil('\n', buf, COMMAND_BUFFER_SIZE - 1);
-    // readBytesUntil does not terminate the string!
-    buf[rlen] = '\0';
-    // prints the received data
-    debugPort->print(F("I received: "));
-    debugPort->print(rlen);
-    for (int i = 0; i < rlen; i++)
-      debugPort->print(buf[i]);
-    debugPort->println();
-    interpretBuffer(buf, rlen, inputPort, client);
-    // Now "light and scream"appropriately...
-    // This does not work on HMWK2 device
-    annunciateAlarmLevel(debugPort);
-    // removing in an attempt to make faster; reason for adding unknown  - rlr
-    //    delay(3000);
-    printAlarmState(debugPort);
+    return;
+  }
+
+  static size_t writeIndex = 0;
+
+  while (inputPort->available() > 0)
+  {
+    const int raw = inputPort->read();
+    if (raw < 0)
+    {
+      break;
+    }
+
+    const char c = (char)raw;
+    if (c == '\r')
+    {
+      continue;
+    }
+
+    if (c == '\n')
+    {
+      const int rlen = (int)writeIndex;
+      buf[rlen] = '\0';
+
+      debugPort->print(F("I received: "));
+      debugPort->print(rlen);
+      for (int i = 0; i < rlen; i++)
+      {
+        debugPort->print(buf[i]);
+      }
+      debugPort->println();
+
+      if (rlen > 0)
+      {
+        interpretBuffer(buf, rlen, debugPort, client);
+        annunciateAlarmLevel(debugPort);
+        printAlarmState(debugPort);
+      }
+      writeIndex = 0;
+      continue;
+    }
+
+    if (writeIndex < (COMMAND_BUFFER_SIZE - 1))
+    {
+      buf[writeIndex++] = c;
+    }
+    else
+    {
+      // Overflow guard: reset buffer if a line grows too long.
+      writeIndex = 0;
+      printError(debugPort);
+    }
   }
 }

--- a/Firmware/GPAD_API/GPAD_API/mqtt_handler.cpp
+++ b/Firmware/GPAD_API/GPAD_API/mqtt_handler.cpp
@@ -1,0 +1,13 @@
+#include "mqtt_handler.h"
+
+extern char publish_Ack_Topic[];
+
+bool publishAck(PubSubClient *client, const char *message)
+{
+  if (client == nullptr || message == nullptr)
+  {
+    return false;
+  }
+
+  return client->publish(publish_Ack_Topic, message);
+}

--- a/Firmware/GPAD_API/GPAD_API/mqtt_handler.h
+++ b/Firmware/GPAD_API/GPAD_API/mqtt_handler.h
@@ -1,0 +1,8 @@
+#ifndef MQTT_HANDLER_H
+#define MQTT_HANDLER_H
+
+#include <PubSubClient.h>
+
+bool publishAck(PubSubClient *client, const char *message);
+
+#endif


### PR DESCRIPTION
# What and Why

- Replaced the unsafe alarm message copy in alarm_api.cpp by switching from raw strcpy to bounded copy with null checks and explicit termination, preventing overflow of the 81-byte alarm buffer.
- Hardened interpretBuffer() alarm parsing by validating rlen >= 2, validating alarm level bounds (0..NUM_LEVELS-1), and copying into a MAX_BUFFER_SIZE buffer with bounded memcpy + terminator (replacing the msg[61] + strncat path).
- Removed the risky restart command path from normal command processing by dropping 'r' from legal prefixes and eliminating the immediate ESP.restart() branch from interpretBuffer().
- Fixed the duplicated/wrong UART extern declaration in GPAD_HAL.h so UART2 is correctly declared as uartSerial2.
Began MQTT/HAL decoupling by removing HAL-local MQTT topic extern usage and routing ACK publishes through a new mqtt_handler module (publishAck()), then calling that helper from HAL info responses.


- Debugged the MQTT regression by removing the fragile GPAP deserialization gate from interpretBuffer() and dispatching directly on the first command byte ('a', 'i', 'h', 's', 'u'). This avoids message drops/failures caused by strict/throwing parse behavior before command handling runs.
- Kept the alarm safety hardening intact in the new flow (rlen >= 2, alarm level bounds check, bounded copy with terminator), so the crash fix remains while MQTT ingestion is more tolerant.
- Removed now-unused GPAP message dependency include from HAL after changing routing logic, while preserving the MQTT ACK helper path you requested earlier.


- I found and fixed a high-probability memory corruption bug in serial input handling: readBytesUntil() now reads at most COMMAND_BUFFER_SIZE - 1, so buf[rlen] = '\0' is always in-bounds. This directly addresses the kind of latent corruption that can cause later LoadProhibited panics and malformed command parsing logs (like blank Command:).
- I also hardened alarm_api.cpp so invalid alarm-level handling no longer dereferences a null serialport pointer during error reporting, reducing another crash vector under bad input paths.


- I continued the crash/debug hardening by adding defensive guards in interpretBuffer():
early return if buf == nullptr, serialport == nullptr, or rlen < 1
explicit reject of empty command byte ('\0')
null-checks before each MQTT ACK publish call in INFO handling.
These changes prevent null-pointer dereferences in command-processing paths that match your LoadProhibited symptom pattern.
- I removed another unsafe string copy path in LCD message sanitization:
filter_control_chars() now handles nullptr
clamps overlong input to MAX_BUFFER_SIZE - 1
replaces strcpy with bounded memcpy + explicit terminator.
This closes another memory-corruption vector that could cause delayed panics in unrelated code paths.


- I audited the remaining ACK-topic publish paths and updated GPAD_menu.cpp so menu acknowledgements now go through mqtt_handler (publishAck(&client, ...)) instead of direct client.publish(publish_Ack_Topic, ...).
- At this point, mqtt_handler is used in both:
HAL INFO response ACK publishes.
- Menu action ACK publishes (Acknowledging!, Dismissed!, Shelved!).
- Remaining direct client.publish(...) calls are in GPAD_API.ino for retained online/LWT/status behavior (not simple ACK wrappers), so I intentionally left those explicit.

- I debugged the “slow receive + occasional software reset while sending” path and replaced the blocking serial command read with a non-blocking parser in processSerial().
- Instead of readBytesUntil(...), it now consumes only currently-available bytes, buffers partial lines across loop iterations, and processes immediately when \n arrives.
- I also added overflow-safe framing and null guards:
guard for debugPort / inputPort == nullptr
ignore \r, terminate on \n
reject overlong lines safely and reset buffer instead of risking corruption.
These reduce watchdog/reset risk from stalled loops or malformed long payloads.
- Fixed stream usage so command interpretation logs and errors consistently use debugPort in this path (interpretBuffer(buf, rlen, debugPort, client)), instead of writing to the input stream pointer.



- I addressed the burst-traffic reset by throttling serial command handling so processSerial() now handles at most one complete command per invocation. This prevents a long tight loop from repeatedly running heavy alarm/UI/audio work when many messages arrive at once.
- I added explicit burst control:
processedCommand flag gates the loop
overflow path also sets processedCommand to stop immediate repeated work
yield() is called after processing to service sched

- I added a targeted anti-reset safeguard in the hot alarm path by rate-limiting annunciateAlarmLevel() to avoid repeated heavy LCD/audio work during burst message traffic. Calls within 50 ms now run only the lightweight unchanged path instead of full redraw/audio dispatch.
- I also added a null guard on serialport in annunciateAlarmLevel() and a yield() after full annunciation, to reduce watchdog pressure and prevent null-deref crash cases during high-load timing windows.


- Added reset-reason reporting to the i (INFO) command flow, so it now prints/publishes a line like Reset reason: SOFTWARE (or TASK_WDT, PANIC, etc.).
- Included ESP-IDF reset APIs with #include <esp_system.h> and added a reset-enum → readable-string helper (resetReasonToString).
- Added a forward declaration so the helper is visible where INFO command code uses it (prevents compile-order issues)


# files changed and DIR 

GPAD_HAL.cpp
Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
 
GPAD_HAL.h
Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
 
GPAD_menu.cpp
Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
 

alarm_api.cpp
Firmware/GPAD_API/GPAD_API/alarm_api.cpp


gpad_serial.cpp
Firmware/GPAD_API/GPAD_API/gpad_serial.cpp
 

mqtt_handler.cpp
Firmware/GPAD_API/GPAD_API/mqtt_handler.cpp
 

mqtt_handler.h
Firmware/GPAD_API/GPAD_API/mqtt_handler.h