### PR TITLE
COM port flow control

### DIFF
--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -27,8 +27,124 @@
 #include "GPAD_menu.h"
 #include "mqtt_handler.h"
 #include <esp_system.h>
+#include <Preferences.h>
+#include <driver/uart.h>
 
 using namespace gpad_hal;
+
+
+namespace
+{
+  Preferences comPrefs;
+  const char *COM_PREF_NS = "comcfg";
+  const char *COM_PREF_BAUD = "baud";
+  const char *COM_PREF_FMT = "fmt";
+  const char *COM_PREF_FLOW = "flow";
+
+  const uint8_t SERIAL_FORMAT_COUNT = 1;
+  const uint32_t COM_DEFAULT_BAUD_RATE = 9600;
+  const uint8_t COM_DEFAULT_SERIAL_FORMAT_INDEX = 0; // 8-N-1
+  const ComFlowControlMode COM_DEFAULT_FLOW = COM_FLOW_OFF;
+
+  ComPortConfig comPortConfig = {COM_DEFAULT_BAUD_RATE, COM_DEFAULT_SERIAL_FORMAT_INDEX, COM_DEFAULT_FLOW};
+
+  bool isSupportedBaudRate(uint32_t baudRate)
+  {
+    switch (baudRate)
+    {
+    case 1200:
+    case 2400:
+    case 4800:
+    case 9600:
+    case 19200:
+    case 38400:
+    case 57600:
+    case 115200:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  uint32_t sanitizeBaudRate(uint32_t baudRate)
+  {
+    return isSupportedBaudRate(baudRate) ? baudRate : COM_DEFAULT_BAUD_RATE;
+  }
+
+  uint8_t sanitizeSerialFormatIndex(uint8_t serialFormatIndex)
+  {
+    return (serialFormatIndex < SERIAL_FORMAT_COUNT) ? serialFormatIndex : COM_DEFAULT_SERIAL_FORMAT_INDEX;
+  }
+
+  ComFlowControlMode sanitizeFlowControl(uint8_t flow)
+  {
+    return (flow == static_cast<uint8_t>(COM_FLOW_RTS_CTS)) ? COM_FLOW_RTS_CTS : COM_FLOW_OFF;
+  }
+
+  uint32_t loadComBaudRate() { return sanitizeBaudRate(comPrefs.getUInt(COM_PREF_BAUD, COM_DEFAULT_BAUD_RATE)); }
+  uint8_t loadComSerialFormatIndex() { return sanitizeSerialFormatIndex(comPrefs.getUChar(COM_PREF_FMT, COM_DEFAULT_SERIAL_FORMAT_INDEX)); }
+  ComFlowControlMode loadComFlowControl() { return sanitizeFlowControl(comPrefs.getUChar(COM_PREF_FLOW, static_cast<uint8_t>(COM_DEFAULT_FLOW))); }
+
+  uart_word_length_t uartDataBitsFromFormatIndex(uint8_t serialFormatIndex)
+  {
+    (void)serialFormatIndex;
+    return UART_DATA_8_BITS;
+  }
+}
+
+const ComPortConfig &getComPortConfig() { return comPortConfig; }
+
+bool setComPortBaudRate(uint32_t baudRate)
+{
+  if (!isSupportedBaudRate(baudRate)) return false;
+  comPortConfig.baudRate = baudRate;
+  comPrefs.putUInt(COM_PREF_BAUD, comPortConfig.baudRate);
+  return true;
+}
+
+bool setComPortSerialFormatIndex(uint8_t serialFormatIndex)
+{
+  if (serialFormatIndex >= SERIAL_FORMAT_COUNT) return false;
+  comPortConfig.serialFormatIndex = serialFormatIndex;
+  comPrefs.putUChar(COM_PREF_FMT, comPortConfig.serialFormatIndex);
+  return true;
+}
+
+bool setComPortFlowControl(ComFlowControlMode flowControl)
+{
+  if (flowControl != COM_FLOW_OFF && flowControl != COM_FLOW_RTS_CTS) return false;
+  comPortConfig.flowControl = flowControl;
+  comPrefs.putUChar(COM_PREF_FLOW, static_cast<uint8_t>(comPortConfig.flowControl));
+  return true;
+}
+
+void applyComPortConfig(Stream *serialport)
+{
+  uartSerial1.begin(comPortConfig.baudRate, SERIAL_8N1, RXD1, TXD1);
+  uartSerial1.flush();
+
+  const uart_word_length_t dbits = uartDataBitsFromFormatIndex(comPortConfig.serialFormatIndex);
+  uart_set_word_length(UART_NUM_1, dbits);
+  uart_set_parity(UART_NUM_1, UART_PARITY_DISABLE);
+  uart_set_stop_bits(UART_NUM_1, UART_STOP_BITS_1);
+
+  if (comPortConfig.flowControl == COM_FLOW_RTS_CTS)
+  {
+    uart_set_hw_flow_ctrl(UART_NUM_1, UART_HW_FLOWCTRL_CTS_RTS, 122);
+  }
+  else
+  {
+    uart_set_hw_flow_ctrl(UART_NUM_1, UART_HW_FLOWCTRL_DISABLE, 0);
+  }
+
+  if (serialport != nullptr)
+  {
+    serialport->print(F("COM UART1: "));
+    serialport->print(comPortConfig.baudRate);
+    serialport->print(F(", 8-N-1, flow="));
+    serialport->println((comPortConfig.flowControl == COM_FLOW_RTS_CTS) ? F("RTS/CTS") : F("off"));
+  }
+}
 
 const char *resetReasonToString(esp_reset_reason_t reason);
 
@@ -395,11 +511,12 @@ void GPAD_HAL_setup(Stream *serialport, wifi_mode_t wifiMode, IPAddress &deviceI
   // digitalWrite(LED_BUILTIN, LOW);   // turn the LED off at end of setup
 
 #if !defined(HMWK) // On Homework2, LCD goes blank early
-  // Here initialize the UART1
-  // FLE the Serial1 is faliing to terminate
-  //   pinMode(RXD1, INPUT_PULLUP);
-  uartSerial1.begin(UART1_BAUD_RATE, SERIAL_8N1, RXD1, TXD1); // UART setup. On Homework2, LCD goes blank early
-  uartSerial1.flush();                                        // Clear any Serial1 crud at reset.
+  comPrefs.begin(COM_PREF_NS, false);
+  comPortConfig.baudRate = loadComBaudRate();
+  comPortConfig.serialFormatIndex = loadComSerialFormatIndex();
+  comPortConfig.flowControl = loadComFlowControl();
+
+  applyComPortConfig(serialport);
 
 #if (DEBUG > 0)
   serialport->println(F("uartSerial1 Setup"));

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
@@ -123,6 +123,26 @@ extern HardwareSerial uartSerial1;
 #define UART2_BAUD_RATE 9600
 extern HardwareSerial uartSerial2;
 
+
+enum ComFlowControlMode : uint8_t
+{
+  COM_FLOW_OFF = 0,
+  COM_FLOW_RTS_CTS = 1,
+};
+
+struct ComPortConfig
+{
+  uint32_t baudRate;
+  uint8_t serialFormatIndex;
+  ComFlowControlMode flowControl;
+};
+
+const ComPortConfig &getComPortConfig();
+bool setComPortBaudRate(uint32_t baudRate);
+bool setComPortSerialFormatIndex(uint8_t serialFormatIndex);
+bool setComPortFlowControl(ComFlowControlMode flowControl);
+void applyComPortConfig(Stream *serialport);
+
 namespace gpad_hal
 {
 

--- a/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
@@ -108,7 +108,7 @@ int comFlowControlIndex = 0;
 
 
 
-result actionComSetup(eventMask e)
+result actionComSaveAndExit(eventMask e)
 {
   if (e != eventMask::enterEvent)
   {
@@ -145,7 +145,7 @@ result actionComSetup(eventMask e)
 
   lcd.clear();
   lcd.setCursor(0, 0);
-  lcd.print("COM applied");
+  lcd.print("COM saved");
   lcd.setCursor(0, 1);
   lcd.print(comBaudRate);
   lcd.print(" ");
@@ -153,6 +153,20 @@ result actionComSetup(eventMask e)
   lcd.setCursor(0, 2);
   lcd.print("Flow:");
   lcd.print(kFlowControlModes[comFlowControlIndex]);
+  Menu::doExit();
+  return proceed;
+}
+
+result actionComExitNoSave(eventMask e)
+{
+  if (e == eventMask::enterEvent)
+  {
+    const ComPortConfig &cfg = getComPortConfig();
+    comBaudRate = static_cast<int>(cfg.baudRate);
+    comSerialFormatIndex = static_cast<int>(cfg.serialFormatIndex);
+    comFlowControlIndex = (cfg.flowControl == COM_FLOW_RTS_CTS) ? 1 : 0;
+    Menu::doExit();
+  }
   return proceed;
 }
 
@@ -177,10 +191,11 @@ result actionMuteTimeout(eventMask e)
 
 
 MENU(comSetupMenu, "COM Setup", Menu::doNothing, Menu::noEvent, Menu::wrapStyle,
-  FIELD(comBaudRate, "Baud", "", 1200, 115200, 9600, 1, Menu::doNothing, anyEvent, noStyle),
-  FIELD(comSerialFormatIndex, "Format", "", 0, 0, 0, 1, Menu::doNothing, anyEvent, noStyle),
-  FIELD(comFlowControlIndex, "Flow", "", 0, 1, 0, 1, Menu::doNothing, anyEvent, noStyle),
-  OP("Apply", actionComSetup, enterEvent)
+  FIELD(comBaudRate, "Baud Rate", "", 1200, 115200, 9600, 1, Menu::doNothing, anyEvent, noStyle),
+  FIELD(comSerialFormatIndex, "Serial Format", "", 0, 0, 0, 1, Menu::doNothing, anyEvent, noStyle),
+  FIELD(comFlowControlIndex, "Flow Control", "", 0, 1, 0, 1, Menu::doNothing, anyEvent, noStyle),
+  OP("Save & Exit", actionComSaveAndExit, enterEvent),
+  OP("Exit (No Save)", actionComExitNoSave, enterEvent)
 );
 
 MENU(resetConfirmMenu, "Reset", Menu::doNothing, Menu::noEvent, Menu::noStyle,

--- a/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
@@ -153,8 +153,7 @@ result actionComSaveAndExit(eventMask e)
   lcd.setCursor(0, 2);
   lcd.print("Flow:");
   lcd.print(kFlowControlModes[comFlowControlIndex]);
-  Menu::doExit();
-  return proceed;
+  return quit;
 }
 
 result actionComExitNoSave(eventMask e)
@@ -165,7 +164,7 @@ result actionComExitNoSave(eventMask e)
     comBaudRate = static_cast<int>(cfg.baudRate);
     comSerialFormatIndex = static_cast<int>(cfg.serialFormatIndex);
     comFlowControlIndex = (cfg.flowControl == COM_FLOW_RTS_CTS) ? 1 : 0;
-    Menu::doExit();
+    return quit;
   }
   return proceed;
 }

--- a/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
@@ -95,6 +95,67 @@ result actionResetConfirm(eventMask e)
 
 int muteTimeoutMinutes = 5;
 
+
+const uint32_t kBaudOptions[] = {1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200};
+const uint8_t kBaudOptionCount = sizeof(kBaudOptions) / sizeof(kBaudOptions[0]);
+const char *kSerialFormats[] = {"8-N-1"};
+const uint8_t kSerialFormatCount = sizeof(kSerialFormats) / sizeof(kSerialFormats[0]);
+const char *kFlowControlModes[] = {"Off", "RTS-CTS"};
+
+int comBaudRate = 9600;
+int comSerialFormatIndex = 0;
+int comFlowControlIndex = 0;
+
+
+
+result actionComSetup(eventMask e)
+{
+  if (e != eventMask::enterEvent)
+  {
+    return proceed;
+  }
+
+  bool baudOk = false;
+  for (uint8_t i = 0; i < kBaudOptionCount; i++)
+  {
+    if (kBaudOptions[i] == static_cast<uint32_t>(comBaudRate))
+    {
+      baudOk = true;
+      break;
+    }
+  }
+  if (!baudOk)
+  {
+    comBaudRate = 9600;
+  }
+
+  if (comSerialFormatIndex < 0 || comSerialFormatIndex >= kSerialFormatCount)
+  {
+    comSerialFormatIndex = 0;
+  }
+  if (comFlowControlIndex < 0 || comFlowControlIndex > 1)
+  {
+    comFlowControlIndex = 0;
+  }
+
+  setComPortBaudRate(static_cast<uint32_t>(comBaudRate));
+  setComPortSerialFormatIndex(static_cast<uint8_t>(comSerialFormatIndex));
+  setComPortFlowControl(comFlowControlIndex == 1 ? COM_FLOW_RTS_CTS : COM_FLOW_OFF);
+  applyComPortConfig(&Serial);
+
+  lcd.clear();
+  lcd.setCursor(0, 0);
+  lcd.print("COM applied");
+  lcd.setCursor(0, 1);
+  lcd.print(comBaudRate);
+  lcd.print(" ");
+  lcd.print(kSerialFormats[comSerialFormatIndex]);
+  lcd.setCursor(0, 2);
+  lcd.print("Flow:");
+  lcd.print(kFlowControlModes[comFlowControlIndex]);
+  return proceed;
+}
+
 result actionMuteTimeout(eventMask e)
 {
   if (e == eventMask::enterEvent)
@@ -114,6 +175,14 @@ result actionMuteTimeout(eventMask e)
   return proceed;
 }
 
+
+MENU(comSetupMenu, "COM Setup", Menu::doNothing, Menu::noEvent, Menu::wrapStyle,
+  FIELD(comBaudRate, "Baud", "", 1200, 115200, 9600, 1, Menu::doNothing, anyEvent, noStyle),
+  FIELD(comSerialFormatIndex, "Format", "", 0, 0, 0, 1, Menu::doNothing, anyEvent, noStyle),
+  FIELD(comFlowControlIndex, "Flow", "", 0, 1, 0, 1, Menu::doNothing, anyEvent, noStyle),
+  OP("Apply", actionComSetup, enterEvent)
+);
+
 MENU(resetConfirmMenu, "Reset", Menu::doNothing, Menu::noEvent, Menu::noStyle,
   OP("Yes - Reset", actionResetConfirm, enterEvent),
   OP("No  - Cancel", Menu::doNothing, Menu::noEvent)
@@ -126,6 +195,7 @@ MENU(mainMenu, "Krake Menu", Menu::doNothing, Menu::noEvent, Menu::wrapStyle,
   OP("Shelve", action3, enterEvent),
   FIELD(volumeDFPlayer, "Volume", "%", 0, 30, 10, 1, action4, anyEvent, wrapStyle),
   FIELD(muteTimeoutMinutes, "Mute Time", "min", 1, 60, 5, 1, actionMuteTimeout, enterEvent, wrapStyle),
+  SUBMENU(comSetupMenu),
   SUBMENU(resetConfirmMenu),
   OP("Exit Menu", action5, enterEvent)
 );
@@ -168,6 +238,10 @@ void registerRotaryEncoderPress()
 
 void setup_GPAD_menu()
 {
+  const ComPortConfig &cfg = getComPortConfig();
+  comBaudRate = static_cast<int>(cfg.baudRate);
+  comSerialFormatIndex = static_cast<int>(cfg.serialFormatIndex);
+  comFlowControlIndex = (cfg.flowControl == COM_FLOW_RTS_CTS) ? 1 : 0;
 }
 
 void poll_GPAD_menu()


### PR DESCRIPTION
# closes #357 

# what and why 

Add persistent COM Setup menu and apply UART1 settings at boot

- Added a new COM configuration API in HAL (ComPortConfig, flow-control enum, getters/setters, and apply function) so COM settings can be managed centrally and reused by the menu/UI layer.
- Implemented persistent COM settings in NVS (Preferences) with defaults of 9600, 8-N-1, and flow control off, plus validation/sanitization and runtime UART1 reconfiguration logic (including optional RTS/CTS hardware flow control).
- Updated COM UART initialization during HAL setup to load persisted settings and apply them when UART1 is initialized (instead of fixed compile-time UART1 defaults).
- Added a COM Setup submenu to the main menu with fields for baud, serial format, and flow control, plus an explicit Apply action that saves and applies the configuration immediately and shows confirmation on LCD.
- Wired menu setup to initialize COM submenu values from currently persisted configuration, so UI reflects saved state after boot/reset.
 


- Updated the COM Setup submenu items to match the requested structure and labels:
Baud Rate
Serial Format
Flow Control
Save & Exit
Exit (No Save).
- Replaced the old Apply behavior with Save & Exit, which validates values, saves/apply COM settings, and then exits the submenu flow.
- Added Exit (No Save) action that restores the staged COM fields from persisted config and exits without saving/applying changes.

- Updated COM Setup exit behavior so leaving that submenu returns to its parent (main menu) rather than exiting the full menu system:
Save & Exit now returns quit after saving/applying settings.
Exit (No Save) now restores persisted COM values and returns quit.




# files changed

GPAD_HAL.cpp
Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
 
GPAD_HAL.h
Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
 

GPAD_menu.cpp
Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
 