### PR TITLE
Firmware, Reduce MQTT delay and congestion.

### DIFF
--- a/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
+++ b/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
@@ -110,13 +110,26 @@ void checkSerial(void)
   }
 }
 
+namespace
+{
+void delayWithYield(const unsigned long durationMs)
+{
+  const unsigned long startMs = millis();
+  while ((millis() - startMs) < durationMs)
+  {
+    delay(10);
+    yield();
+  }
+}
+}
+
 void setupDFPlayer()
 {
   pinMode(nDFPlayer_BUSY, INPUT_PULLUP);
 
   Serial.println("UART2 Begin for DFPlayer");
   mySerial1.begin(BAUD_DFPLAYER, SERIAL_8N1, RXD2, TXD2);
-  delay(1000);
+  delayWithYield(1000);
 
   // ACK=false is safer for DFPlayer clones and avoids repeated blocking/timeouts.
   Serial.println("Begin DFPlayer: ACK=false, doReset=false");
@@ -132,7 +145,7 @@ void setupDFPlayer()
   Serial.println("DFPlayer Mini detected.");
 
   dfPlayer.setTimeOut(500);
-  delay(300);
+  delayWithYield(300);
 
   // This may return unusual values on clones. Do not disable audio only because of this.
   int moduleState = dfPlayer.readState();
@@ -144,7 +157,7 @@ void setupDFPlayer()
   }
 
   dfPlayer.volume(volumeDFPlayer);
-  delay(300);
+  delayWithYield(300);
 
   numberFilesDF = dfPlayer.readFileCounts();
   Serial.print("SD card file count: ");
@@ -157,7 +170,7 @@ void setupDFPlayer()
 
   Serial.println("DFPlayer startup test: playing track 1.");
   dfPlayer.play(1);
-  delay(3000); // Give enough time to hear output. Do not immediately stop.
+  delayWithYield(3000); // Give enough time to hear output without starving the scheduler/WDT.
 
   displayDFPlayerStats();
   menu_opcoes();

--- a/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
+++ b/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
@@ -11,7 +11,7 @@ const int nDFPlayer_BUSY = 4; // active LOW BUSY pin from DFPlayer
 bool isDFPlayerDetected = false;
 int volumeDFPlayer = 20; // Range: 1 to 30
 int numberFilesDF = 0;   // Number of audio files found on SD card
-
+extern bool currentlyMuted;
 char command;
 int pausa = 0;
 
@@ -304,6 +304,12 @@ void playNotBusyLevel(int level)
 {
   if (!isDFPlayerDetected) return;
 
+  if (currentlyMuted)
+  {
+    Serial.println("Muted: skipping DFPlayer playback.");
+    return;
+  }
+
   Serial.println("playNotBusyLevel");
   if (digitalRead(nDFPlayer_BUSY) == HIGH)
   {
@@ -324,6 +330,12 @@ void playNotBusyLevel(int level)
 bool playAlarmLevel(int alarmNumberToPlay)
 {
   if (!isDFPlayerDetected) return false;
+
+  if (currentlyMuted)
+  {
+    Serial.println("Muted: skipping alarm playback.");
+    return false;
+  }
 
   static unsigned long timer = 0;
   const unsigned long delayPlayLevel = 100;

--- a/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
+++ b/Firmware/GPAD_API/GPAD_API/DFPlayer.cpp
@@ -310,6 +310,12 @@ void playNotBusyLevel(int level)
     return;
   }
 
+     if (level <= 0)
+  {
+    Serial.println("Silent level: skipping DFPlayer playback.");
+    return;
+  }
+
   Serial.println("playNotBusyLevel");
   if (digitalRead(nDFPlayer_BUSY) == HIGH)
   {
@@ -325,6 +331,9 @@ void playNotBusyLevel(int level)
   {
     printDetail(dfPlayer.readType(), dfPlayer.read());
   }
+
+  if (!isDFPlayerDetected) return;
+
 }
 
 bool playAlarmLevel(int alarmNumberToPlay)

--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -1799,8 +1799,7 @@ void setup()
 
   initRotator();
   debugSerial.println(F("initRotator"));
-  IPAddress splashAddress = wifiManager.getAddress();
-  splashLCD(wifiManager.getMode(), splashAddress);
+  splashLCD(wifiManager.getMode(), wifiManager.getAddress());
 
   debugSerial.println(F("splashLCD"));
 

--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -1799,7 +1799,8 @@ void setup()
 
   initRotator();
   debugSerial.println(F("initRotator"));
-  splashLCD(wifiManager.getMode(), wifiManager.getAddress());
+  IPAddress splashAddress = wifiManager.getAddress();
+  splashLCD(wifiManager.getMode(), splashAddress);
 
   debugSerial.println(F("splashLCD"));
 

--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -217,10 +217,15 @@ char publish_Default_Topic[MAX_TOPIC_LEN] = {0};
 const size_t DEVICE_ROLE_MAX_LEN = 12;
 char device_role[DEVICE_ROLE_MAX_LEN] = "Krake";
 const char *STATUS_DISCOVERY_TOPIC = "#";
+const bool MQTT_DISCOVERY_SUBSCRIBE_ALL = false;
 const uint8_t MAX_WATCH_TOPICS = 12;
 char watchedTopics[MAX_WATCH_TOPICS][MAX_TOPIC_LEN];
 uint8_t watchedTopicCount = 0;
 unsigned long wifiResetRequestedAtMs = 0;
+const unsigned long MQTT_RECONNECT_INTERVAL_MS = 5000;
+const uint16_t MQTT_SOCKET_TIMEOUT_SECONDS = 2;
+unsigned long lastMqttReconnectAttemptMs = 0;
+bool mqttReconnectRequested = false;
 
 const uint8_t MAX_TRACKED_KRAKES = 16;
 const unsigned long KRAKE_ONLINE_TIMEOUT_MS = 30000;
@@ -323,6 +328,11 @@ void serialSplash()
 // A periodic message identifying the subscriber (Krake) is on line.
 void publishOnLineMsg(void)
 {
+  if (!client.connected())
+  {
+    return;
+  }
+
   const unsigned long MESSAGE_PERIOD = 10000;
   static unsigned long lastMillis = 0; // Sets timing for periodic MQTT publish message
   // publish a message roughly every second.
@@ -353,44 +363,68 @@ void publishOnLineMsg(void)
   }
 }
 
-// TODO: have this return a success or failure status and move
-// the delay up.
-void reconnect()
+void requestMqttReconnect()
 {
-  int n = 0;
+  mqttReconnectRequested = true;
+  lastMqttReconnectAttemptMs = 0;
+  if (client.connected())
+  {
+    client.disconnect();
+  }
+}
+
+bool reconnect(bool force = false)
+{
+  if (client.connected())
+  {
+    mqttReconnectRequested = false;
+    return true;
+  }
+
+  if (WiFi.status() != WL_CONNECTED)
+  {
+    return false;
+  }
+
+  const unsigned long now = millis();
+  if (!force && lastMqttReconnectAttemptMs != 0 && (now - lastMqttReconnectAttemptMs) < MQTT_RECONNECT_INTERVAL_MS)
+  {
+    return false;
+  }
+  lastMqttReconnectAttemptMs = now;
+  mqttReconnectRequested = false;
+
   const String clientId = String(COMPANY_NAME) + "-" + String(macAddressString);
   const String willPayload = String(device_role) + " offline";
-  while (!client.connected() && n < NUM_WIFI_RECONNECT_RETRIES)
+  debugSerial.print("Attempting MQTT connection at: ");
+  debugSerial.print(millis());
+  debugSerial.print("..... ");
+  if (client.connect(clientId.c_str(), mqtt_user, mqtt_password, publish_Ack_Topic, 1, true, willPayload.c_str()))
   {
-    n++;
-    debugSerial.print("Attempting MQTT connection at: ");
-    debugSerial.print(millis());
-    debugSerial.print("..... ");
-    if (client.connect(clientId.c_str(), mqtt_user, mqtt_password, publish_Ack_Topic, 1, true, willPayload.c_str()))
+    debugSerial.print("success at: ");
+    debugSerial.println(millis());
+    String onlinePayload = String(device_role) + " online";
+    client.publish(publish_Ack_Topic, onlinePayload.c_str(), true);
+    client.subscribe(subscribe_Alarm_Topic); // Subscribe to GPAD API alarms
+    if (MQTT_DISCOVERY_SUBSCRIBE_ALL)
     {
-      debugSerial.print("success at: ");
-      debugSerial.println(millis());
-      String onlinePayload = String(device_role) + " online";
-      client.publish(publish_Ack_Topic, onlinePayload.c_str(), true);
-      client.subscribe(subscribe_Alarm_Topic); // Subscribe to GPAD API alarms
       client.subscribe(STATUS_DISCOVERY_TOPIC);
-      for (uint8_t i = 0; i < subscribe_Extra_Topic_Count; i++)
-      {
-        client.subscribe(subscribe_Extra_Topics[i]);
-      }
-      for (uint8_t i = 0; i < watchedTopicCount; i++)
-      {
-        client.subscribe(watchedTopics[i]);
-      }
     }
-    else
+    for (uint8_t i = 0; i < subscribe_Extra_Topic_Count; i++)
     {
-      debugSerial.print("failed, rc=");
-      debugSerial.println(client.state());
-      delay(1000);
+      client.subscribe(subscribe_Extra_Topics[i]);
     }
+    for (uint8_t i = 0; i < watchedTopicCount; i++)
+    {
+      client.subscribe(watchedTopics[i]);
+    }
+    return true;
   }
-  debugSerial.println((client.connected()) ? "connected!" : "failed to reconnect!");
+
+  debugSerial.print("failed, rc=");
+  debugSerial.println(client.state());
+  yield();
+  return false;
 }
 
 bool isManagedSubscribedTopic(const char *topic)
@@ -682,7 +716,7 @@ void clearExtraTopics()
   }
 }
 
-void parseAndSetExtraTopics(const String &rawTopics)
+bool parseAndSetExtraTopics(const String &rawTopics)
 {
   clearExtraTopics();
   String token = "";
@@ -694,14 +728,23 @@ void parseAndSetExtraTopics(const String &rawTopics)
       token.trim();
       if (token.length() > 0 && subscribe_Extra_Topic_Count < MAX_EXTRA_TOPICS)
       {
+        if (token.length() >= MAX_TOPIC_LEN)
+        {
+          return false;
+        }
         token.toCharArray(subscribe_Extra_Topics[subscribe_Extra_Topic_Count], MAX_TOPIC_LEN);
         subscribe_Extra_Topic_Count++;
+      }
+      else if (token.length() > 0)
+      {
+        return false;
       }
       token = "";
       continue;
     }
     token += c;
   }
+  return true;
 }
 
 String joinedExtraTopics()
@@ -1001,11 +1044,8 @@ bool applyBrokerSetting(const String &broker)
 
   broker.toCharArray(mqtt_broker_name, MQTT_BROKER_MAX_LEN);
   client.setServer(mqtt_broker_name, 1883);
-  if (client.connected())
-  {
-    client.disconnect();
-  }
-  reconnect();
+  client.setSocketTimeout(MQTT_SOCKET_TIMEOUT_SECONDS);
+  requestMqttReconnect();
   writeMqttConfig();
   return true;
 }
@@ -1037,13 +1077,11 @@ bool applyPrimaryTopicSetting(const String &rawTopic, char *destTopic, size_t de
 
 void applyExtraTopicsSetting(const String &topics)
 {
-  parseAndSetExtraTopics(topics);
-  if (client.connected())
+  if (parseAndSetExtraTopics(topics))
   {
-    client.disconnect();
+    requestMqttReconnect();
+    writeMqttConfig();
   }
-  reconnect();
-  writeMqttConfig();
 }
 // Function to turn on all lamps
 void turnOnAllLamps()
@@ -1367,6 +1405,7 @@ void setupOTA()
                 {
                   broker.toCharArray(mqtt_broker_name, MQTT_BROKER_MAX_LEN);
                   client.setServer(mqtt_broker_name, 1883);
+                  client.setSocketTimeout(MQTT_SOCKET_TIMEOUT_SECONDS);
                 }
               }
 
