### PR TITLE
Avoid marking devices online from retained _ALM messages

### DIFF
--- a/Firmware/GPAD_API/data/js/device-monitor.js
+++ b/Firmware/GPAD_API/data/js/device-monitor.js
@@ -82,18 +82,31 @@ function macFromTopic(topic) {
   return macToName[mac] ? mac : null;
 }
 
+function topicSuffix(topic) {
+  const clean = normalizeTopic(topic).toUpperCase();
+  const parts = clean.split("_");
+  return parts.length > 1 ? parts[parts.length - 1] : "";
+}
+
 function markSeen(mac, topic, payload) {
   const device = devices[mac];
   if (!device) return;
 
   const text = String(payload ?? "");
-  device.lastSeen = Date.now();
+  const suffix = topicSuffix(topic);
+  const now = Date.now();
   device.lastTopic = normalizeTopic(topic);
   device.lastMessage = text;
 
-  // Last Will / retained offline status support, if firmware publishes it.
-  const lower = text.toLowerCase();
-  device.online = !(lower.includes("offline") || lower.includes("disconnected"));
+  // _ALM may contain retained command payloads and should not force a device online.
+  // Only presence/status channels update last-seen heartbeat state.
+  if (suffix === "ACK" || suffix === "STATUS" || suffix === "HEARTBEAT") {
+    device.lastSeen = now;
+
+    // Last Will / retained offline status support, if firmware publishes it.
+    const lower = text.toLowerCase();
+    device.online = !(lower.includes("offline") || lower.includes("disconnected"));
+  }
 
   messageCount++;
   render();


### PR DESCRIPTION
## closes issue #502 

## What and Why 

Fixed the device monitor logic so retained _ALM messages no longer incorrectly mark devices as online right after subscribe/reconnect. Online presence is now updated only from _ACK, _STATUS, and _HEARTBEAT topics. This addresses the “all online for some time before correct status” behavior you reported. 
Added a topicSuffix() helper and updated markSeen() to gate heartbeat/presence updates by topic type, while still recording message content and incrementing message count for all topics. 


## files changed 

Firmware/GPAD_API/data/js/device-monitor.js