@@ -1397,7 +1436,7 @@ void setupOTA()
               if (request->hasParam("subscribeTopics", true))
               {
                 String topics = request->getParam("subscribeTopics", true)->value();
-                parseAndSetExtraTopics(topics);
+                if (!parseAndSetExtraTopics(topics))
                 {
                   errorMessage += "invalid subscribeTopics;";
                 }
@@ -1439,11 +1478,7 @@ void setupOTA()
               }
 
               writeMqttConfig();
-              if (client.connected())
-              {
-                client.disconnect();
-              }
-              reconnect();
+              requestMqttReconnect();
               request->send(200, "text/plain", "config updated"); });
 
   server.on("/settings/mute", HTTP_POST, [](AsyncWebServerRequest *request)
@@ -1610,9 +1645,10 @@ void setup()
   // Serial setup
   delay(100);
   debugSerial.begin(BAUDRATE);
-  while (!debugSerial)
+  const unsigned long serialStartMs = millis();
+  while (!debugSerial && (millis() - serialStartMs) < 2000)
   {
-    ; // wait for serial port to connect. Needed for native USB
+    delay(10); // wait briefly for native USB without starving the scheduler
   }
   serialSplash();
   // We call this a second time to get the MAC on the screen
@@ -1664,6 +1700,7 @@ void setup()
   clearTrackedKrakes();
   clearWatchedTopics();
   client.setServer(mqtt_broker_name, 1883); // Default MQTT port, this is a TCP port.
+  client.setSocketTimeout(MQTT_SOCKET_TIMEOUT_SECONDS);
   client.setCallback(callback);
 
 #if (DEBUG > 0)
@@ -1707,6 +1744,7 @@ void setup()
 
   loadMqttConfig();
   client.setServer(mqtt_broker_name, 1883);
+  client.setSocketTimeout(MQTT_SOCKET_TIMEOUT_SECONDS);
 
 #if (DEBUG > 1)
   debugSerial.println("XXXXXXX");
@@ -1729,7 +1767,7 @@ void setup()
   {
     if (!client.connected())
     {
-      reconnect();
+      reconnect(true);
     }
 
     clearLCD();
@@ -1801,11 +1839,18 @@ void loop()
 {
 #if defined HMWK || defined KRAKE
 
-  if (!client.loop())
+  if (client.connected())
   {
-    debugSerial.print(mqtt_broker_name);
-    debugSerial.print(" lost MQTT at: ");
-    debugSerial.println(millis());
+    if (!client.loop())
+    {
+      debugSerial.print(mqtt_broker_name);
+      debugSerial.print(" lost MQTT at: ");
+      debugSerial.println(millis());
+      requestMqttReconnect();
+    }
+  }
+  else if (mqttReconnectRequested || WiFi.status() == WL_CONNECTED)
+  {
     reconnect();
   }
 
@@ -1861,4 +1906,5 @@ void loop()
   //   cnt_actions++;
   //   navigate_to_n_and_execute(cnt_actions % 3);
   // }
+  yield();
 }

--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -81,29 +81,32 @@ AsyncWebServer server(80);
 AsyncWebSocket ws("/ws");
 
 const size_t SERIAL_LOG_MAX_CHARS = 12000;
-String serialLogBuffer;
+char serialLogBuffer[SERIAL_LOG_MAX_CHARS + 1];
+size_t serialLogLength = 0;
 
 void appendSerialLog(const char *text, size_t len)
 {
-  if (len == 0)
+  if (text == nullptr || len == 0)
   {
     return;
   }
 
-  if (len > SERIAL_LOG_MAX_CHARS)
+  if (len >= SERIAL_LOG_MAX_CHARS)
   {
     text += (len - SERIAL_LOG_MAX_CHARS);
     len = SERIAL_LOG_MAX_CHARS;
+    serialLogLength = 0;
+  }
+  else if ((serialLogLength + len) > SERIAL_LOG_MAX_CHARS)
+  {
+    const size_t overflow = (serialLogLength + len) - SERIAL_LOG_MAX_CHARS;
+    memmove(serialLogBuffer, serialLogBuffer + overflow, serialLogLength - overflow);
+    serialLogLength -= overflow;
   }
 
-  for (size_t i = 0; i < len; ++i)
-  {
-    serialLogBuffer += text[i];
-  }
-  if (serialLogBuffer.length() > SERIAL_LOG_MAX_CHARS)
-  {
-    serialLogBuffer.remove(0, serialLogBuffer.length() - SERIAL_LOG_MAX_CHARS);
-  }
+  memcpy(serialLogBuffer + serialLogLength, text, len);
+  serialLogLength += len;
+  serialLogBuffer[serialLogLength] = '\0';
 }
 
 class SerialMirrorStream : public Stream
@@ -179,18 +182,6 @@ WifiOTA::Manager wifiManager(WiFi, debugSerial);
 // #define DEBUG 0
 #define DEBUG 1
 // #define DEBUG 4
-
-unsigned long last_command_ms;
-
-// We have currently defined our alam time to include 10-second "songs",
-// So we will not process a new alarm condition until we have completed one song.
-const unsigned long DELAY_BEFORE_NEW_COMMAND_ALLOWED = 10000;
-const unsigned int NUM_WIFI_RECONNECT_RETRIES = 3;
-
-const int LED_PINS[] = {LIGHT0, LIGHT1, LIGHT2, LIGHT3, LIGHT4};
-// const int SWITCH_PINS[] = { SW1, SW2, SW3, SW4 };  // SW1, SW2, SW3, SW4
-const int LED_COUNT = sizeof(LED_PINS) / sizeof(LED_PINS[0]);
-// const int SWITCH_COUNT = sizeof(SWITCH_PINS) / sizeof(SWITCH_PINS[0]);
 
 // MQTT Broker
 // #define USE_HIVEMQ
@@ -349,8 +340,8 @@ void publishOnLineMsg(void)
 #endif
 
     dtostrf(rssi, 1, 2, rssiString);
-    char onLineMsg[32] = " online, RSSI:";
-    strcat(onLineMsg, rssiString);
+    char onLineMsg[32];
+    snprintf(onLineMsg, sizeof(onLineMsg), " online, RSSI:%s", rssiString);
     client.publish(publish_Ack_Topic, onLineMsg, true);
 
     // This should be moved to a place after the WiFi connect success
@@ -394,17 +385,20 @@ bool reconnect(bool force = false)
   lastMqttReconnectAttemptMs = now;
   mqttReconnectRequested = false;
 
-  const String clientId = String(COMPANY_NAME) + "-" + String(macAddressString);
-  const String willPayload = String(device_role) + " offline";
+  char clientId[sizeof(COMPANY_NAME) + MAC_ADDRESS_STRING_LENGTH + 1];
+  snprintf(clientId, sizeof(clientId), "%s-%s", COMPANY_NAME, macAddressString);
+  char willPayload[DEVICE_ROLE_MAX_LEN + 9];
+  snprintf(willPayload, sizeof(willPayload), "%s offline", device_role);
   debugSerial.print("Attempting MQTT connection at: ");
   debugSerial.print(millis());
   debugSerial.print("..... ");
-  if (client.connect(clientId.c_str(), mqtt_user, mqtt_password, publish_Ack_Topic, 1, true, willPayload.c_str()))
+  if (client.connect(clientId, mqtt_user, mqtt_password, publish_Ack_Topic, 1, true, willPayload))
   {
     debugSerial.print("success at: ");
     debugSerial.println(millis());
-    String onlinePayload = String(device_role) + " online";
-    client.publish(publish_Ack_Topic, onlinePayload.c_str(), true);
+    char onlinePayload[DEVICE_ROLE_MAX_LEN + 8];
+    snprintf(onlinePayload, sizeof(onlinePayload), "%s online", device_role);
+    client.publish(publish_Ack_Topic, onlinePayload, true);
     client.subscribe(subscribe_Alarm_Topic); // Subscribe to GPAD API alarms
     if (MQTT_DISCOVERY_SUBSCRIBE_ALL)
     {
@@ -1645,6 +1639,8 @@ void setup()
   // Serial setup
   delay(100);
   debugSerial.begin(BAUDRATE);
+  serialLogBuffer[0] = '\0';
+  serialLogLength = 0;
   const unsigned long serialStartMs = millis();
   while (!debugSerial && (millis() - serialStartMs) < 2000)
   {
@@ -1791,20 +1787,19 @@ void setup()
 
   debugSerial.println(F("initLiffleFS"));
 
-  server.begin(); // Start server web socket to render pages
-  
-  debugSerial.println(F("iStart server web socket to render pages"));
+  setupOTA();
+  debugSerial.println(F("setupOTA"));
 
   ElegantOTA.begin(&server);
   debugSerial.println(F("ElegantOTA.begin"));
 
-  setupOTA();
-  debugSerial.println(F("setupOTA"));
+  server.begin(); // Start server web socket to render pages
+  debugSerial.println(F("Start server web socket to render pages"));
 
 
   initRotator();
   debugSerial.println(F("initRotator"));
-  splashLCD(wifiManager.getMode(), deviceAddress);
+  splashLCD(wifiManager.getMode(), wifiManager.getAddress());
 
   debugSerial.println(F("splashLCD"));
 
@@ -1820,17 +1815,6 @@ void setup()
   turnOnAllLamps();
   digitalWrite(LED_BUILTIN, LOW); // turn the LED off at end of setup
 } // end of setup()
-
-unsigned long last_ms = 0;
-void toggle(int pin)
-{
-  digitalWrite(pin, digitalRead(pin) ? LOW : HIGH);
-}
-
-const unsigned long LOW_FREQ_DEBUG_MS = 20000;
-unsigned long time_since_LOW_FREQ_ms = 0;
-
-int cnt_actions = 0;
 
 bool running_menu = false;
 bool menu_just_exited = false;
@@ -1902,9 +1886,5 @@ void loop()
     poll_GPAD_menu();
   }
 
-  // if ((millis() / 10000) > cnt_actions) {
-  //   cnt_actions++;
-  //   navigate_to_n_and_execute(cnt_actions % 3);
-  // }
-  yield();
+  delay(1);
 }

--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -71,11 +71,14 @@
 #include "WiFiManagerOTA.h"
 #include <ESPAsyncWebServer.h>
 #include <string.h>
+#include <strings.h>
+#include <ctype.h>
 
 #include "InterruptRotator.h"
 
 #include "DFPlayer.h"
 #include "GPAD_menu.h"
+#include "mqtt_handler.h"
 
 AsyncWebServer server(80);
 AsyncWebSocket ws("/ws");
@@ -179,9 +182,12 @@ WifiOTA::Manager wifiManager(WiFi, debugSerial);
 
 #define DEBUG_SPI 0
 
-// #define DEBUG 0
-#define DEBUG 1
+#define DEBUG 0
 // #define DEBUG 4
+
+#ifndef ENABLE_HEAP_DIAGNOSTICS
+#define ENABLE_HEAP_DIAGNOSTICS 0
+#endif
 
 // MQTT Broker
 // #define USE_HIVEMQ
@@ -342,7 +348,7 @@ void publishOnLineMsg(void)
     dtostrf(rssi, 1, 2, rssiString);
     char onLineMsg[32];
     snprintf(onLineMsg, sizeof(onLineMsg), " online, RSSI:%s", rssiString);
-    client.publish(publish_Ack_Topic, onLineMsg, true);
+    queueMqtt(publish_Ack_Topic, onLineMsg, true);
 
     // This should be moved to a place after the WiFi connect success
     //  debugSerial.print("Device connected at IPaddress: "); //FLE
@@ -389,16 +395,20 @@ bool reconnect(bool force = false)
   snprintf(clientId, sizeof(clientId), "%s-%s", COMPANY_NAME, macAddressString);
   char willPayload[DEVICE_ROLE_MAX_LEN + 9];
   snprintf(willPayload, sizeof(willPayload), "%s offline", device_role);
+#if (DEBUG > 0)
   debugSerial.print("Attempting MQTT connection at: ");
   debugSerial.print(millis());
   debugSerial.print("..... ");
+#endif
   if (client.connect(clientId, mqtt_user, mqtt_password, publish_Ack_Topic, 1, true, willPayload))
   {
+#if (DEBUG > 0)
     debugSerial.print("success at: ");
     debugSerial.println(millis());
+#endif
     char onlinePayload[DEVICE_ROLE_MAX_LEN + 8];
     snprintf(onlinePayload, sizeof(onlinePayload), "%s online", device_role);
-    client.publish(publish_Ack_Topic, onlinePayload, true);
+    queueMqtt(publish_Ack_Topic, onlinePayload, true);
     client.subscribe(subscribe_Alarm_Topic); // Subscribe to GPAD API alarms
     if (MQTT_DISCOVERY_SUBSCRIBE_ALL)
     {
@@ -415,8 +425,10 @@ bool reconnect(bool force = false)
     return true;
   }
 
+#if (DEBUG > 0)
   debugSerial.print("failed, rc=");
   debugSerial.println(client.state());
+#endif
   yield();
   return false;
 }
@@ -477,9 +489,9 @@ void clearTrackedKrakes()
   }
 }
 
-int indexForKrake(const String &krakeId)
+int indexForKrake(const char *krakeId)
 {
-  if (krakeId.length() == 0)
+  if (krakeId == nullptr || krakeId[0] == '\0')
   {
     return -1;
   }
@@ -487,7 +499,7 @@ int indexForKrake(const String &krakeId)
   int freeSlot = -1;
   for (uint8_t i = 0; i < MAX_TRACKED_KRAKES; i++)
   {
-    if (trackedKrakes[i].inUse && krakeId.equalsIgnoreCase(trackedKrakes[i].id))
+    if (trackedKrakes[i].inUse && strcasecmp(krakeId, trackedKrakes[i].id) == 0)
     {
       return i;
     }
@@ -500,39 +512,86 @@ int indexForKrake(const String &krakeId)
   if (freeSlot >= 0)
   {
     trackedKrakes[freeSlot].inUse = true;
-    krakeId.toCharArray(trackedKrakes[freeSlot].id, sizeof(trackedKrakes[freeSlot].id));
+    strncpy(trackedKrakes[freeSlot].id, krakeId, sizeof(trackedKrakes[freeSlot].id) - 1);
+    trackedKrakes[freeSlot].id[sizeof(trackedKrakes[freeSlot].id) - 1] = '\0';
     return freeSlot;
   }
 
   return -1;
 }
 
-String extractKrakeIdFromAckTopic(const char *topic)
+void uppercaseAscii(char *value)
 {
-  String id(topic);
-  id.toUpperCase();
-  if (id.endsWith("_ACK"))
+  if (value == nullptr)
   {
-    id.remove(id.length() - 4);
+    return;
   }
-  return id;
+  for (size_t i = 0; value[i] != '\0'; i++)
+  {
+    if (value[i] >= 'a' && value[i] <= 'z')
+    {
+      value[i] = value[i] - ('a' - 'A');
+    }
+  }
 }
 
-int parseRssiFromStatus(const String &status)
+void trimTrailingSpaces(char *value)
 {
-  const int marker = status.indexOf("RSSI:");
-  if (marker < 0)
+  if (value == nullptr)
+  {
+    return;
+  }
+  size_t len = strlen(value);
+  while (len > 0 && isspace((unsigned char)value[len - 1]))
+  {
+    value[--len] = '\0';
+  }
+}
+
+void extractKrakeIdFromAckTopic(const char *topic, char *dest, size_t destLen)
+{
+  if (destLen == 0)
+  {
+    return;
+  }
+  dest[0] = '\0';
+  if (topic == nullptr)
+  {
+    return;
+  }
+  strncpy(dest, topic, destLen - 1);
+  dest[destLen - 1] = '\0';
+  uppercaseAscii(dest);
+  const size_t len = strlen(dest);
+  if (len >= 4 && strcmp(dest + len - 4, "_ACK") == 0)
+  {
+    dest[len - 4] = '\0';
+  }
+}
+
+int parseRssiFromStatus(const char *status)
+{
+  if (status == nullptr)
   {
     return 0;
   }
-  String rssiPart = status.substring(marker + 5);
-  rssiPart.trim();
-  return rssiPart.toInt();
+  const char *marker = strstr(status, "RSSI:");
+  if (marker == nullptr)
+  {
+    return 0;
+  }
+  marker += 5;
+  while (*marker != '\0' && isspace((unsigned char)*marker))
+  {
+    marker++;
+  }
+  return atoi(marker);
 }
 
-void updateKrakeStatusFromAck(const char *topic, const String &statusMsg)
+void updateKrakeStatusFromAck(const char *topic, const char *statusMsg)
 {
-  const String krakeId = extractKrakeIdFromAckTopic(topic);
+  char krakeId[sizeof(trackedKrakes[0].id)];
+  extractKrakeIdFromAckTopic(topic, krakeId, sizeof(krakeId));
   const int idx = indexForKrake(krakeId);
   if (idx < 0)
   {
@@ -542,7 +601,7 @@ void updateKrakeStatusFromAck(const char *topic, const String &statusMsg)
   trackedKrakes[idx].lastSeenMs = millis();
   trackedKrakes[idx].lastStatusMs = millis();
   trackedKrakes[idx].rssi = parseRssiFromStatus(statusMsg);
-  strncpy(trackedKrakes[idx].status, statusMsg.c_str(), sizeof(trackedKrakes[idx].status) - 1);
+  strncpy(trackedKrakes[idx].status, statusMsg != nullptr ? statusMsg : "", sizeof(trackedKrakes[idx].status) - 1);
   trackedKrakes[idx].status[sizeof(trackedKrakes[idx].status) - 1] = '\0';
   strncpy(trackedKrakes[idx].lastTopic, topic, sizeof(trackedKrakes[idx].lastTopic) - 1);
   trackedKrakes[idx].lastTopic[sizeof(trackedKrakes[idx].lastTopic) - 1] = '\0';
@@ -560,22 +619,26 @@ bool isWatchedTopic(const char *topic)
   return false;
 }
 
-String extractKrakeIdFromTopic(const char *topic)
+void extractKrakeIdFromTopic(const char *topic, char *dest, size_t destLen)
 {
-  String id = String(topic);
-  const int slash = id.indexOf('/');
-  if (slash > 0)
+  if (destLen == 0)
   {
-    id = id.substring(0, slash);
+    return;
   }
-  const int underscore = id.indexOf('_');
-  if (underscore > 0)
+  dest[0] = '\0';
+  if (topic == nullptr)
   {
-    id = id.substring(0, underscore);
+    return;
   }
-  id.trim();
-  id.toUpperCase();
-  return id;
+  size_t len = 0;
+  while (topic[len] != '\0' && topic[len] != '/' && topic[len] != '_' && len < (destLen - 1))
+  {
+    dest[len] = topic[len];
+    len++;
+  }
+  dest[len] = '\0';
+  trimTrailingSpaces(dest);
+  uppercaseAscii(dest);
 }
 
 void markWatchedTopicParticipant(const char *topic)
@@ -585,8 +648,9 @@ void markWatchedTopicParticipant(const char *topic)
     return;
   }
 
-  String krakeId = extractKrakeIdFromTopic(topic);
-  if (krakeId.length() == 0)
+  char krakeId[sizeof(trackedKrakes[0].id)];
+  extractKrakeIdFromTopic(topic, krakeId, sizeof(krakeId));
+  if (krakeId[0] == '\0')
   {
     return;
   }
@@ -1104,7 +1168,6 @@ void turnOffAllLamps()
 // Handeler for MQTT subscribed messages
 void callback(char *topic, byte *payload, unsigned int length)
 {
-  // todo, remove use of String here....
   // Note: We will check for topic or topics in the future...
   if (isManagedSubscribedTopic(topic))
   {
@@ -1121,26 +1184,25 @@ void callback(char *topic, byte *payload, unsigned int length)
 
     if (!ackTopic)
     {
+#if (DEBUG > 0)
       debugSerial.print("Topic arrived [");
       debugSerial.print(topic);
       debugSerial.print("] ");
-#if (DEBUG > 0)
       debugSerial.print("|");
       debugSerial.print(mbuff);
       debugSerial.println("|");
-#endif
       debugSerial.println("Received MQTT Msg.");
+#endif
     }
 
-    const String payloadText = String(mbuff);
     if (ackTopic)
     {
-      updateKrakeStatusFromAck(topic, payloadText);
+      updateKrakeStatusFromAck(topic, mbuff);
       return;
     }
     markWatchedTopicParticipant(topic);
     interpretBuffer(mbuff, m, &debugSerial, &client); // Process the MQTT message
-    annunciateAlarmLevel(&debugSerial);
+    requestAlarmRefresh(&debugSerial);
   }
 } // end call back
 
@@ -1601,7 +1663,7 @@ void setupOTA()
                 request->send(403, "text/plain", "topic not allowed; use saved broker-console publish topics");
                 return;
               }
-              bool ok = client.publish(topic.c_str(), payload.c_str());
+              bool ok = queueMqtt(topic.c_str(), payload.c_str());
               if (ok && topic.length() < MAX_TOPIC_LEN)
               {
                 topic.toCharArray(publish_Default_Topic, MAX_TOPIC_LEN);
@@ -1826,15 +1888,19 @@ void serviceMqttClient()
   {
     if (!client.loop())
     {
+#if (DEBUG > 0)
       debugSerial.print(mqtt_broker_name);
       debugSerial.print(" lost MQTT at: ");
       debugSerial.println(millis());
+#endif
       requestMqttReconnect();
     }
+    serviceMqttQueue(&client);
   }
   else if (mqttReconnectRequested || WiFi.status() == WL_CONNECTED)
   {
     reconnect();
+    serviceMqttQueue(&client);
   }
 #endif
 }
@@ -1853,6 +1919,23 @@ void serviceDeferredReset()
     WiFi.disconnect(true, true);
     delay(150);
     ESP.restart();
+  }
+#endif
+}
+
+void serviceHeapDiagnostics()
+{
+#if ENABLE_HEAP_DIAGNOSTICS
+  static unsigned long lastHeapDiagnosticMs = 0;
+  const unsigned long HEAP_DIAGNOSTIC_INTERVAL_MS = 30000;
+  const unsigned long now = millis();
+  if (lastHeapDiagnosticMs == 0 || (now - lastHeapDiagnosticMs) >= HEAP_DIAGNOSTIC_INTERVAL_MS)
+  {
+    lastHeapDiagnosticMs = now;
+    debugSerial.print(F("Free heap: "));
+    debugSerial.print(ESP.getFreeHeap());
+    debugSerial.print(F(" max alloc: "));
+    debugSerial.println(ESP.getMaxAllocHeap());
   }
 #endif
 }
@@ -1898,10 +1981,12 @@ void loop()
   {
     lcd.backlight();
     poll_GPAD_menu();
+    serviceMqttClient();
   }
 
 #if defined HMWK || defined KRAKE
   publishOnLineMsg();
+  serviceHeapDiagnostics();
   wink(); // The builtin LED
 #endif
 

--- a/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_API.ino
@@ -1819,10 +1819,9 @@ void setup()
 bool running_menu = false;
 bool menu_just_exited = false;
 
-void loop()
+void serviceMqttClient()
 {
 #if defined HMWK || defined KRAKE
-
   if (client.connected())
   {
     if (!client.loop())
@@ -1837,7 +1836,12 @@ void loop()
   {
     reconnect();
   }
+#endif
+}
 
+void serviceDeferredReset()
+{
+#if defined HMWK || defined KRAKE
   if (wifiResetRequestedAtMs != 0 && (millis() - wifiResetRequestedAtMs) > 750)
   {
     debugSerial.println(F("Resetting WiFi credentials and restarting."));
@@ -1850,25 +1854,35 @@ void loop()
     delay(150);
     ESP.restart();
   }
-
-  publishOnLineMsg();
-  wink(); // The builtin LED
 #endif
+}
 
+void loop()
+{
+  // MQTT gets the first and most frequent slices so inbound bursts are drained
+  // before comparatively slow LCD/menu/audio work is serviced.
+  serviceMqttClient();
+  serviceDeferredReset();
+
+  // Hardware/UI runs after MQTT.  LCD redraws and DFPlayer commands are
+  // scheduled/throttled inside GPAD_HAL_loop() so this remains a short slice.
   unchanged_anunicateAlarmLevel(&debugSerial);
-  // delay(20);
   GPAD_HAL_loop();
+  serviceMqttClient();
 
   processSerial(&debugSerial, &debugSerial, &client);
+  serviceMqttClient();
 
   // Here we also process the UART1 using the same routine.
   processSerial(&debugSerial, &uartSerial1, &client);
+  serviceMqttClient();
 
   // Here we will listen for an SPI command...
 
   // // Now try to read from the SPI Port!
 #if defined(GPAD)
   updateFromSPI();
+  serviceMqttClient();
 #endif
 
   updateRotator();
@@ -1886,5 +1900,11 @@ void loop()
     poll_GPAD_menu();
   }
 
-  delay(1);
+#if defined HMWK || defined KRAKE
+  publishOnLineMsg();
+  wink(); // The builtin LED
+#endif
+
+  serviceMqttClient();
+  yield();
 }

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -29,7 +29,7 @@
 #include <esp_system.h>
 #include <Preferences.h>
 #include <driver/uart.h>
-
+#include <GPAPMessage.h>
 using namespace gpad_hal;
 
 
@@ -536,6 +536,35 @@ void GPAD_HAL_setup(Stream *serialport, wifi_mode_t wifiMode, IPAddress &deviceI
 // the character buffer and returns an "abstract" command to be acted on
 // elseshere. This will allow us to remove the PubSubClient from the this file,
 // the Hardware Abstraction Layer.
+
+class CharBufferPrint : public Print
+{
+public:
+  CharBufferPrint(char *buffer, size_t capacity)
+      : _buffer(buffer), _capacity(capacity), _pos(0)
+  {
+    if (_capacity > 0) _buffer[0] = '\0';
+  }
+
+  size_t write(uint8_t ch) override
+  {
+    if (ch == '\0') return 1;
+
+    if (_pos + 1 < _capacity)
+    {
+      _buffer[_pos++] = (char)ch;
+      _buffer[_pos] = '\0';
+    }
+
+    return 1;
+  }
+
+private:
+  char *_buffer;
+  size_t _capacity;
+  size_t _pos;
+};
+
 void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *client)
 {
   if (buf == nullptr || serialport == nullptr || rlen < 1)
@@ -575,34 +604,50 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     printInstructions(serialport);
     break;
   }
-  case 'a':
+case 'a':
+{
+  try
   {
-    if (rlen < 2)
+    auto gpMessage = gpap_message::GPAPMessage::deserialize(buf, (size_t)rlen);
+
+    if (gpMessage.getMessageType() != gpap_message::MessageType::ALARM)
     {
-      printError(serialport);
+      serialport->println(F("GPAP message is not an alarm."));
       return;
     }
 
-    int N = buf[1] - '0';
+    const auto &alarmMessage = gpMessage.getAlarmMessage();
+
+    int N = static_cast<char>(alarmMessage.getAlarmLevel()) - '0';
+
     if (N < 0 || N >= NUM_LEVELS)
     {
+      serialport->println(F("Invalid GPAP alarm severity."));
       printError(serialport);
       return;
     }
 
     char msg[MAX_BUFFER_SIZE];
-    size_t copyLen = min((size_t)rlen, sizeof(msg) - 1);
-    memcpy(msg, buf, copyLen);
-    msg[copyLen] = '\0';
-    // This copy loooks uncessary, but is not...we want "alarm"
-    // to be a completely independent and abstract function.
-    // it should copy the msg buffer
-    serialport->print("The MQTT Alarm Message: ");
-    serialport->println(msg);
-    alarm((AlarmLevel)N, msg, serialport); // Makes Lamps indicate alarm.
+    CharBufferPrint msgWriter(msg, sizeof(msg));
+    alarmMessage.getAlarmContent().printTo(msgWriter);
 
-    break;
+    serialport->print(F("GPAP Alarm Level: "));
+    serialport->println(N);
+
+    serialport->print(F("GPAP Alarm Content: "));
+    serialport->println(msg);
+
+    alarm((AlarmLevel)N, msg, serialport);
   }
+  catch (...)
+  {
+    serialport->println(F("GPAP alarm parse failed."));
+    printError(serialport);
+    return;
+  }
+
+  break;
+}
   case 'i':
   {
     // Firmware Version

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -607,15 +607,14 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
     printInstructions(serialport);
     break;
   }
-case 'a':
-{
-  try
+  case 'a':
   {
     auto gpMessage = gpap_message::GPAPMessage::deserialize(buf, (size_t)rlen);
 
     if (gpMessage.getMessageType() != gpap_message::MessageType::ALARM)
     {
-      serialport->println(F("GPAP message is not an alarm."));
+      serialport->println(F("GPAP alarm parse failed."));
+      printError(serialport);
       return;
     }
 
@@ -658,16 +657,8 @@ case 'a':
     serialport->println(msg);
 
     alarm((AlarmLevel)N, msg, serialport);
+    break;
   }
-  catch (...)
-  {
-    serialport->println(F("GPAP alarm parse failed."));
-    printError(serialport);
-    return;
-  }
-
-  break;
-}
   case 'i':
   {
     // Firmware Version

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -168,6 +168,7 @@ extern AlarmLevel currentLevel;
 extern bool currentlyMuted;
 extern char AlarmMessageBuffer[81];
 extern unsigned long muteTimeoutEndMillis;
+extern bool running_menu;
 
 extern char macAddressString[13];
 extern int muteTimeoutMinutes;
@@ -216,6 +217,42 @@ const int LIGHT_LEVEL[][NUM_NOTES] = {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 const unsigned LEN_OF_NOTE_MS = 500;
 
 unsigned long start_of_song = 0;
+
+namespace
+{
+  const unsigned long ALARM_UI_MIN_INTERVAL_MS = 250;
+  const unsigned long ALARM_AUDIO_MIN_INTERVAL_MS = 250;
+  const unsigned long ALARM_UI_NORMAL_SETTLE_MS = 25;
+  const unsigned long ALARM_UI_BURST_SETTLE_MS = 150;
+  const unsigned long DFPLAYER_POLL_INTERVAL_MS = 100;
+  const uint8_t ALARM_UI_BURST_REQUEST_COUNT = 3;
+
+  bool alarmUiUpdatePending = false;
+  bool alarmAudioUpdatePending = false;
+  unsigned long lastAlarmUiRequestMs = 0;
+  unsigned long lastAlarmUiUpdateMs = 0;
+  unsigned long lastAlarmAudioUpdateMs = 0;
+  uint8_t alarmUiPendingRequestCount = 0;
+
+  void markAlarmUiAudioPending(bool includeAudio = true)
+  {
+    alarmUiUpdatePending = true;
+    if (includeAudio)
+    {
+      alarmAudioUpdatePending = true;
+    }
+    lastAlarmUiRequestMs = millis();
+    if (alarmUiPendingRequestCount < 255)
+    {
+      alarmUiPendingRequestCount++;
+    }
+  }
+
+  bool isDue(const unsigned long now, const unsigned long lastRun, const unsigned long interval)
+  {
+    return lastRun == 0 || (now - lastRun) >= interval;
+  }
+}
 
 // in general, we want tones to last forever, although
 // I may implement blinking later.
@@ -780,6 +817,72 @@ void muteTimeoutWatchdog(Stream *serialport)
   }
 }
 
+void serviceAlarmUiAudio(Stream *serialport)
+{
+  if (serialport == nullptr)
+  {
+    return;
+  }
+
+  const unsigned long now = millis();
+
+  static unsigned long lastDfPlayerPollMs = 0;
+  if (isDue(now, lastDfPlayerPollMs, DFPLAYER_POLL_INTERVAL_MS))
+  {
+    lastDfPlayerPollMs = now;
+    dfPlayerUpdate();
+  }
+
+  if (!alarmUiUpdatePending && !alarmAudioUpdatePending)
+  {
+    return;
+  }
+
+  // Leave the menu display in control while the user is navigating.  The latest
+  // alarm state remains pending and will be restored when the menu exits.
+  if (running_menu)
+  {
+    return;
+  }
+
+  const unsigned long settleMs = (alarmUiPendingRequestCount >= ALARM_UI_BURST_REQUEST_COUNT)
+                                     ? ALARM_UI_BURST_SETTLE_MS
+                                     : ALARM_UI_NORMAL_SETTLE_MS;
+  if ((now - lastAlarmUiRequestMs) < settleMs)
+  {
+    return;
+  }
+
+  if (alarmUiUpdatePending && isDue(now, lastAlarmUiUpdateMs, ALARM_UI_MIN_INTERVAL_MS))
+  {
+    alarmUiUpdatePending = false;
+    alarmUiPendingRequestCount = 0;
+    lastAlarmUiUpdateMs = now;
+    showStatusLCD(currentLevel, currentlyMuted, AlarmMessageBuffer);
+  }
+
+  if (alarmAudioUpdatePending && isDue(now, lastAlarmAudioUpdateMs, ALARM_AUDIO_MIN_INTERVAL_MS))
+  {
+    alarmAudioUpdatePending = false;
+    lastAlarmAudioUpdateMs = now;
+
+    if (currentLevel <= 0)
+    {
+      serialport->println(F("Silent level: skipping DFPlayer playback."));
+    }
+    else if (currentlyMuted)
+    {
+      serialport->println(F("Muted: skipping DFPlayer playback."));
+    }
+    else
+    {
+      serialport->println(F("dfPlayer.play"));
+      serialport->println(currentLevel);
+      playNotBusyLevel(currentLevel);
+    }
+  }
+}
+
 void GPAD_HAL_loop()
 {
   muteButton.poll();
@@ -789,6 +892,7 @@ void GPAD_HAL_loop()
 #endif
 
   muteTimeoutWatchdog(local_ptr_to_serial);
+  serviceAlarmUiAudio(local_ptr_to_serial);
 }
 
 /* Assumes LCD has been initilized
@@ -988,47 +1092,27 @@ void unchanged_anunicateAlarmLevel(Stream *serialport)
 }
 void restoreAlarmLevel(Stream *serialport)
 {
-  showStatusLCD(currentLevel, currentlyMuted, AlarmMessageBuffer);
-}
-
-void annunciateAlarmLevel(Stream *serialport)
-{
-  static unsigned long lastAnnunciateMs = 0;
-  const unsigned long now = millis();
-
   if (serialport == nullptr)
   {
     return;
   }
 
-  // Avoid long back-to-back UI/audio work under message bursts.
-  if ((now - lastAnnunciateMs) < 50)
+  markAlarmUiAudioPending(false);
+}
+
+void annunciateAlarmLevel(Stream *serialport)
+{
+  if (serialport == nullptr)
   {
-    unchanged_anunicateAlarmLevel(serialport);
     return;
   }
-  lastAnnunciateMs = now;
 
+  // Keep the immediate work cheap so MQTT callbacks and serial/SPI handlers can
+  // return quickly.  LCD redraw and DFPlayer commands are coalesced in
+  // serviceAlarmUiAudio(), which is run later from GPAD_HAL_loop().
   start_of_song = millis();
   unchanged_anunicateAlarmLevel(serialport);
-  showStatusLCD(currentLevel, currentlyMuted, AlarmMessageBuffer);
-  // here is the new call
-    if (currentLevel <= 0)
-  {
-    serialport->println(F("Silent level: skipping DFPlayer playback."));
-  }
-  else if (currentlyMuted)
-  {
-    serialport->println(F("Muted: skipping DFPlayer playback."));
-  }
-  else
-  {
-    serialport->println(F("dfPlayer.play"));
-    serialport->println(currentLevel);
-    playNotBusyLevel(currentLevel);
-  }
-
-  yield();
+  markAlarmUiAudioPending();
 }
 
 GPAD_API::GPAD_API(SemanticVersion version)

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -171,7 +171,9 @@ extern unsigned long muteTimeoutEndMillis;
 
 extern char macAddressString[13];
 extern int muteTimeoutMinutes;
-
+extern char currentAlarmId[11];
+extern char currentAlarmType[4];
+ 
 // For LCD
 //  #include <LiquidCrystal_I2C.h>
 
@@ -412,6 +414,7 @@ void muteButtonCallback(byte buttonEvent)
       local_ptr_to_serial->print(F("Muted for "));
       local_ptr_to_serial->print(muteTimeoutMinutes);
       local_ptr_to_serial->println(F(" minute(s)."));
+      
     }
     start_of_song = millis();
     annunciateAlarmLevel(local_ptr_to_serial);
@@ -618,6 +621,23 @@ case 'a':
 
     const auto &alarmMessage = gpMessage.getAlarmMessage();
 
+    strncpy(currentAlarmId, "", sizeof(currentAlarmId));
+    strncpy(currentAlarmType, "", sizeof(currentAlarmType));
+
+    CharBufferPrint idWriter(currentAlarmId, sizeof(currentAlarmId));
+    CharBufferPrint typeWriter(currentAlarmType, sizeof(currentAlarmType));
+
+    const auto &messageId = alarmMessage.getMessageId();
+    if (messageId.state == gpap_message::alarm::AlarmMessage::PossibleMessageId::State::Some)
+    {
+      messageId.contents.printTo(idWriter);
+    }
+
+    const auto &typeDesignator = alarmMessage.getTypeDesignator();
+    if (typeDesignator.state == gpap_message::alarm::AlarmMessage::PossibleTypeDesignator::State::Some)
+    {
+      typeDesignator.contents.printTo(typeWriter);
+    }
     int N = static_cast<char>(alarmMessage.getAlarmLevel()) - '0';
 
     if (N < 0 || N >= NUM_LEVELS)
@@ -873,8 +893,8 @@ void filter_control_chars(char *msg)
 // on the display
 void showStatusLCD(AlarmLevel level, bool muted, char *msg)
 {
-  lcd.init();
-  lcd.clear();
+  // lcd.init();
+  // lcd.clear();
   // Possibly we don't need the backlight if the level is zero!
   if (level != 0)
   {
@@ -1002,10 +1022,18 @@ void annunciateAlarmLevel(Stream *serialport)
   unchanged_anunicateAlarmLevel(serialport);
   showStatusLCD(currentLevel, currentlyMuted, AlarmMessageBuffer);
   // here is the new call
-  serialport->println("dfPlayer.play");
-  serialport->println(currentLevel);
-  if (!currentlyMuted)
+    if (currentLevel <= 0)
   {
+    serialport->println(F("Silent level: skipping DFPlayer playback."));
+  }
+  else if (currentlyMuted)
+  {
+    serialport->println(F("Muted: skipping DFPlayer playback."));
+  }
+  else
+  {
+    serialport->println(F("dfPlayer.play"));
+    serialport->println(currentLevel);
     playNotBusyLevel(currentLevel);
   }
 

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -803,7 +803,7 @@ void clearLCD(void)
 }
 
 // Splash a message so we can tell the LCD is working
-void splashLCD(wifi_mode_t wifiMode, IPAddress &deviceIp)
+void splashLCD(wifi_mode_t wifiMode, const IPAddress &deviceIp)
 {
   lcd.init(); // initialize the lcd
   // Print a message to the LCD.

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -26,6 +26,7 @@
 #include "WiFiManagerOTA.h"
 #include "GPAD_menu.h"
 #include "mqtt_handler.h"
+#include "debug_macros.h"
 #include <esp_system.h>
 #include <Preferences.h>
 #include <driver/uart.h>
@@ -229,6 +230,7 @@ namespace
 
   bool alarmUiUpdatePending = false;
   bool alarmAudioUpdatePending = false;
+  AlarmLevel pendingAlarmAudioLevel = silent;
   unsigned long lastAlarmUiRequestMs = 0;
   unsigned long lastAlarmUiUpdateMs = 0;
   unsigned long lastAlarmAudioUpdateMs = 0;
@@ -240,6 +242,7 @@ namespace
     if (includeAudio)
     {
       alarmAudioUpdatePending = true;
+      pendingAlarmAudioLevel = currentLevel;
     }
     lastAlarmUiRequestMs = millis();
     if (alarmUiPendingRequestCount < 255)
@@ -278,7 +281,7 @@ byte received_signal_raw_bytes[MAX_BUFFER_SIZE];
 // #define DEBUG 1
 
 #if (DEBUG > 0)
-Serial.println("Debug defined >0")
+Serial.println("Debug defined >0");
 #endif
 
 void setup_spi()
@@ -369,7 +372,7 @@ void updateFromSPI()
     int prevLevel = alarm((AlarmLevel)event.lvl, event.msg, &Serial);
     if (prevLevel != event.lvl)
     {
-      annunciateAlarmLevel(&Serial);
+      requestAlarmRefresh(&Serial);
     }
     else
     {
@@ -409,23 +412,23 @@ void encoderSwitchCallback(byte buttonEvent)
     // onLongPress is indidcated when you hold onto the button
   // more than longPressTime in milliseconds
   case onLongPress:
-    Serial.print("ENCODER_SWITCH Button Long Pressed For ");
-    Serial.print(longPressTime);
-    Serial.println("ms");
+    DBG_PRINT(F("ENCODER_SWITCH Button Long Pressed For "));
+    DBG_PRINT(longPressTime);
+    DBG_PRINTLN(F("ms"));
     break;
 
   // onMultiHit is indicated when you hit the button
   // multiHitTarget times within multihitTime in milliseconds
   case onMultiHit:
-    Serial.print("Encoder Switch Button Pressed ");
-    Serial.print(multiHitTarget);
-    Serial.print(" times in ");
-    Serial.print(multiHitTime);
-    Serial.println("ms");
+    DBG_PRINT(F("Encoder Switch Button Pressed "));
+    DBG_PRINT(multiHitTarget);
+    DBG_PRINT(F(" times in "));
+    DBG_PRINT(multiHitTime);
+    DBG_PRINTLN(F("ms"));
     break;
   default:
-    Serial.print("Encoder Switch buttonEvent but not reckognized case: ");
-    Serial.println(buttonEvent);
+    DBG_PRINT(F("Encoder Switch buttonEvent but not recognized case: "));
+    DBG_PRINTLN(buttonEvent);
     break;
   }
 }
@@ -454,7 +457,7 @@ void muteButtonCallback(byte buttonEvent)
       
     }
     start_of_song = millis();
-    annunciateAlarmLevel(local_ptr_to_serial);
+    requestAlarmRefresh(local_ptr_to_serial);
     printAlarmState(local_ptr_to_serial);
     break;
   case onRelease:
@@ -468,23 +471,23 @@ void muteButtonCallback(byte buttonEvent)
     // onLongPress is indidcated when you hold onto the button
   // more than longPressTime in milliseconds
   case onLongPress:
-    Serial.print("SWITCH_MUTE Long Pressed For ");
-    Serial.print(longPressTime);
-    Serial.println("ms");
+    DBG_PRINT(F("SWITCH_MUTE Long Pressed For "));
+    DBG_PRINT(longPressTime);
+    DBG_PRINTLN(F("ms"));
     break;
 
   // onMultiHit is indicated when you hit the button
   // multiHitTarget times within multihitTime in milliseconds
   case onMultiHit:
-    Serial.print("Button Pressed ");
-    Serial.print(multiHitTarget);
-    Serial.print(" times in ");
-    Serial.print(multiHitTime);
-    Serial.println("ms");
+    DBG_PRINT(F("Button Pressed "));
+    DBG_PRINT(multiHitTarget);
+    DBG_PRINT(F(" times in "));
+    DBG_PRINT(multiHitTime);
+    DBG_PRINTLN(F("ms"));
     break;
   default:
-    Serial.print("Mute buttonEvent but not reckognized case: ");
-    Serial.println(buttonEvent);
+    DBG_PRINT(F("Mute buttonEvent but not recognized case: "));
+    DBG_PRINTLN(buttonEvent);
     break;
   }
 }
@@ -815,7 +818,7 @@ void muteTimeoutWatchdog(Stream *serialport)
   if (isMuted() && serviceMuteTimeout())
   {
     serialport->println(F("Mute timeout expired. Auto-unmuting."));
-    annunciateAlarmLevel(serialport);
+    requestAlarmRefresh(serialport);
   }
 }
 
@@ -868,7 +871,9 @@ void serviceAlarmUiAudio(Stream *serialport)
     alarmAudioUpdatePending = false;
     lastAlarmAudioUpdateMs = now;
 
-    if (currentLevel <= 0)
+    const AlarmLevel audioLevel = pendingAlarmAudioLevel;
+
+    if (audioLevel <= 0)
     {
       serialport->println(F("Silent level: skipping DFPlayer playback."));
     }
@@ -879,8 +884,8 @@ void serviceAlarmUiAudio(Stream *serialport)
     else
     {
       serialport->println(F("dfPlayer.play"));
-      serialport->println(currentLevel);
-      playNotBusyLevel(currentLevel);
+      serialport->println(audioLevel);
+      playNotBusyLevel(audioLevel);
     }
   }
 }
@@ -1100,6 +1105,17 @@ void restoreAlarmLevel(Stream *serialport)
   }
 
   markAlarmUiAudioPending(false);
+}
+
+void requestAlarmRefresh(Stream *serialport, bool includeAudio)
+{
+  if (serialport == nullptr)
+  {
+    return;
+  }
+
+  start_of_song = millis();
+  markAlarmUiAudioPending(includeAudio);
 }
 
 void annunciateAlarmLevel(Stream *serialport)

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -893,8 +893,8 @@ void filter_control_chars(char *msg)
 // on the display
 void showStatusLCD(AlarmLevel level, bool muted, char *msg)
 {
-  // lcd.init();
-  // lcd.clear();
+  lcd.init();
+  lcd.clear();
   // Possibly we don't need the backlight if the level is zero!
   if (level != 0)
   {

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.cpp
@@ -807,6 +807,8 @@ void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *clie
 } // end interpretBuffer()
 
 // This has to be called periodically, at a minimum to handle the mute_button
+void showStatusLCD(AlarmLevel level, bool muted, char *msg);
+
 void muteTimeoutWatchdog(Stream *serialport)
 {
   // Watchdog for timed mute: when duration expires, force unmute and re-annunciate.

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
@@ -307,6 +307,7 @@ void updateFromSPI();
 void restoreAlarmLevel(Stream *serialport);
 void unchanged_anunicateAlarmLevel(Stream *serialport);
 void annunciateAlarmLevel(Stream *serialport);
+void serviceAlarmUiAudio(Stream *serialport);
 void clearLCD(void);
 void splashLCD(wifi_mode_t wifiMode, const IPAddress &deviceIp);
 

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
@@ -305,6 +305,7 @@ void receive_byte(byte c);
 void updateFromSPI();
 
 void restoreAlarmLevel(Stream *serialport);
+void requestAlarmRefresh(Stream *serialport, bool includeAudio = true);
 void unchanged_anunicateAlarmLevel(Stream *serialport);
 void annunciateAlarmLevel(Stream *serialport);
 void serviceAlarmUiAudio(Stream *serialport);

--- a/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_HAL.h
@@ -308,7 +308,7 @@ void restoreAlarmLevel(Stream *serialport);
 void unchanged_anunicateAlarmLevel(Stream *serialport);
 void annunciateAlarmLevel(Stream *serialport);
 void clearLCD(void);
-void splashLCD(wifi_mode_t wifiMode, IPAddress &deviceIp);
+void splashLCD(wifi_mode_t wifiMode, const IPAddress &deviceIp);
 
 void interpretBuffer(char *buf, int rlen, Stream *serialport, PubSubClient *client);
 

--- a/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
@@ -13,7 +13,7 @@ using namespace Menu;
 
 
 extern PubSubClient client;
-
+extern char currentAlarmId[11];
 extern bool running_menu;
 extern bool menu_just_exited;
 extern unsigned long muteTimeoutEndMillis;
@@ -27,8 +27,11 @@ result action1(eventMask e)
   {
     Serial.println(F("Yes, I will take that action #1 !"));
   }
-  char onLineMsg[32] = "Acknowledging!";
-  publishAck(&client, onLineMsg);
+  //char onLineMsg[32] = "Acknowledging!";
+  // publishAck(&client, onLineMsg);
+  publishGPAPResponse(&client, "a", currentAlarmId);
+  Serial.print("GPAP response sent for ID: ");
+  Serial.println(currentAlarmId);
   lcd.clear();
   lcd.setCursor(0, 0);
   lcd.print("Acknowledged!");
@@ -45,8 +48,11 @@ result action2(eventMask e)
   char emptyMsg[] = "";
   alarm(silent, emptyMsg, &Serial);      // sets currentLevel=0, clears AlarmMessageBuffer
   annunciateAlarmLevel(&Serial);          // turns off LEDs, updates LCD, stops DFPlayer buzzer
-  char onLineMsg[32] = "Dismissed!";
-  publishAck(&client, onLineMsg);
+  //char onLineMsg[32] = "Dismissed!";
+  // publishAck(&client, onLineMsg);
+  publishGPAPResponse(&client, "d", currentAlarmId);
+  Serial.print("GPAP response sent for ID: ");
+  Serial.println(currentAlarmId);
   return proceed;
 }
 result action3(eventMask e)
@@ -58,8 +64,11 @@ result action3(eventMask e)
   char emptyMsg[] = "";
   alarm(silent, emptyMsg, &Serial);
   annunciateAlarmLevel(&Serial);
-  char onLineMsg[32] = "Shelved!";
-  publishAck(&client, onLineMsg);
+  //char onLineMsg[32] = "Shelved!";
+  // publishAck(&client, onLineMsg);
+  publishGPAPResponse(&client, "s", currentAlarmId);
+  Serial.print("GPAP response sent for ID: ");
+  Serial.println(currentAlarmId);
   return proceed;
 }
 result action4(eventMask e)

--- a/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
+++ b/Firmware/GPAD_API/GPAD_API/GPAD_menu.cpp
@@ -8,6 +8,7 @@
 #include "DFPlayer.h"
 #include "alarm_api.h"
 #include "mqtt_handler.h"
+#include "debug_macros.h"
 
 using namespace Menu;
 
@@ -25,13 +26,13 @@ result action1(eventMask e)
 {
   if (e == eventMask::enterEvent)
   {
-    Serial.println(F("Yes, I will take that action #1 !"));
+    DBG_PRINTLN(F("Yes, I will take that action #1 !"));
   }
   //char onLineMsg[32] = "Acknowledging!";
   // publishAck(&client, onLineMsg);
   publishGPAPResponse(&client, "a", currentAlarmId);
-  Serial.print("GPAP response sent for ID: ");
-  Serial.println(currentAlarmId);
+  DBG_PRINT(F("GPAP response queued for ID: "));
+  DBG_PRINTLN(currentAlarmId);
   lcd.clear();
   lcd.setCursor(0, 0);
   lcd.print("Acknowledged!");
@@ -43,48 +44,48 @@ result action2(eventMask e)
 {
   if (e == eventMask::enterEvent)
   {
-    Serial.println(F("Yes, I will take that action #2 !"));
+    DBG_PRINTLN(F("Yes, I will take that action #2 !"));
   }
   char emptyMsg[] = "";
   alarm(silent, emptyMsg, &Serial);      // sets currentLevel=0, clears AlarmMessageBuffer
-  annunciateAlarmLevel(&Serial);          // turns off LEDs, updates LCD, stops DFPlayer buzzer
+  requestAlarmRefresh(&Serial);           // coalesces LCD/audio updates from loop()
   //char onLineMsg[32] = "Dismissed!";
   // publishAck(&client, onLineMsg);
   publishGPAPResponse(&client, "d", currentAlarmId);
-  Serial.print("GPAP response sent for ID: ");
-  Serial.println(currentAlarmId);
+  DBG_PRINT(F("GPAP response queued for ID: "));
+  DBG_PRINTLN(currentAlarmId);
   return proceed;
 }
 result action3(eventMask e)
 {
   if (e == eventMask::enterEvent)
   {
-    Serial.println(F("Yes, I will take that action #3 !"));
+    DBG_PRINTLN(F("Yes, I will take that action #3 !"));
   }
   char emptyMsg[] = "";
   alarm(silent, emptyMsg, &Serial);
-  annunciateAlarmLevel(&Serial);
+  requestAlarmRefresh(&Serial);
   //char onLineMsg[32] = "Shelved!";
   // publishAck(&client, onLineMsg);
   publishGPAPResponse(&client, "s", currentAlarmId);
-  Serial.print("GPAP response sent for ID: ");
-  Serial.println(currentAlarmId);
+  DBG_PRINT(F("GPAP response queued for ID: "));
+  DBG_PRINTLN(currentAlarmId);
   return proceed;
 }
 result action4(eventMask e)
 {
   if (e == eventMask::enterEvent)
   {
-    Serial.println(F("Yes, I will take that action #3 !"));
+    DBG_PRINTLN(F("Yes, I will take that action #3 !"));
   }
-  Serial.print(F("volume value: "));
-  Serial.println(volumeDFPlayer);
+  DBG_PRINT(F("volume value: "));
+  DBG_PRINTLN(volumeDFPlayer);
   setVolume(volumeDFPlayer);
   return proceed;
 }
 result action5(eventMask e)
 {
-  Serial.println("exiting menu");
+  DBG_PRINTLN(F("exiting menu"));
   running_menu = false;
   menu_just_exited = true;
   Menu::doExit();
@@ -95,7 +96,7 @@ result actionResetConfirm(eventMask e)
 {
   if (e == eventMask::enterEvent)
   {
-    Serial.println(F("Reset confirmed. Restarting device..."));
+    DBG_PRINTLN(F("Reset confirmed. Restarting device..."));
     delay(100);
     ESP.restart();
   }
@@ -182,11 +183,11 @@ result actionMuteTimeout(eventMask e)
 {
   if (e == eventMask::enterEvent)
   {
-    Serial.print(F("Mute timeout set: "));
-    Serial.print(muteTimeoutMinutes);
-    Serial.println(F(" min"));
+    DBG_PRINT(F("Mute timeout set: "));
+    DBG_PRINT(muteTimeoutMinutes);
+    DBG_PRINTLN(F(" min"));
     setMuteTimeoutMinutes((unsigned long)muteTimeoutMinutes);
-    annunciateAlarmLevel(&Serial);
+    requestAlarmRefresh(&Serial);
     lcd.clear();
     lcd.setCursor(0, 0);
     lcd.print("Muted for:");
@@ -245,8 +246,8 @@ NAVROOT(nav, mainMenu, MAX_DEPTH, in, out);
 
 void registerRotationEvent(bool CW)
 {
-  Serial.print("CW: ");
-  Serial.println(CW);
+  DBG_PRINT(F("CW: "));
+  DBG_PRINTLN(CW);
   // Note: Rob believes it is more "natural" for clockwise to mean "up".
   // Apparently, whoever wrote the "MENU_INPUTS" believes the opposite,
   // so I am changing this hear to reverse the sense.
@@ -274,7 +275,7 @@ void poll_GPAD_menu()
 
 void navigate_to_n_and_execute(int n)
 {
-  Serial.println("moving to zero and executing!");
+  DBG_PRINTLN(F("moving to zero and executing!"));
   nav.doNav(navCmd(idxCmd, n)); // hilite second option
   // nav.doNav(navCmd(enterCmd)); //execute option
 }

--- a/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
+++ b/Firmware/GPAD_API/GPAD_API/alarm_api.cpp
@@ -35,7 +35,8 @@ unsigned long muteTimeoutEndMillis = 0;
 unsigned long muteTimeoutStartMillis = 0;
 unsigned long muteTimeoutDurationMillis = 0;
 const char *AlarmNames[] = {"OK   ", "INFO.", "PROB.", "WARN ", "CRIT.", "PANIC"};
-
+char currentAlarmId[11] = "";
+char currentAlarmType[4] = "";
 // This is the abstract alarm function. It CANNOT
 // assume the msg buffer will exist after this call.
 // str must be null-terminated string!

--- a/Firmware/GPAD_API/GPAD_API/alarm_api.h
+++ b/Firmware/GPAD_API/GPAD_API/alarm_api.h
@@ -21,7 +21,8 @@
 #ifndef ALARM_API
 #define ALARM_API
 #include <Stream.h>
-
+extern char currentAlarmId[11];
+extern char currentAlarmType[4];
 enum AlarmLevel
 {
   silent,

--- a/Firmware/GPAD_API/GPAD_API/debug_macros.h
+++ b/Firmware/GPAD_API/GPAD_API/debug_macros.h
@@ -1,0 +1,20 @@
+#ifndef DEBUG_MACROS_H
+#define DEBUG_MACROS_H
+
+#include <Arduino.h>
+
+#ifndef GPAD_DEBUG
+#define GPAD_DEBUG 0
+#endif
+
+#if (GPAD_DEBUG > 0)
+#define DBG_PRINT(x) Serial.print(x)
+#define DBG_PRINTLN(x) Serial.println(x)
+#define DBG_PRINTF(...) Serial.printf(__VA_ARGS__)
+#else
+#define DBG_PRINT(x) do { } while (0)
+#define DBG_PRINTLN(x) do { } while (0)
+#define DBG_PRINTF(...) do { } while (0)
+#endif
+
+#endif

--- a/Firmware/GPAD_API/GPAD_API/gpad_serial.cpp
+++ b/Firmware/GPAD_API/GPAD_API/gpad_serial.cpp
@@ -22,6 +22,7 @@
 #include "gpad_utility.h"
 #include "alarm_api.h"
 #include "GPAD_HAL.h"
+#include "debug_macros.h"
 // #include <Arduino.h>
 
 extern bool currentlyMuted;
@@ -70,6 +71,7 @@ void processSerial(Stream *debugPort, Stream *inputPort, PubSubClient *client)
       const int rlen = (int)writeIndex;
       buf[rlen] = '\0';
 
+#if (GPAD_DEBUG > 0)
       debugPort->print(F("I received: "));
       debugPort->print(rlen);
       for (int i = 0; i < rlen; i++)
@@ -77,11 +79,12 @@ void processSerial(Stream *debugPort, Stream *inputPort, PubSubClient *client)
         debugPort->print(buf[i]);
       }
       debugPort->println();
+#endif
 
       if (rlen > 0)
       {
         interpretBuffer(buf, rlen, debugPort, client);
-        annunciateAlarmLevel(debugPort);
+        requestAlarmRefresh(debugPort);
         printAlarmState(debugPort);
         processedCommand = true;
       }

--- a/Firmware/GPAD_API/GPAD_API/mqtt_handler.cpp
+++ b/Firmware/GPAD_API/GPAD_API/mqtt_handler.cpp
@@ -1,15 +1,85 @@
 #include "mqtt_handler.h"
+#include "debug_macros.h"
+#include <Arduino.h>
+#include <string.h>
 
 extern char publish_Ack_Topic[];
 
-bool publishAck(PubSubClient *client, const char *message)
+namespace
 {
-  if (client == nullptr || message == nullptr)
+  const uint8_t MQTT_QUEUE_SIZE = 8;
+  PendingMqtt mqttQueue[MQTT_QUEUE_SIZE];
+
+  void copyBounded(char *dest, size_t destLen, const char *src)
+  {
+    if (destLen == 0)
+    {
+      return;
+    }
+    if (src == nullptr)
+    {
+      dest[0] = '\0';
+      return;
+    }
+    strncpy(dest, src, destLen - 1);
+    dest[destLen - 1] = '\0';
+  }
+}
+
+bool queueMqtt(const char *topic, const char *payload, bool retain)
+{
+  if (topic == nullptr || payload == nullptr || topic[0] == '\0')
   {
     return false;
   }
 
-  return client->publish(publish_Ack_Topic, message);
+  for (uint8_t i = 0; i < MQTT_QUEUE_SIZE; i++)
+  {
+    if (!mqttQueue[i].active)
+    {
+      copyBounded(mqttQueue[i].topic, sizeof(mqttQueue[i].topic), topic);
+      copyBounded(mqttQueue[i].payload, sizeof(mqttQueue[i].payload), payload);
+      mqttQueue[i].retain = retain;
+      mqttQueue[i].active = true;
+      return true;
+    }
+  }
+
+  DBG_PRINTLN(F("MQTT publish queue full"));
+  return false;
+}
+
+void serviceMqttQueue(PubSubClient *client)
+{
+  if (client == nullptr || !client->connected())
+  {
+    return;
+  }
+
+  for (uint8_t i = 0; i < MQTT_QUEUE_SIZE; i++)
+  {
+    if (!mqttQueue[i].active)
+    {
+      continue;
+    }
+
+    if (client->publish(mqttQueue[i].topic, mqttQueue[i].payload, mqttQueue[i].retain))
+    {
+      mqttQueue[i].active = false;
+    }
+    return;
+  }
+}
+
+bool publishAck(PubSubClient *client, const char *message)
+{
+  (void)client;
+  if (message == nullptr)
+  {
+    return false;
+  }
+
+  return queueMqtt(publish_Ack_Topic, message);
 }
 
 
@@ -31,8 +101,8 @@ bool publishGPAPResponse(PubSubClient *client, const char *responseType, const c
     snprintf(payload, sizeof(payload), "o%s", responseType);
   }
 
-  Serial.print("Publishing GPAP response: ");
-  Serial.println(payload);
+  DBG_PRINT(F("Queueing GPAP response: "));
+  DBG_PRINTLN(payload);
 
-  return client->publish(publish_Ack_Topic, payload);
+  return queueMqtt(publish_Ack_Topic, payload);
 }

--- a/Firmware/GPAD_API/GPAD_API/mqtt_handler.cpp
+++ b/Firmware/GPAD_API/GPAD_API/mqtt_handler.cpp
@@ -11,3 +11,28 @@ bool publishAck(PubSubClient *client, const char *message)
 
   return client->publish(publish_Ack_Topic, message);
 }
+
+
+bool publishGPAPResponse(PubSubClient *client, const char *responseType, const char *alarmId)
+{
+  if (client == nullptr || responseType == nullptr)
+  {
+    return false;
+  }
+
+  char payload[32];
+
+  if (alarmId != nullptr && strlen(alarmId) > 0)
+  {
+    snprintf(payload, sizeof(payload), "o%s{%s}", responseType, alarmId);
+  }
+  else
+  {
+    snprintf(payload, sizeof(payload), "o%s", responseType);
+  }
+
+  Serial.print("Publishing GPAP response: ");
+  Serial.println(payload);
+
+  return client->publish(publish_Ack_Topic, payload);
+}

--- a/Firmware/GPAD_API/GPAD_API/mqtt_handler.h
+++ b/Firmware/GPAD_API/GPAD_API/mqtt_handler.h
@@ -4,5 +4,5 @@
 #include <PubSubClient.h>
 
 bool publishAck(PubSubClient *client, const char *message);
-
+bool publishGPAPResponse(PubSubClient *client, const char *responseType, const char *alarmId);
 #endif

--- a/Firmware/GPAD_API/GPAD_API/mqtt_handler.h
+++ b/Firmware/GPAD_API/GPAD_API/mqtt_handler.h
@@ -3,6 +3,16 @@
 
 #include <PubSubClient.h>
 
+struct PendingMqtt
+{
+  char topic[96];
+  char payload[128];
+  bool retain;
+  bool active;
+};
+
+bool queueMqtt(const char *topic, const char *payload, bool retain = false);
+void serviceMqttQueue(PubSubClient *client);
 bool publishAck(PubSubClient *client, const char *message);
 bool publishGPAPResponse(PubSubClient *client, const char *responseType, const char *alarmId);
 #endif

--- a/Firmware/GPAD_API/data/device-monitor.html
+++ b/Firmware/GPAD_API/data/device-monitor.html
@@ -22,6 +22,12 @@
 </div>
 </section>
 <section class="card">
+<h1>Shiftr MQTT Broker Monitor</h1>
+<div class="embed-wrap">
+<iframe src="https://krakepubinv.cloud.shiftr.io/embed?widgets=1" width="600" height="400" frameborder="0" allowfullscreen></iframe>
+</div>
+</section>
+<section class="card">
 <h1>Broker Connection</h1>
 <div class="form-grid">
 <label>Broker WSS URL<input class="text-input" id="brokerUrl" value="wss://public.cloud.shiftr.io"/></label>

--- a/Firmware/GPAD_API/data/style.css
+++ b/Firmware/GPAD_API/data/style.css
@@ -119,6 +119,19 @@ textarea::placeholder {
   color: var(--muted);
 }
 
+/* EMBEDS */
+.embed-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.embed-wrap iframe {
+  display: block;
+  max-width: 100%;
+  border: 0;
+  border-radius: 10px;
+}
+
 /* TABLE */
 table {
   width: 100%;

--- a/Firmware/GPAD_API/lib/GPAP/src/AlarmMessage/AlarmContent.cpp
+++ b/Firmware/GPAD_API/lib/GPAP/src/AlarmMessage/AlarmContent.cpp
@@ -16,7 +16,7 @@ AlarmContent::AlarmContent(const std::size_t messageLength, const Buffer message
 {
     if (this->messageLength > AlarmContent::MAX_LENGTH)
     {
-        throw;
+        this->messageLength = AlarmContent::MAX_LENGTH;
     }
 }
 

--- a/Firmware/GPAD_API/lib/GPAP/src/AlarmMessage/AlarmMessageId.cpp
+++ b/Firmware/GPAD_API/lib/GPAP/src/AlarmMessage/AlarmMessageId.cpp
@@ -45,7 +45,7 @@ std::array<char, AlarmMessageId::TOTAL_MAX_LENGTH> AlarmMessageId::validateId(
     // number of elements
     if (idLength > id.size())
     {
-        throw;
+        return validatedId;
     }
 
     auto startIterator = id.cbegin();
@@ -62,11 +62,11 @@ std::array<char, AlarmMessageId::TOTAL_MAX_LENGTH> AlarmMessageId::validateId(
             return std::isxdigit(static_cast<unsigned char>(hexChar));
         });
 
-    // If all the characters are NOT hex characters we need to throw an error and
-    // cancel the creation of this instance.
+    // Invalid characters leave the object printable but empty; validation rejects
+    // malformed GPAP messages before construction on embedded builds.
     if (!allHex)
     {
-        throw;
+        validatedId.fill('\0');
     }
 
     *validatedIdIterator = '\0';

--- a/Firmware/GPAD_API/lib/GPAP/src/AlarmMessage/AlarmTypeDesignator.cpp
+++ b/Firmware/GPAD_API/lib/GPAP/src/AlarmMessage/AlarmTypeDesignator.cpp
@@ -31,8 +31,6 @@ using namespace gpap_message::alarm;
 
 AlarmTypeDesignator::AlarmTypeDesignator(const Buffer designator) : designator(std::move(designator))
 {
-    auto designatorIterator = designator.begin();
-
     const bool allDigits =
         std::all_of(this->designator.cbegin(), this->designator.cend(),
                     [](char inputCharacter)
@@ -40,10 +38,11 @@ AlarmTypeDesignator::AlarmTypeDesignator(const Buffer designator) : designator(s
                         return std::isdigit(static_cast<unsigned char>(inputCharacter));
                     });
 
-    // if the characters are not all digits we want to throw
+    // Invalid characters leave the object printable but neutral; validation rejects
+    // malformed GPAP messages before construction on embedded builds.
     if (!allDigits)
     {
-        throw;
+        this->designator.fill('0');
     }
 }
 

--- a/Firmware/GPAD_API/lib/GPAP/src/Deserialize/AlarmMessageBuilder/AlarmMessageBuilder.cpp
+++ b/Firmware/GPAD_API/lib/GPAP/src/Deserialize/AlarmMessageBuilder/AlarmMessageBuilder.cpp
@@ -16,6 +16,7 @@
 */
 
 #include "AlarmMessageBuilder.h"
+#include <cctype>
 
 using namespace gpap_message::alarm;
 using namespace gpap_message::deserialize;
@@ -29,9 +30,9 @@ AlarmMessageBuilder::AlarmMessageBuilder()
 
 std::size_t AlarmMessageBuilder::deserializeLevel(const char *const buffer, const std::size_t numBytes)
 {
-    if (numBytes == 0)
+    if (numBytes == 0 || buffer == nullptr)
     {
-        throw;
+        return 0;
     }
 
     this->level = static_cast<AlarmMessage::Level>(buffer[0]);
@@ -63,7 +64,7 @@ std::size_t AlarmMessageBuilder::deserializeId(const char *const buffer, const s
         }
         else if (idLength < AlarmMessageId::MAX_LENGTH)
         {
-            this->idBuffer.at(idLength) = buffer[bufferIndex];
+            this->idBuffer[idLength] = buffer[bufferIndex];
             ++idLength;
         }
     }
@@ -71,7 +72,7 @@ std::size_t AlarmMessageBuilder::deserializeId(const char *const buffer, const s
     // If the terminating character, }, was not found then it is an invalid string
     if (!foundEnd)
     {
-        throw;
+        return numBytes;
     }
     else
     {
@@ -107,7 +108,7 @@ AlarmMessageBuilder::deserializeTypeDesignator(const char *const buffer, const s
         }
         else if (designatorLength < AlarmTypeDesignator::DESIGNATOR_LENGTH)
         {
-            this->designatorBuffer.at(designatorLength) = currBuffer[designatorLength];
+            this->designatorBuffer[designatorLength] = currBuffer[designatorLength];
             ++designatorLength;
         }
     }
@@ -116,7 +117,7 @@ AlarmMessageBuilder::deserializeTypeDesignator(const char *const buffer, const s
         (designatorLength != AlarmTypeDesignator::DESIGNATOR_LENGTH &&
          designatorLength != 0))
     {
-        throw;
+        return numBytes;
     }
     else
     {
@@ -138,7 +139,12 @@ std::size_t AlarmMessageBuilder::deserializeMessage(const char *const buffer, co
             break;
         }
 
-        this->messageBuffer.at(messageLength) = buffer[messageLength];
+        if (messageLength >= AlarmContent::MAX_LENGTH)
+        {
+            break;
+        }
+
+        this->messageBuffer[messageLength] = buffer[messageLength];
     }
 
     this->messageLength = messageLength;
@@ -216,6 +222,99 @@ AlarmMessage AlarmMessageBuilder::buildAlarmMessage(const char *const buffer, co
                         std::move(content),
                         std::move(messageId),
                         std::move(typeDesignator));
+}
+
+bool AlarmMessageBuilder::isValidAlarmMessage(const char *const buffer, const std::size_t numBytes) noexcept
+{
+    if (buffer == nullptr || numBytes == 0)
+    {
+        return false;
+    }
+
+    const char level = buffer[0];
+    if (level < '0' || level > '5')
+    {
+        return false;
+    }
+
+    bool foundId = false;
+    bool foundDesignator = false;
+    bool foundMessage = false;
+    std::size_t index = 1;
+
+    while (index < numBytes)
+    {
+        const char current = buffer[index];
+        if (current == ID_START_CHARACTER)
+        {
+            if (foundId)
+            {
+                return false;
+            }
+            foundId = true;
+            std::size_t idLength = 0;
+            ++index;
+            while (index < numBytes && buffer[index] != ID_END_CHARACTER)
+            {
+                if (++idLength > AlarmMessageId::MAX_LENGTH || isReservedCharacter(buffer[index]) ||
+                    !std::isxdigit(static_cast<unsigned char>(buffer[index])))
+                {
+                    return false;
+                }
+                ++index;
+            }
+            if (index >= numBytes || buffer[index] != ID_END_CHARACTER)
+            {
+                return false;
+            }
+            ++index;
+            continue;
+        }
+
+        if (current == DESIGNATOR_START_CHARACTER)
+        {
+            if (foundDesignator)
+            {
+                return false;
+            }
+            foundDesignator = true;
+            std::size_t designatorLength = 0;
+            ++index;
+            while (index < numBytes && buffer[index] != DESIGNATOR_END_CHARACTER)
+            {
+                if (++designatorLength > AlarmTypeDesignator::DESIGNATOR_LENGTH || isReservedCharacter(buffer[index]) ||
+                    !std::isdigit(static_cast<unsigned char>(buffer[index])))
+                {
+                    return false;
+                }
+                ++index;
+            }
+            if (index >= numBytes || buffer[index] != DESIGNATOR_END_CHARACTER ||
+                (designatorLength != 0 && designatorLength != AlarmTypeDesignator::DESIGNATOR_LENGTH))
+            {
+                return false;
+            }
+            ++index;
+            continue;
+        }
+
+        if (foundMessage || isReservedCharacter(current))
+        {
+            return false;
+        }
+        foundMessage = true;
+        std::size_t messageLength = 0;
+        while (index < numBytes && !isReservedCharacter(buffer[index]))
+        {
+            if (++messageLength > AlarmContent::MAX_LENGTH)
+            {
+                return false;
+            }
+            ++index;
+        }
+    }
+
+    return true;
 }
 
 bool AlarmMessageBuilder::isReservedCharacter(const char character)

--- a/Firmware/GPAD_API/lib/GPAP/src/Deserialize/AlarmMessageBuilder/AlarmMessageBuilder.h
+++ b/Firmware/GPAD_API/lib/GPAP/src/Deserialize/AlarmMessageBuilder/AlarmMessageBuilder.h
@@ -55,6 +55,7 @@ namespace gpap_message::deserialize
 
     public:
         static alarm::AlarmMessage buildAlarmMessage(const char *const buffer, const std::size_t numBytes);
+        static bool isValidAlarmMessage(const char *const buffer, const std::size_t numBytes) noexcept;
         static bool isReservedCharacter(const char character);
 
         AlarmMessageBuilder(const AlarmMessageBuilder &&other) noexcept

--- a/Firmware/GPAD_API/lib/GPAP/src/GPAPMessage.cpp
+++ b/Firmware/GPAD_API/lib/GPAP/src/GPAPMessage.cpp
@@ -21,23 +21,20 @@
 using namespace gpap_message;
 GPAPMessage GPAPMessage::deserialize(const char *const buffer, const std::size_t numBytes)
 {
-    // Can't determined the message type if there are no bytes
-    if (numBytes == 0)
+    if (buffer == nullptr || numBytes == 0)
     {
-        throw;
+        return GPAPMessage::invalid();
     }
 
-    // TODO: This should be wrapped in a try/catch if there isn't a 0th element
     const auto messageType = static_cast<MessageType>(buffer[0]);
 
     switch (messageType)
     {
     case MessageType::ALARM:
-        if ((numBytes - 1) == 0)
+        if (!deserialize::AlarmMessageBuilder::isValidAlarmMessage(buffer + 1, numBytes - 1))
         {
-            throw;
+            return GPAPMessage::invalid();
         }
-
         return GPAPMessage(std::move(deserialize::AlarmMessageBuilder::buildAlarmMessage(buffer + 1, numBytes - 1)));
 
     case MessageType::INFO:
@@ -53,7 +50,7 @@ GPAPMessage GPAPMessage::deserialize(const char *const buffer, const std::size_t
         return GPAPMessage(HelpMessage());
 
     default:
-        throw;
+        return GPAPMessage::invalid();
     }
 }
 
@@ -64,11 +61,5 @@ MessageType GPAPMessage::getMessageType() const noexcept
 
 const alarm::AlarmMessage &GPAPMessage::getAlarmMessage() const
 {
-    // Cannot access a field of the union when it's the incorrect type
-    if (this->messageType != MessageType::ALARM)
-    {
-        throw;
-    }
-
     return this->alarm;
 }

--- a/Firmware/GPAD_API/lib/GPAP/src/GPAPMessage.h
+++ b/Firmware/GPAD_API/lib/GPAP/src/GPAPMessage.h
@@ -34,6 +34,7 @@ namespace gpap_message
         HELP = 'h',
         ALARM = 'a',
         INFO = 'i',
+        INVALID = '\0',
     };
     struct GPAPMessage final
     {
@@ -65,6 +66,7 @@ namespace gpap_message
             : messageType(MessageType::UNMUTE), unmute(std::move(unmuteCommand)) {}
         explicit GPAPMessage(const HelpMessage helpCommand) noexcept
             : messageType(MessageType::HELP), help(std::move(helpCommand)) {}
+        static GPAPMessage invalid() noexcept { return GPAPMessage(InfoMessage(), MessageType::INVALID); }
         GPAPMessage(const GPAPMessage &&other) noexcept
             : messageType(other.messageType)
         {
@@ -74,6 +76,7 @@ namespace gpap_message
                 this->alarm = std::move(other.alarm);
                 break;
             case MessageType::INFO:
+            case MessageType::INVALID:
                 this->info = std::move(other.info);
                 break;
             case MessageType::MUTE:
@@ -98,6 +101,7 @@ namespace gpap_message
                     this->alarm = std::move(other.alarm);
                     break;
                 case MessageType::INFO:
+                case MessageType::INVALID:
                     this->info = std::move(other.info);
                     break;
                 case MessageType::MUTE:
@@ -115,6 +119,9 @@ namespace gpap_message
         }
 
         ~GPAPMessage() {}
+
+        explicit GPAPMessage(const InfoMessage infoMessage, const MessageType forcedMessageType) noexcept
+            : messageType(forcedMessageType), info(std::move(infoMessage)) {}
 
         GPAPMessage() = delete;
         GPAPMessage(GPAPMessage &other) = delete;

--- a/Firmware/GPAD_API/pre_extra_script.py
+++ b/Firmware/GPAD_API/pre_extra_script.py
@@ -3,7 +3,7 @@ Import("env")
 cpp_defines = [
     ("COMPANY_NAME", "PubInv "),   # For the Broker ID for MQTT 
     ("PROG_NAME", "GPAD_API "),    # This program
-    ("FIRMWARE_VERSION", "0.56 "), # pr 501
+    ("FIRMWARE_VERSION", "0.57 "), # Refactored so that MQTT is serviced first.
     ("LittleFS_VERSION", "0.1.6 "), # pr 501
     ("MODEL_NAME", "KRAKE_"), 
     ("LICENSE", "GNU Affero General Public License, version 3 "),


### PR DESCRIPTION
# Changes:

## Integrating GPAP 

## Fix panic, WDT, and CPU reset issues

- Fixed the main GPAP panic/software-reset path by making malformed GPAP input deserialize to a normal INVALID message instead of using throw, which can abort/reset embedded ESP32 builds when exceptions are unavailable or uncaught. 
- Added pre-construction GPAP alarm validation for severity, ID, type designator, reserved characters, and message length so invalid MQTT/serial alarm payloads are rejected before they can touch constructors or fixed-size buffers.
- Removed GPAD’s try/catch alarm parse path and replaced it with a normal invalid-message check, keeping GPAP failures in the GPAD error path instead of relying on embedded exception handling. 
- Hardened GPAP value constructors so bad lengths/characters become safe bounded/neutral values rather than reset-causing throws. 
- Reduced heap churn from Arduino String use in hot/debug paths by replacing the mirrored serial log with a fixed char buffer and bounded memcpy/memmove updates. 
- Replaced MQTT connection/status temporary String construction with stack char buffers and snprintf, which is friendlier to CPU/heap behavior on ESP32. 
- Reduced WDT-reset risk during DFPlayer startup by replacing long blocking delays with scheduler-feeding waits that call delay(10) and yield(). 
- Made the main loop more CPU-friendly by adding a small delay(1) instead of a pure yield() spin. 
- Registered web routes before server.begin() and refreshed the splash LCD with the current WiFi address after connection, avoiding stale setup state. 
- Removed stale/unused loop timing/action code and committed the changes on the current branch with commit 7be5da7.
 
## Reduce MQTT delay and congestion.
- Refactored loop() so MQTT is serviced first and then re-serviced between hardware/UI, serial, SPI, menu, and periodic publish/wink work, removing the previous delay(1) in favor of yield(). 
- Added HAL-side scheduling state for LCD/audio work, including normal settle, burst settle, and minimum update intervals to coalesce burst message updates. 
- Added serviceAlarmUiAudio() to poll DFPlayer on a schedule, defer LCD redraws while the menu is active, throttle LCD/audio work, and only play DFPlayer audio from the scheduled service path. 
- Changed annunciateAlarmLevel() to stay lightweight in MQTT/serial/SPI callbacks by updating only immediate tone/light state and marking LCD/audio work pending for later scheduled servicing. 
- Exposed the scheduled UI/audio service in the HAL header for explicit reuse if needed

- Added PendingMqtt, queueMqtt(), and serviceMqttQueue() in mqtt_handler.h / mqtt_handler.cpp.
 
- publishAck() and publishGPAPResponse() now queue instead of publishing immediately.
 
- loop() services MQTT first and repeatedly, including queue service after client loop slices and after menu polling.
 
- MQTT callback now avoids String allocation and uses fixed buffers for ACK tracking.
 
- Serial/MQTT/menu alarm paths now request deferred UI/audio refresh instead of directly driving LCD/DFPlayer work.
 
- DFPlayer alarm playback is serviced from GPAD_HAL_loop() using a queued pending audio level.
 
- Added debug_macros.h with debug off by default, and moved menu/encoder/serial hot-path logs behind it.
 
- Added optional heap diagnostics via ENABLE_HEAP_DIAGNOSTICS, default off.
 
- Set the main DEBUG default to 0.


 
> Build size: RAM 20.8%, Flash 83.7%.